### PR TITLE
feat: code-review-graph 풀 통합 — MCP + Settings + Dashboard + D3 viz (PR-D)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,7 @@ import { GitManager } from './services/GitManager'
 import { UpdateChecker } from './services/UpdateChecker'
 import { AgentTeamWatcher } from './services/AgentTeamWatcher'
 import { FsManager, type FsListOpts } from './services/FsManager'
+import { CodeReviewGraphManager, type InstallMethod } from './services/CodeReviewGraphManager'
 
 const execFileAsync = promisify(execFile)
 
@@ -21,7 +22,8 @@ process.env.VITE_PUBLIC = process.env.VITE_DEV_SERVER_URL
 
 let mainWindow: BrowserWindow | null = null
 const ptyManager = new PtyManager()
-const workspaceManager = new WorkspaceManager()
+const crGraphManager = new CodeReviewGraphManager()
+const workspaceManager = new WorkspaceManager(crGraphManager)
 const harnessScanner = new HarnessScanner()
 const gitManager = new GitManager()
 const updateChecker = new UpdateChecker()
@@ -245,6 +247,7 @@ ipcMain.handle(
         protocol?: 'ssh' | 'https'
         autoCreateRepos?: boolean
       }
+      crGraph?: { autoBuild?: boolean }
     }
   ) => {
     return workspaceManager.create(options)
@@ -362,6 +365,31 @@ ipcMain.handle('harness:update', async (_event, workspacePath: string) => {
     ? path.join(process.resourcesPath, 'harness-template', 'CLAUDE.md')
     : path.resolve(__dirname, '..', 'resources', 'harness-template', 'CLAUDE.md')
   return workspaceManager.updateHarness({ workspacePath, templatePath, claudeMdPath })
+})
+
+// ─── IPC Handlers: code-review-graph ───────────────────────────────
+
+ipcMain.handle('cr-graph:isInstalled', () => crGraphManager.isInstalled())
+
+ipcMain.handle('cr-graph:install', (_event, method?: InstallMethod) =>
+  crGraphManager.install(method)
+)
+
+ipcMain.handle('cr-graph:build', (_event, workspacePath: string) =>
+  crGraphManager.build(workspacePath)
+)
+
+ipcMain.handle('cr-graph:stats', (_event, workspacePath: string) =>
+  crGraphManager.stats(workspacePath)
+)
+
+ipcMain.handle('cr-graph:vizStart', (_event, workspacePath: string) =>
+  crGraphManager.vizUrl(workspacePath)
+)
+
+ipcMain.handle('cr-graph:vizStop', (_event, pid: number) => {
+  crGraphManager.stopViz(pid)
+  return true
 })
 
 // ─── IPC Handlers: Git ─────────────────────────────────────────────
@@ -588,6 +616,7 @@ if (!gotTheLock) {
   app.on('window-all-closed', () => {
     ptyManager.disposeAll()
     agentTeamWatcher.stop()
+    crGraphManager.disposeAll()
     if (process.platform !== 'darwin') app.quit()
   })
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -41,6 +41,7 @@ const api = {
         protocol?: 'ssh' | 'https'
         autoCreateRepos?: boolean
       }
+      crGraph?: { autoBuild?: boolean }
     }) => ipcRenderer.invoke('workspace:create', options),
     open: (dirPath: string) =>
       ipcRenderer.invoke('workspace:open', dirPath),
@@ -142,6 +143,36 @@ const api = {
       ipcRenderer.invoke('teams:create', opts),
     remove: (teamId: string): Promise<void> =>
       ipcRenderer.invoke('teams:remove', teamId),
+  },
+
+  // ─── code-review-graph ───────────────────────────────────────────
+  crGraph: {
+    isInstalled: (): Promise<{
+      installed: boolean
+      version?: string
+      method?: 'pipx' | 'pip' | 'uv'
+    }> => ipcRenderer.invoke('cr-graph:isInstalled'),
+    install: (
+      method?: 'pipx' | 'pip' | 'uv'
+    ): Promise<{ ok: boolean; output: string }> =>
+      ipcRenderer.invoke('cr-graph:install', method),
+    build: (
+      workspacePath: string
+    ): Promise<{ ok: boolean; durationMs: number; output: string }> =>
+      ipcRenderer.invoke('cr-graph:build', workspacePath),
+    stats: (
+      workspacePath: string
+    ): Promise<{
+      nodes: number
+      edges: number
+      files: number
+      languages: string[]
+      lastBuiltAt: string | null
+    } | null> => ipcRenderer.invoke('cr-graph:stats', workspacePath),
+    vizStart: (workspacePath: string): Promise<{ url: string; pid: number }> =>
+      ipcRenderer.invoke('cr-graph:vizStart', workspacePath),
+    vizStop: (pid: number): Promise<boolean> =>
+      ipcRenderer.invoke('cr-graph:vizStop', pid),
   },
 
   // ─── Updates ─────────────────────────────────────────────────────

--- a/electron/services/CodeReviewGraphManager.ts
+++ b/electron/services/CodeReviewGraphManager.ts
@@ -1,0 +1,405 @@
+import { execFile, spawn, type ChildProcess } from 'child_process'
+import { promisify } from 'util'
+import fs from 'fs-extra'
+import path from 'path'
+import os from 'os'
+import net from 'net'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * `code-review-graph` is a Python CLI shipped via PyPI. Users may install via
+ * pipx, uv tool, or `pip install --user`. This manager:
+ *   1. Detects whether the CLI is on PATH (and which install method is most
+ *      likely available).
+ *   2. Runs a one-shot install when asked (auto-picking pipx > uv > pip).
+ *   3. Spawns `build`, `stats`, and `viz` against a workspace and surfaces
+ *      progress / output / pid back through IPC.
+ *
+ * Failure mode: every operation must be graceful. The renderer relies on
+ * `installed: false` / null returns / `ok: false` to drive the UI — we never
+ * throw across the IPC boundary unless the input is invalid.
+ */
+
+export type InstallMethod = 'pipx' | 'pip' | 'uv'
+
+export interface InstallStatus {
+  installed: boolean
+  version?: string
+  method?: InstallMethod
+}
+
+export interface InstallResult {
+  ok: boolean
+  output: string
+}
+
+export interface BuildResult {
+  ok: boolean
+  durationMs: number
+  output: string
+}
+
+export interface StatsResult {
+  nodes: number
+  edges: number
+  files: number
+  languages: string[]
+  lastBuiltAt: string | null
+}
+
+export interface VizHandle {
+  url: string
+  pid: number
+}
+
+/**
+ * Electron apps launched from Finder/Dock on macOS get a stripped PATH that
+ * misses Homebrew, pyenv, pipx, uv, etc. Mirror the augmentation
+ * HarnessScanner uses so `which code-review-graph` actually finds binaries
+ * installed via `pipx install` (`~/.local/bin`) or `uv tool install`
+ * (`~/.local/bin` as well).
+ */
+function augmentedPathEnv(): NodeJS.ProcessEnv {
+  const basePath = process.env.PATH || ''
+  const extras: string[] = []
+  if (os.platform() === 'darwin') {
+    extras.push('/opt/homebrew/bin', '/usr/local/bin')
+  }
+  const home = process.env.HOME || ''
+  if (home) {
+    extras.push(`${home}/.local/bin`, `${home}/.cargo/bin`)
+  }
+  const augmented = [...extras, basePath].filter(Boolean).join(path.delimiter)
+  return { ...process.env, PATH: augmented }
+}
+
+const CLI = 'code-review-graph'
+const WHICH = os.platform() === 'win32' ? 'where' : 'which'
+
+/** Pick a free port in [3000, 9000) to avoid stomping on common dev servers. */
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.unref()
+    srv.on('error', () => {
+      // Retry once with explicit port — fall back to letting OS pick.
+      const fallback = 3000 + Math.floor(Math.random() * 6000)
+      resolve(fallback)
+    })
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address()
+      if (addr && typeof addr === 'object') {
+        const p = addr.port
+        srv.close(() => resolve(p))
+      } else {
+        srv.close(() => resolve(3000 + Math.floor(Math.random() * 6000)))
+      }
+    })
+  })
+}
+
+export class CodeReviewGraphManager {
+  /** Active viz spawn handles keyed by pid for stop-by-pid. */
+  private vizProcs = new Map<number, ChildProcess>()
+
+  /**
+   * Probe `code-review-graph --version`. If the CLI is missing, return
+   * `installed: false`. The `method` field is best-effort: we look at the
+   * resolved binary path to guess pipx (`/pipx/`) or uv (`/uv/`) — otherwise
+   * fall back to `pip`.
+   */
+  async isInstalled(): Promise<InstallStatus> {
+    const env = augmentedPathEnv()
+    let resolvedPath: string | null = null
+    try {
+      const { stdout } = await execFileAsync(WHICH, [CLI], {
+        encoding: 'utf-8',
+        timeout: 3000,
+        env,
+      })
+      resolvedPath = stdout.split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? null
+    } catch {
+      return { installed: false }
+    }
+
+    let version: string | undefined
+    try {
+      const { stdout } = await execFileAsync(CLI, ['--version'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        env,
+      })
+      version = stdout.trim() || undefined
+    } catch {
+      // CLI exists but `--version` failed — still mark as installed so the UI
+      // can offer rebuild/upgrade actions.
+    }
+
+    let method: InstallMethod | undefined
+    if (resolvedPath) {
+      if (resolvedPath.includes('/pipx/') || resolvedPath.includes('\\pipx\\')) method = 'pipx'
+      else if (resolvedPath.includes('/uv/') || resolvedPath.includes('\\uv\\')) method = 'uv'
+      else method = 'pip'
+    }
+
+    return { installed: true, version, method }
+  }
+
+  /**
+   * Install the CLI. When `method` is omitted, auto-pick the best installer
+   * present on PATH (pipx > uv > pip). All variants stream stdout+stderr
+   * back so the UI can show the install log.
+   */
+  async install(method?: InstallMethod): Promise<InstallResult> {
+    const env = augmentedPathEnv()
+    const chosen = method ?? (await this.pickInstallMethod(env))
+    if (!chosen) {
+      return {
+        ok: false,
+        output: 'No installer found. Install pipx, uv, or pip first (https://pipx.pypa.io).',
+      }
+    }
+
+    const [bin, args] = this.installCommand(chosen)
+    try {
+      const { stdout, stderr } = await execFileAsync(bin, args, {
+        encoding: 'utf-8',
+        timeout: 5 * 60 * 1000,
+        env,
+        maxBuffer: 16 * 1024 * 1024,
+      })
+      return { ok: true, output: `${stdout}\n${stderr}`.trim() }
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }
+      const out = `${e.stdout ?? ''}\n${e.stderr ?? ''}\n${e.message ?? ''}`.trim()
+      return { ok: false, output: out }
+    }
+  }
+
+  /**
+   * Run `code-review-graph build` against `workspacePath`. When `onProgress`
+   * is supplied, every line of stdout/stderr is forwarded — useful for the
+   * dashboard to show live build logs without polling.
+   */
+  async build(
+    workspacePath: string,
+    opts?: { onProgress?: (line: string) => void }
+  ): Promise<BuildResult> {
+    if (!workspacePath || typeof workspacePath !== 'string') {
+      return { ok: false, durationMs: 0, output: 'workspacePath is required' }
+    }
+    if (!(await fs.pathExists(workspacePath))) {
+      return { ok: false, durationMs: 0, output: `workspace not found: ${workspacePath}` }
+    }
+
+    const env = augmentedPathEnv()
+    const start = Date.now()
+    return new Promise<BuildResult>((resolve) => {
+      let proc: ChildProcess
+      try {
+        proc = spawn(CLI, ['build'], { cwd: workspacePath, env })
+      } catch (err) {
+        resolve({ ok: false, durationMs: 0, output: (err as Error).message })
+        return
+      }
+
+      const buf: string[] = []
+      const onLine = (chunk: Buffer | string) => {
+        const text = chunk.toString()
+        buf.push(text)
+        if (opts?.onProgress) {
+          for (const line of text.split(/\r?\n/)) {
+            if (line.trim()) opts.onProgress(line)
+          }
+        }
+      }
+      proc.stdout?.on('data', onLine)
+      proc.stderr?.on('data', onLine)
+
+      proc.on('error', (err) => {
+        resolve({
+          ok: false,
+          durationMs: Date.now() - start,
+          output: `${buf.join('')}\n${err.message}`.trim(),
+        })
+      })
+      proc.on('close', (code) => {
+        resolve({
+          ok: code === 0,
+          durationMs: Date.now() - start,
+          output: buf.join('').trim(),
+        })
+      })
+    })
+  }
+
+  /**
+   * Try `code-review-graph stats --json`. If the subcommand doesn't exist
+   * (older versions / different schema), fall back to inspecting the on-disk
+   * sqlite db's mtime so the UI can at least show "last built at".
+   */
+  async stats(workspacePath: string): Promise<StatsResult | null> {
+    if (!workspacePath || typeof workspacePath !== 'string') return null
+    if (!(await fs.pathExists(workspacePath))) return null
+
+    const env = augmentedPathEnv()
+    try {
+      const { stdout } = await execFileAsync(CLI, ['stats', '--json'], {
+        cwd: workspacePath,
+        encoding: 'utf-8',
+        timeout: 30 * 1000,
+        env,
+        maxBuffer: 8 * 1024 * 1024,
+      })
+      const trimmed = stdout.trim()
+      if (trimmed) {
+        const parsed = JSON.parse(trimmed) as Partial<StatsResult> & Record<string, unknown>
+        const built = await this.findDbMtime(workspacePath)
+        return {
+          nodes: typeof parsed.nodes === 'number' ? parsed.nodes : 0,
+          edges: typeof parsed.edges === 'number' ? parsed.edges : 0,
+          files: typeof parsed.files === 'number' ? parsed.files : 0,
+          languages: Array.isArray(parsed.languages)
+            ? parsed.languages.filter((l): l is string => typeof l === 'string')
+            : [],
+          lastBuiltAt:
+            typeof parsed.lastBuiltAt === 'string' ? parsed.lastBuiltAt : built,
+        }
+      }
+    } catch {
+      // Either the CLI is missing, the subcommand doesn't exist, or stdout
+      // wasn't valid JSON. Fall through to mtime-only fallback below.
+    }
+
+    const built = await this.findDbMtime(workspacePath)
+    if (!built) return null
+    return { nodes: 0, edges: 0, files: 0, languages: [], lastBuiltAt: built }
+  }
+
+  /**
+   * Spawn `code-review-graph viz --port <port> --no-open` in the background
+   * and return the localhost URL + pid. The pid is tracked internally so
+   * `stopViz(pid)` can kill it later. If the chosen port is already taken,
+   * we retry with a randomly chosen port in 3000-9000.
+   */
+  async vizUrl(workspacePath: string, port?: number): Promise<VizHandle> {
+    if (!workspacePath || typeof workspacePath !== 'string') {
+      throw new Error('workspacePath is required')
+    }
+
+    const env = augmentedPathEnv()
+    const startPort = port && port > 0 ? port : await pickFreePort()
+
+    const proc = spawn(CLI, ['viz', '--port', String(startPort), '--no-open'], {
+      cwd: workspacePath,
+      env,
+      detached: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    if (!proc.pid) {
+      throw new Error('Failed to spawn code-review-graph viz')
+    }
+
+    this.vizProcs.set(proc.pid, proc)
+    proc.on('exit', () => {
+      if (proc.pid) this.vizProcs.delete(proc.pid)
+    })
+
+    return { url: `http://localhost:${startPort}`, pid: proc.pid }
+  }
+
+  /** Best-effort kill — sends SIGTERM. Caller may retry with a new vizUrl. */
+  stopViz(pid: number): void {
+    if (!Number.isInteger(pid) || pid <= 0) return
+    const proc = this.vizProcs.get(pid)
+    if (proc) {
+      try {
+        proc.kill('SIGTERM')
+      } catch {
+        // Already exited / no permission.
+      }
+      this.vizProcs.delete(pid)
+      return
+    }
+    // Process not in our tracking map — try anyway (could be a leftover from a
+    // previous renderer session) but swallow ESRCH.
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch {
+      // ignore
+    }
+  }
+
+  /** Disposes every viz process — called on app quit. */
+  disposeAll(): void {
+    for (const [pid, proc] of this.vizProcs.entries()) {
+      try {
+        proc.kill('SIGTERM')
+      } catch {
+        // ignore
+      }
+      this.vizProcs.delete(pid)
+    }
+  }
+
+  // ─── Internals ───────────────────────────────────────────────────────
+
+  private async pickInstallMethod(env: NodeJS.ProcessEnv): Promise<InstallMethod | null> {
+    const order: InstallMethod[] = ['pipx', 'uv', 'pip']
+    for (const m of order) {
+      const probe = m === 'pip' ? 'pip3' : m
+      try {
+        await execFileAsync(WHICH, [probe], { encoding: 'utf-8', timeout: 2000, env })
+        return m
+      } catch {
+        if (m === 'pip') {
+          // Fall back to plain `pip` if `pip3` isn't on PATH.
+          try {
+            await execFileAsync(WHICH, ['pip'], { encoding: 'utf-8', timeout: 2000, env })
+            return 'pip'
+          } catch {
+            // continue
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  private installCommand(method: InstallMethod): [string, string[]] {
+    switch (method) {
+      case 'pipx':
+        return ['pipx', ['install', 'code-review-graph']]
+      case 'uv':
+        return ['uv', ['tool', 'install', 'code-review-graph']]
+      case 'pip':
+        // Prefer `pip3 install --user` to avoid touching the system Python.
+        return ['pip3', ['install', '--user', 'code-review-graph']]
+    }
+  }
+
+  /**
+   * Locate the build artefact (sqlite db) and return its mtime as ISO. Looks
+   * at common locations the CLI uses: `.code-review-graph/db.sqlite`,
+   * `.code-review-graph/graph.db`, and a top-level `code-review-graph.db`.
+   */
+  private async findDbMtime(workspacePath: string): Promise<string | null> {
+    const candidates = [
+      path.join(workspacePath, '.code-review-graph', 'db.sqlite'),
+      path.join(workspacePath, '.code-review-graph', 'graph.db'),
+      path.join(workspacePath, '.code-review-graph', 'graph.sqlite'),
+      path.join(workspacePath, 'code-review-graph.db'),
+    ]
+    for (const file of candidates) {
+      try {
+        const stat = await fs.stat(file)
+        return stat.mtime.toISOString()
+      } catch {
+        // not found — try next
+      }
+    }
+    return null
+  }
+}

--- a/electron/services/WorkspaceManager.ts
+++ b/electron/services/WorkspaceManager.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { app } from 'electron'
 import { execFileSync } from 'child_process'
+import type { CodeReviewGraphManager } from './CodeReviewGraphManager'
 
 export interface Workspace {
   id: string
@@ -46,8 +47,10 @@ const STORE_PATH = () => path.join(app.getPath('userData'), 'workspaces.json')
 
 export class WorkspaceManager {
   private workspaces: Workspace[] = []
+  private crGraph: CodeReviewGraphManager | null
 
-  constructor() {
+  constructor(crGraph?: CodeReviewGraphManager) {
+    this.crGraph = crGraph ?? null
     this.load()
   }
 
@@ -78,6 +81,9 @@ export class WorkspaceManager {
     templatePath?: string
     claudeMdPath?: string
     splitRepos?: SplitReposOptions
+    /** Opt-in: kick off `code-review-graph build` once the workspace
+     *  scaffolding is in place. Failures are swallowed (best-effort). */
+    crGraph?: { autoBuild?: boolean }
   }): Promise<Workspace> {
     const projectPath = path.join(options.path, options.name)
 
@@ -137,6 +143,17 @@ export class WorkspaceManager {
 
     this.workspaces.unshift(workspace)
     this.save()
+
+    // Best-effort: kick off `code-review-graph build` in the background. We
+    // don't await — workspace creation should not block on a (potentially
+    // long) graph build. Errors are intentionally swallowed (the UI surfaces
+    // build status separately via cr-graph:stats / a manual rebuild button).
+    if (options.crGraph?.autoBuild && this.crGraph) {
+      this.crGraph.build(projectPath).catch(() => {
+        // graceful — CLI may not be installed yet
+      })
+    }
+
     return workspace
   }
 

--- a/resources/harness-template/.claude/agents/code-reviewer.md
+++ b/resources/harness-template/.claude/agents/code-reviewer.md
@@ -12,6 +12,16 @@ Senior fullstack code reviewer. 상용 프로덕트 기준으로 리뷰. 변경 
 - 도메인 규칙 위반 검출
 - 변경 파일 스택 판별: `.dart` → Flutter, `.ts` in `server/` → NestJS, `.ts/.tsx` in `cms/` → Next.js, `schema.prisma` → Prisma
 
+## Tools 활용
+
+리뷰를 시작하기 전에 반드시 다음 순서를 따른다 (전체 코드베이스 스캔은 토큰 낭비):
+
+1. `code-review-graph` MCP 의 blast radius 도구로 변경 파일의 영향 범위(영향 받는 caller / dependent / test)를 조회한다.
+2. 그래프가 알려준 영향 범위 안의 파일만 `Read` 한다. 매칭되지 않은 파일은 읽지 않는다.
+3. caller / dependent / 테스트 누락 여부는 그래프 결과로 판단하고, 누락이 의심되는 노드만 추가로 `Read` 로 확인한다.
+
+이 순서를 어기고 변경 파일과 무관한 영역을 광범위하게 읽으면 토큰을 낭비할 뿐 아니라 리뷰 정확도도 떨어진다.
+
 ## 체크리스트
 
 ### 🔴 Critical (하나라도 있으면 반려)

--- a/resources/harness-template/.claude/mcp.json
+++ b/resources/harness-template/.claude/mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "code-review-graph": {
+      "command": "uvx",
+      "args": ["code-review-graph", "serve"]
+    },
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],

--- a/resources/harness-template/.claude/rules/common/mcp.md
+++ b/resources/harness-template/.claude/rules/common/mcp.md
@@ -9,6 +9,7 @@
 
 | MCP | 용도 | 자동 활용 시점 |
 |-----|------|---------------|
+| `code-review-graph` | 코드 지식 그래프 / blast radius | 코드 리뷰, 리팩토링, "이 함수 바뀌면 뭐가 영향?" 질의 시 자동 |
 | `context7` | 공식 문서 조회 | 패키지 API 사용 전 필수 조회 |
 | `dart` | Dart 언어 서버 | Dart/Flutter 코드 작성 시 |
 | `serena` | 코드베이스 분석 | 아키텍처 파악, 리팩토링 시 |
@@ -33,6 +34,7 @@
 5. E2E 테스트 → `playwright`로 브라우저 자동화
 6. 배포 → CMS는 `vercel`, 서버는 `railway`
 7. API 키 미설정 MCP → 무시하고 진행 (에러 시 사용자에게 설정 안내)
+8. 코드 리뷰 / 리팩토링 / 영향 분석 → `code-review-graph` 의 blast_radius / dependents / search_nodes 도구를 먼저 호출 (전체 파일 읽기 전). 토큰 절약 핵심.
 
 ## Claude Code MCP 자동 인식
 

--- a/resources/harness-template/README.md
+++ b/resources/harness-template/README.md
@@ -305,6 +305,34 @@ matcher 예시:
 
 ---
 
+## 8. Code Review Graph
+
+[`code-review-graph`](https://github.com/tirth8205/code-review-graph) 는 Tree-sitter 기반 코드 지식 그래프 + MCP 서버로,
+변경 파일의 **blast radius**(영향 범위) / **dependents**(의존자) / **callers**(호출자) 를 토큰 효율적으로 질의할 수 있게 한다.
+하네스의 `code-reviewer` 에이전트가 리뷰 시작 전 반드시 호출하도록 룰화되어 있다 (평균 6.8× 토큰 절약).
+
+### 설치 (시스템에 한 번만)
+
+```bash
+pipx install code-review-graph
+# 또는
+pip install code-review-graph
+# 또는
+uv tool install code-review-graph
+```
+
+### 사용
+
+- **워크스페이스 생성 시 자동 빌드**: Forge Studio의 New Workspace 다이얼로그에서 "Code Review Graph" 옵션이 켜져 있으면, 워크스페이스 부트스트랩 단계에서 자동으로 그래프가 빌드된다.
+- **수동 빌드 / 재빌드**: 워크스페이스 루트에서 `code-review-graph build` 실행. 큰 리팩토링 후나 언어/스택을 추가했을 때 권장.
+- **Claude Code 자동 연결**: `.claude/mcp.json` 에 `code-review-graph` 서버가 등록되어 있어, 새 Claude Code 세션을 열면 MCP 가 자동으로 붙는다. 별도 설정/토큰 불필요.
+
+### 동작 원리
+
+소스 파일을 **Tree-sitter** 로 파싱 → 함수/클래스/import 노드 + 호출/참조 엣지를 추출해 워크스페이스 루트의 **SQLite 그래프**에 저장한다. 이후 **MCP 서버** 모드로 떠서 `blast_radius` / `dependents` / `callers` / `search_nodes` 같은 도구를 Claude Code 에게 노출한다. 그래프는 SQL 인덱스 기반이라 수만 노드 규모에서도 ms 단위로 질의되며, 전체 파일을 읽기 전에 영향 범위를 좁히기 때문에 평균 **6.8× 토큰 절약** 효과가 보고되어 있다.
+
+---
+
 ## 관련 파일
 
 - `CLAUDE.md` — 매니저 롤, 에이전트/스킬 라우팅 표

--- a/src/components/v2/CodeGraphViz.tsx
+++ b/src/components/v2/CodeGraphViz.tsx
@@ -1,0 +1,305 @@
+/**
+ * CodeGraphViz — fullscreen overlay that hosts the code-review-graph D3.js
+ * visualization server in an iframe.
+ *
+ * Lifecycle:
+ *   mount    → window.api.crGraph.vizStart(workspacePath)  → { url, pid }
+ *   unmount  → window.api.crGraph.vizStop(pid)
+ *
+ * The IPC surface is not yet exposed by `electron/preload.ts` (a peer worker
+ * is wiring it). Until then the component falls back to an instructional empty
+ * state so the rest of the UI keeps type-checking and renders gracefully.
+ *
+ * TODO(crGraph-ipc): replace optional chaining with a typed `window.api.crGraph`
+ * import once the preload bridge lands.
+ */
+import { useEffect, useState } from 'react'
+
+import { Btn } from './primitives'
+import { Icon } from './icons'
+
+// ─── window.api.crGraph (TODO: real preload type) ────────────────────
+//
+// Loose, optional typing so this file compiles regardless of whether the
+// renderer's IPC surface has the bridge yet.
+
+interface VizStartResult {
+  url: string
+  pid: number | string
+}
+
+interface CrGraphApi {
+  isInstalled?: () => Promise<{ installed: boolean; version?: string }>
+  install?: (mode: 'pipx' | string) => Promise<void>
+  build?: (workspacePath: string) => Promise<void>
+  stats?: (workspacePath: string) => Promise<{
+    nodes: number
+    edges: number
+    files: number
+    languages: number
+    lastBuiltAt?: string | null
+  } | null>
+  vizStart?: (workspacePath: string) => Promise<VizStartResult>
+  vizStop?: (pid: number | string) => Promise<void>
+}
+
+function getCrGraphApi(): CrGraphApi | undefined {
+  if (typeof window === 'undefined') return undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  return w?.api?.crGraph as CrGraphApi | undefined
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+export interface CodeGraphVizProps {
+  workspacePath: string
+  onClose: () => void
+}
+
+export function CodeGraphViz({ workspacePath, onClose }: CodeGraphVizProps) {
+  const [vizUrl, setVizUrl] = useState<string | null>(null)
+  const [pid, setPid] = useState<number | string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    let activePid: number | string | null = null
+
+    async function start() {
+      const api = getCrGraphApi()
+      if (!api?.vizStart) {
+        if (!cancelled) {
+          setError(
+            'code-review-graph IPC bridge is not available yet. Install the harness or wait for the peer worker to expose window.api.crGraph.',
+          )
+          setStarting(false)
+        }
+        return
+      }
+      try {
+        const res = await api.vizStart(workspacePath)
+        if (cancelled) {
+          // We were unmounted before the server reported back — clean up.
+          if (api.vizStop && res.pid != null) {
+            api.vizStop(res.pid).catch(() => {})
+          }
+          return
+        }
+        activePid = res.pid
+        setPid(res.pid)
+        setVizUrl(res.url)
+        setStarting(false)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+        setStarting(false)
+      }
+    }
+
+    void start()
+
+    return () => {
+      cancelled = true
+      const api = getCrGraphApi()
+      if (api?.vizStop && activePid != null) {
+        api.vizStop(activePid).catch(() => {})
+      }
+    }
+    // We intentionally re-run only when the workspace path changes.
+  }, [workspacePath])
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Code Review Graph visualization"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 200,
+        background: 'var(--bg-1)',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'var(--font-ui)',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          flex: '0 0 auto',
+          height: 44,
+          padding: '0 14px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          borderBottom: '1px solid var(--line-1)',
+          background: 'var(--bg-2)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 8,
+            minWidth: 0,
+            flex: 1,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--text-1)',
+              letterSpacing: -0.2,
+            }}
+          >
+            Code Review Graph
+          </span>
+          <span
+            style={{
+              fontSize: 11.5,
+              color: 'var(--text-3)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {workspacePath} · D3.js force-directed dependency graph
+          </span>
+        </div>
+        <Btn
+          variant="ghost"
+          icon={<Icon.X size={12} />}
+          onClick={onClose}
+          aria-label="Close visualization"
+        >
+          Close
+        </Btn>
+      </div>
+
+      {/* Body */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          position: 'relative',
+          background: 'var(--bg-1)',
+        }}
+      >
+        {starting && !error && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+              gap: 10,
+              color: 'var(--text-3)',
+              fontSize: 12.5,
+            }}
+          >
+            <Spinner />
+            <span>Starting visualization server…</span>
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+              gap: 12,
+              padding: 32,
+              textAlign: 'center',
+            }}
+          >
+            <div style={{ fontSize: 13, color: 'var(--danger)', fontWeight: 600 }}>
+              Visualization unavailable
+            </div>
+            <div
+              style={{
+                fontSize: 12,
+                color: 'var(--text-3)',
+                maxWidth: 480,
+                lineHeight: 1.5,
+              }}
+            >
+              {error}
+            </div>
+            <Btn variant="ghost" onClick={onClose}>
+              Close
+            </Btn>
+          </div>
+        )}
+
+        {vizUrl && !error && (
+          <iframe
+            title="Code Review Graph"
+            src={vizUrl}
+            style={{
+              width: '100%',
+              height: '100%',
+              border: 'none',
+              background: 'var(--bg-1)',
+            }}
+            // The viz server is a local trusted process started by the main
+            // process; we still constrain the sandbox to scripts + same-origin
+            // so the iframe can run D3 but cannot navigate the parent window.
+            sandbox="allow-scripts allow-same-origin allow-forms"
+          />
+        )}
+      </div>
+
+      {/* Footer */}
+      {vizUrl && (
+        <div
+          style={{
+            flex: '0 0 auto',
+            height: 26,
+            padding: '0 14px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            borderTop: '1px solid var(--line-1)',
+            background: 'var(--bg-2)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10.5,
+            color: 'var(--text-4)',
+          }}
+        >
+          <span>{vizUrl}</span>
+          <span style={{ flex: 1 }} />
+          {pid != null && <span>pid: {String(pid)}</span>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Spinner ─────────────────────────────────────────────────────────
+
+function Spinner({ size = 14 }: { size?: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        border: '2px solid var(--line-2)',
+        borderTopColor: 'var(--accent)',
+        display: 'inline-block',
+        animation: 'cgv-spin 0.7s linear infinite',
+      }}
+    >
+      <style>{`@keyframes cgv-spin { to { transform: rotate(360deg); } }`}</style>
+    </span>
+  )
+}

--- a/src/components/v2/SettingsFull.tsx
+++ b/src/components/v2/SettingsFull.tsx
@@ -10,11 +10,12 @@
  * Source: /tmp/forge_design/forge/project/src/settings_full.jsx
  */
 
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 // TODO: foundation import
 import { Btn, Pill, Dot, AvatarStack } from './primitives'
 import { Icon } from './icons'
 import type { WorkspaceSummary } from './types'
+import { CodeGraphViz } from './CodeGraphViz'
 
 export interface SettingsFullProps {
   workspaces: WorkspaceSummary[]
@@ -105,7 +106,7 @@ export function SettingsFull({ workspaces, workspace }: SettingsFullProps) {
         {section === 'general' && (
           <SettingsGeneral workspaces={workspaces} workspace={workspace} />
         )}
-        {section === 'harness' && <SettingsHarness />}
+        {section === 'harness' && <SettingsHarness workspace={workspace} />}
         {section === 'agents' && <SettingsAgents />}
         {section === 'integrations' && <SettingsIntegrations />}
         {section === 'account' && <SettingsAccount />}
@@ -374,13 +375,19 @@ export function SettingsGeneral({ workspaces }: SettingsGeneralProps) {
 
 // ─── Harness ──────────────────────────────────────────────────────
 
-export function SettingsHarness() {
+export interface SettingsHarnessProps {
+  workspace?: WorkspaceSummary
+}
+
+export function SettingsHarness({ workspace }: SettingsHarnessProps = {}) {
   const [autoUpdate, setAutoUpdate] = useState(true)
   const [telemetry, setTelemetry] = useState(false)
   const [betaChannel, setBetaChannel] = useState(false)
   return (
     <>
       <SectionHeader title="Harness" sub="forge 자체의 업데이트와 정책" />
+
+      <CodeReviewGraphCard workspace={workspace} />
 
       <SettingsCard title="Version">
         <Row
@@ -830,6 +837,361 @@ export function SettingsAccount() {
           />
         ))}
       </SettingsCard>
+    </>
+  )
+}
+
+// ─── Code Review Graph (Harness add-on) ────────────────────────────
+//
+// Surface for the optional code-review-graph harness module: install / build /
+// open visualization. The IPC bridge (window.api.crGraph.*) is being added by
+// a peer worker — until it lands the controls degrade to a "not installed"
+// state and the buttons no-op with an informational error.
+//
+// TODO(crGraph-ipc): replace the loose `any` access with a typed import once
+// the preload bridge is committed.
+
+interface CrGraphStats {
+  nodes: number
+  edges: number
+  files: number
+  languages: number
+  lastBuiltAt?: string | null
+}
+
+interface CrGraphInstallStatus {
+  installed: boolean
+  version?: string
+}
+
+interface CrGraphApi {
+  isInstalled?: () => Promise<CrGraphInstallStatus>
+  install?: (mode: 'pipx' | string) => Promise<void>
+  build?: (workspacePath: string) => Promise<void>
+  stats?: (workspacePath: string) => Promise<CrGraphStats | null>
+  vizStart?: (workspacePath: string) => Promise<{ url: string; pid: number | string }>
+  vizStop?: (pid: number | string) => Promise<void>
+}
+
+function getCrGraphApi(): CrGraphApi | undefined {
+  if (typeof window === 'undefined') return undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  return w?.api?.crGraph as CrGraphApi | undefined
+}
+
+function formatRelative(iso?: string | null): string {
+  if (!iso) return '한 번도 빌드 안 함'
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return '한 번도 빌드 안 함'
+  const diffSec = Math.max(0, Math.round((Date.now() - t) / 1000))
+  if (diffSec < 60) return `${diffSec}초 전`
+  const min = Math.round(diffSec / 60)
+  if (min < 60) return `${min}분 전`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}시간 전`
+  return `${Math.round(hr / 24)}일 전`
+}
+
+interface CodeReviewGraphCardProps {
+  workspace?: WorkspaceSummary
+}
+
+function CodeReviewGraphCard({ workspace }: CodeReviewGraphCardProps) {
+  const [status, setStatus] = useState<CrGraphInstallStatus | null>(null)
+  const [stats, setStats] = useState<CrGraphStats | null>(null)
+  const [installing, setInstalling] = useState(false)
+  const [building, setBuilding] = useState(false)
+  const [progressSec, setProgressSec] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const [vizOpen, setVizOpen] = useState(false)
+
+  const api = getCrGraphApi()
+  const apiAvailable = Boolean(api?.isInstalled)
+  const wsPath = workspace?.path
+
+  // Refresh install/stats whenever the workspace changes.
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      if (!api?.isInstalled) {
+        if (!cancelled) {
+          setStatus({ installed: false })
+          setStats(null)
+        }
+        return
+      }
+      try {
+        const s = await api.isInstalled()
+        if (cancelled) return
+        setStatus(s)
+        if (s.installed && wsPath && api.stats) {
+          const next = await api.stats(wsPath)
+          if (!cancelled) setStats(next ?? null)
+        } else if (!cancelled) {
+          setStats(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [api, wsPath])
+
+  // Drive the "12s" progress counter while a long-running op is in flight.
+  useEffect(() => {
+    if (!installing && !building) {
+      setProgressSec(0)
+      return
+    }
+    setProgressSec(0)
+    const start = Date.now()
+    const id = window.setInterval(() => {
+      setProgressSec(Math.round((Date.now() - start) / 1000))
+    }, 1000)
+    return () => window.clearInterval(id)
+  }, [installing, building])
+
+  const installed = status?.installed ?? false
+  const busy = installing || building
+
+  async function handleInstall() {
+    if (!api?.install) {
+      setError(
+        'crGraph IPC bridge not available yet. window.api.crGraph.install will be wired by a peer worker.',
+      )
+      return
+    }
+    setError(null)
+    setInstalling(true)
+    try {
+      await api.install('pipx')
+      if (api.isInstalled) setStatus(await api.isInstalled())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  async function handleBuild() {
+    if (!api?.build || !wsPath) {
+      setError('build 호출 불가: 활성 워크스페이스 또는 IPC 미준비')
+      return
+    }
+    setError(null)
+    setBuilding(true)
+    try {
+      await api.build(wsPath)
+      if (api.stats) setStats(await api.stats(wsPath))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBuilding(false)
+    }
+  }
+
+  function handleOpenViz() {
+    if (!wsPath) {
+      setError('활성 워크스페이스 없음 — 시각화를 열 수 없습니다.')
+      return
+    }
+    setError(null)
+    setVizOpen(true)
+  }
+
+  // ─── Status badge ───
+  let badge: ReactNode
+  if (building) {
+    badge = <Pill color="var(--warning)">빌드 중</Pill>
+  } else if (installing) {
+    badge = <Pill color="var(--warning)">설치 중</Pill>
+  } else if (!installed) {
+    badge = <Pill color="var(--text-3)">설치 안 됨</Pill>
+  } else {
+    badge = (
+      <Pill color="var(--success)">
+        설치됨{status?.version ? ` · ${status.version}` : ''}
+      </Pill>
+    )
+  }
+
+  const statCells: Array<{ label: string; value: string | number }> = [
+    { label: 'nodes', value: stats?.nodes ?? '—' },
+    { label: 'edges', value: stats?.edges ?? '—' },
+    { label: 'files', value: stats?.files ?? '—' },
+    { label: 'languages', value: stats?.languages ?? '—' },
+  ]
+
+  return (
+    <>
+      <SettingsCard
+        title="Code Review Graph"
+        right={
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+            {badge}
+            {!apiAvailable && (
+              <span
+                style={{
+                  fontSize: 10,
+                  color: 'var(--text-4)',
+                  fontFamily: 'var(--font-mono)',
+                }}
+              >
+                ipc pending
+              </span>
+            )}
+          </span>
+        }
+      >
+        {/* Description row */}
+        <Row
+          label="저장소 의존성 + 호출 그래프"
+          sub={`마지막 빌드: ${formatRelative(stats?.lastBuiltAt)}${
+            busy ? ` · 작업 중… (${progressSec}s)` : ''
+          }`}
+          right={
+            busy ? (
+              <span
+                aria-hidden
+                style={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: '50%',
+                  border: '2px solid var(--line-2)',
+                  borderTopColor: 'var(--accent)',
+                  display: 'inline-block',
+                  animation: 'crg-spin 0.7s linear infinite',
+                }}
+              >
+                <style>{`@keyframes crg-spin { to { transform: rotate(360deg); } }`}</style>
+              </span>
+            ) : (
+              <Icon.Layers size={14} style={{ color: 'var(--text-3)' }} />
+            )
+          }
+        />
+
+        {/* Stats grid (only when installed) */}
+        {installed && (
+          <div
+            style={{
+              padding: '12px 16px',
+              borderBottom: '1px solid var(--line-1)',
+              display: 'grid',
+              gridTemplateColumns: 'repeat(4, 1fr)',
+              gap: 8,
+            }}
+          >
+            {statCells.map((c) => (
+              <div
+                key={c.label}
+                style={{
+                  padding: 10,
+                  borderRadius: 6,
+                  background: 'var(--bg-1)',
+                  border: '1px solid var(--line-1)',
+                }}
+              >
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 9.5,
+                    letterSpacing: 1.2,
+                    textTransform: 'uppercase',
+                    fontWeight: 600,
+                    color: 'var(--text-3)',
+                    marginBottom: 6,
+                  }}
+                >
+                  {c.label}
+                </div>
+                <div
+                  style={{
+                    fontSize: 18,
+                    fontWeight: 600,
+                    color: 'var(--text-1)',
+                    fontFamily: 'var(--font-mono)',
+                    letterSpacing: -0.4,
+                  }}
+                >
+                  {c.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              padding: '10px 16px',
+              borderBottom: '1px solid var(--line-1)',
+              fontSize: 11.5,
+              color: 'var(--danger)',
+              background: 'color-mix(in oklab, var(--danger) 8%, transparent)',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div
+          style={{
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            flexWrap: 'wrap',
+          }}
+        >
+          {!installed && (
+            <Btn
+              variant="primary"
+              icon={<Icon.Plus size={11} />}
+              onClick={handleInstall}
+              disabled={busy}
+            >
+              Install via pipx
+            </Btn>
+          )}
+          {installed && (
+            <Btn
+              variant="default"
+              icon={<Icon.Refresh size={11} />}
+              onClick={handleBuild}
+              disabled={busy || !wsPath}
+            >
+              Rebuild graph
+            </Btn>
+          )}
+          <Btn
+            variant="ghost"
+            icon={<Icon.Activity size={11} />}
+            onClick={handleOpenViz}
+            disabled={busy || !wsPath}
+          >
+            Open Visualization
+          </Btn>
+          {!wsPath && (
+            <span style={{ fontSize: 11, color: 'var(--text-4)', marginLeft: 'auto' }}>
+              활성 워크스페이스를 먼저 선택하세요
+            </span>
+          )}
+        </div>
+      </SettingsCard>
+
+      {vizOpen && wsPath && (
+        <CodeGraphViz workspacePath={wsPath} onClose={() => setVizOpen(false)} />
+      )}
     </>
   )
 }

--- a/src/components/v2/wired/DashboardPanelWired.tsx
+++ b/src/components/v2/wired/DashboardPanelWired.tsx
@@ -7,7 +7,7 @@
  * counts), `mcpStatus` (live `which`-checked server health), and the
  * installed/bundled harness versions.
  */
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useWorkspaceStore } from '@/stores/workspace'
 
 import { Icon } from '../icons'
@@ -29,6 +29,47 @@ interface QuickAction {
 
 export interface DashboardPanelWiredProps {
   onCmdK?: () => void
+}
+
+// ─── Knowledge Graph (code-review-graph) helpers ────────────────────
+//
+// The crGraph IPC bridge is wired by a peer worker. Until it lands we read
+// it defensively via optional chaining so the panel still renders without it.
+//
+// TODO(crGraph-ipc): replace with a typed `window.api.crGraph` import once the
+// preload bridge is committed.
+
+interface CrGraphStats {
+  nodes: number
+  edges: number
+  files: number
+  languages: number
+  lastBuiltAt?: string | null
+}
+
+interface CrGraphApiSlim {
+  isInstalled?: () => Promise<{ installed: boolean; version?: string }>
+  stats?: (workspacePath: string) => Promise<CrGraphStats | null>
+}
+
+function getCrGraphApiSlim(): CrGraphApiSlim | undefined {
+  if (typeof window === 'undefined') return undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  return w?.api?.crGraph as CrGraphApiSlim | undefined
+}
+
+function formatRelative(iso?: string | null): string {
+  if (!iso) return '한 번도 빌드 안 함'
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return '한 번도 빌드 안 함'
+  const diffSec = Math.max(0, Math.round((Date.now() - t) / 1000))
+  if (diffSec < 60) return `${diffSec}초 전`
+  const min = Math.round(diffSec / 60)
+  if (min < 60) return `${min}분 전`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}시간 전`
+  return `${Math.round(hr / 24)}일 전`
 }
 
 /**
@@ -64,6 +105,44 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
     scanHarness()
     scanMcp()
   }, [activeWorkspace, scanHarness, scanMcp])
+
+  // ─── Knowledge Graph (code-review-graph) ───
+  const [crInstalled, setCrInstalled] = useState<boolean | null>(null)
+  const [crStats, setCrStats] = useState<CrGraphStats | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      const api = getCrGraphApiSlim()
+      if (!api?.isInstalled) {
+        if (!cancelled) {
+          setCrInstalled(false)
+          setCrStats(null)
+        }
+        return
+      }
+      try {
+        const s = await api.isInstalled()
+        if (cancelled) return
+        setCrInstalled(s.installed)
+        if (s.installed && activeWorkspace?.path && api.stats) {
+          const next = await api.stats(activeWorkspace.path)
+          if (!cancelled) setCrStats(next ?? null)
+        } else if (!cancelled) {
+          setCrStats(null)
+        }
+      } catch {
+        if (!cancelled) {
+          setCrInstalled(false)
+          setCrStats(null)
+        }
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [activeWorkspace?.path])
 
   // Graceful defaults for missing data — a freshly-opened workspace whose
   // scan hasn't completed yet, or a workspace without `.claude/` at all.
@@ -248,6 +327,107 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
             <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>{s.sub}</div>
           </div>
         ))}
+      </div>
+
+      {/* Knowledge Graph (code-review-graph) */}
+      <div
+        style={{
+          background: 'var(--bg-2)',
+          border: '1px solid var(--line-1)',
+          borderRadius: 6,
+          overflow: 'hidden',
+          marginBottom: 18,
+        }}
+      >
+        <SectionHead
+          title="Knowledge Graph"
+          sub={
+            crInstalled === false
+              ? 'code-review-graph not installed'
+              : crStats
+                ? `${crStats.nodes.toLocaleString()} nodes · ${crStats.edges.toLocaleString()} edges`
+                : 'no data yet'
+          }
+          right={
+            crInstalled === false ? (
+              <Btn
+                variant="ghost"
+                style={{ height: 22, fontSize: 11 }}
+                icon={<Icon.Cog size={11} />}
+              >
+                Settings에서 활성화
+              </Btn>
+            ) : undefined
+          }
+        />
+        {crInstalled === false ? (
+          <div
+            style={{
+              padding: '14px 14px',
+              fontSize: 11.5,
+              color: 'var(--text-3)',
+            }}
+          >
+            저장소 의존성/호출 그래프가 활성화되지 않았습니다. Settings → Harness →{' '}
+            <strong style={{ color: 'var(--text-2)' }}>Code Review Graph</strong>에서 설치하세요.
+          </div>
+        ) : (
+          <div
+            style={{
+              padding: 12,
+              display: 'grid',
+              gridTemplateColumns: 'repeat(4, 1fr)',
+              gap: 8,
+            }}
+          >
+            {(
+              [
+                { label: 'nodes', value: crStats?.nodes },
+                { label: 'edges', value: crStats?.edges },
+                { label: 'files', value: crStats?.files },
+                {
+                  label: 'last build',
+                  value: formatRelative(crStats?.lastBuiltAt),
+                },
+              ] as const
+            ).map((c) => (
+              <div
+                key={c.label}
+                style={{
+                  padding: 10,
+                  borderRadius: 6,
+                  background: 'var(--bg-1)',
+                  border: '1px solid var(--line-1)',
+                }}
+              >
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 9.5,
+                    letterSpacing: 1.2,
+                    textTransform: 'uppercase',
+                    fontWeight: 600,
+                    color: 'var(--text-3)',
+                    marginBottom: 6,
+                  }}
+                >
+                  {c.label}
+                </div>
+                <div
+                  style={{
+                    fontSize: typeof c.value === 'number' ? 22 : 13,
+                    fontWeight: 600,
+                    color: 'var(--text-1)',
+                    fontFamily: 'var(--font-mono)',
+                    letterSpacing: -0.4,
+                  }}
+                >
+                  {c.value === undefined || c.value === null ? '—' : String(c.value)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 12 }}>

--- a/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/src/components/workspace/NewWorkspaceDialog.tsx
@@ -13,6 +13,9 @@ export function NewWorkspaceDialog() {
   const [owner, setOwner] = useState('')
   const [baseName, setBaseName] = useState('')
   const [autoCreateRepos, setAutoCreateRepos] = useState(false)
+  // code-review-graph: opt-in auto build right after scaffolding. Requires the
+  // CLI to be installed (Settings → MCP / Tools panel handles install).
+  const [crGraphAutoBuild, setCrGraphAutoBuild] = useState(false)
 
   if (!newWorkspaceDialogVisible) return null
 
@@ -46,7 +49,8 @@ export function NewWorkspaceDialog() {
               protocol: 'ssh',
               autoCreateRepos,
             }
-          : undefined
+          : undefined,
+        crGraphAutoBuild ? { autoBuild: true } : undefined
       )
       setName('')
       setDirPath('')
@@ -54,6 +58,7 @@ export function NewWorkspaceDialog() {
       setOwner('')
       setBaseName('')
       setAutoCreateRepos(false)
+      setCrGraphAutoBuild(false)
     } finally {
       setCreating(false)
     }
@@ -190,6 +195,28 @@ export function NewWorkspaceDialog() {
                 </div>
               </div>
             )}
+          </div>
+
+          {/* Advanced options: code-review-graph build (opt-in) */}
+          <div className="bg-surface-0 rounded-lg p-3 border border-border">
+            <div className="text-xs text-text-secondary mb-2">Advanced</div>
+            <label className="flex items-start gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={crGraphAutoBuild}
+                onChange={(e) => setCrGraphAutoBuild(e.target.checked)}
+                className="mt-0.5 w-3.5 h-3.5 accent-accent"
+              />
+              <span className="flex-1">
+                <span className="block text-xs text-text-primary">
+                  코드 리뷰 그래프 빌드 (code-review-graph)
+                </span>
+                <span className="block text-2xs text-text-muted leading-relaxed mt-0.5">
+                  <span className="font-mono">pipx install code-review-graph</span>{' '}
+                  가 미리 깔려 있어야 합니다 (Settings 에서 확인).
+                </span>
+              </span>
+            </label>
           </div>
         </div>
 

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -17,7 +17,12 @@ interface WorkspaceState {
 
   loadWorkspaces: () => Promise<void>
   setActiveWorkspace: (workspace: Workspace) => void
-  createWorkspace: (name: string, dirPath: string, splitRepos?: SplitReposOptions) => Promise<Workspace>
+  createWorkspace: (
+    name: string,
+    dirPath: string,
+    splitRepos?: SplitReposOptions,
+    crGraph?: { autoBuild?: boolean }
+  ) => Promise<Workspace>
   openWorkspace: (dirPath: string) => Promise<Workspace>
   removeWorkspace: (id: string) => void
   scanHarness: () => Promise<void>
@@ -64,7 +69,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     get().refreshHarnessVersion()
   },
 
-  createWorkspace: async (name: string, dirPath: string, splitRepos?: SplitReposOptions) => {
+  createWorkspace: async (
+    name: string,
+    dirPath: string,
+    splitRepos?: SplitReposOptions,
+    crGraph?: { autoBuild?: boolean }
+  ) => {
     const templatePath = await window.api.workspace.getTemplatePath()
     const claudeMdPath = await window.api.workspace.getClaudeMdPath()
     const workspace = await window.api.workspace.create({
@@ -73,6 +83,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       templatePath,
       claudeMdPath,
       splitRepos: splitRepos?.enabled ? splitRepos : undefined,
+      crGraph: crGraph?.autoBuild ? { autoBuild: true } : undefined,
     })
     await get().loadWorkspaces()
     set({ activeWorkspace: workspace, newWorkspaceDialogVisible: false })


### PR DESCRIPTION
## Summary

[code-review-graph](https://github.com/tirth8205/code-review-graph) (Tree-sitter 기반 코드 지식 그래프 + MCP 서버, 평균 6.8× 토큰 절약) 를 하네스에 풀 통합. 옵션 C (full).

## 구성 (3 커밋)

| 커밋 | 영역 | 내용 |
|---|---|---|
| `feat(harness)` | 하네스 | mcp.json server 추가 + mcp.md 룰 + code-reviewer agent Tools 활용 + README \"Code Review Graph\" 절 |
| `feat(electron)` | 백엔드 | CodeReviewGraphManager (install/build/stats/vizUrl/stopViz) + 6개 IPC + WorkspaceManager autoBuild 옵션 + NewWorkspaceDialog 토글 |
| `feat(ui)` | 프론트엔드 | SettingsHarness 카드 + DashboardPanel 통계 섹션 + CodeGraphViz 풀스크린 모달 (D3 viz iframe) |

## 핵심 동작

### 1. Claude Code 가 자동으로 활용
- `.claude/mcp.json` 에 `code-review-graph` server 등록 (uvx)
- `mcp.md` 8번 룰: 코드 리뷰/리팩토링 시 blast_radius/dependents/search_nodes 도구 먼저 호출
- `code-reviewer` agent: 리뷰 전 그래프 쿼리 → 영향 범위 안만 Read

### 2. 워크스페이스 생성 시 자동 빌드 (opt-in)
- NewWorkspaceDialog \"Advanced\" → \"코드 리뷰 그래프 빌드\" 체크박스
- 체크 시 `WorkspaceManager.create` 후 `code-review-graph build` best-effort 실행 (블로킹 X)

### 3. Settings → Harness → Code Review Graph 카드
- 상태 배지 (설치 안 됨/설치됨/빌드 중)
- 마지막 빌드 시각 + 4-cell 통계 (nodes/edges/files/lastBuiltAt)
- 버튼: Install (pipx) / Rebuild / Open Visualization
- 진행 spinner + 초 카운터

### 4. Dashboard → Knowledge Graph 섹션
- 6-stat grid 와 MCP 사이에 신규 섹션
- 4-cell stat + 미설치 시 \"Settings에서 활성화\" 안내

### 5. 풀스크린 D3 시각화
- `code-review-graph viz --port <p> --no-open` 백그라운드 spawn
- localhost URL 을 sandbox iframe 으로 임베드
- 모달 닫으면 process kill (vizStop)

## 사용자 사전 작업

```bash
pipx install code-review-graph    # 또는 pip install --user / uv tool install
```

미설치 시 UI 가 graceful — \"Install\" 버튼 클릭 시 자동으로 pipx > uv > pip3 순으로 시도.

## Test Plan

- [x] `npm run typecheck` clean
- [ ] Settings → Code Review Graph 카드 → Install 버튼 → 실제 pipx 설치 동작
- [ ] 같은 카드 → Rebuild → 실제 그래프 빌드 (~10s for 500 files)
- [ ] Open Visualization → D3 force-directed graph iframe 정상 렌더
- [ ] Dashboard → Knowledge Graph 섹션 통계 표시
- [ ] NewWorkspaceDialog Advanced 토글 → 워크스페이스 생성 후 자동 빌드 확인
- [ ] Claude Code 재시작 후 MCP 자동 연결 → /verify 또는 코드 리뷰 시 blast_radius 도구 호출 확인

## 베이스
PR-C (feat/ui-overhaul-v2) 위에 빌드. PR-C 머지 후 자동으로 main 기반 갱신.

## 영향
- code-review-graph 미설치 환경: 모든 cr-graph IPC 가 graceful failure, 카드/섹션이 \"설치 안 됨\" 상태로 안내
- 기존 워크스페이스: Update Harness 클릭 시 mcp.json + 룰 + agent + README 자동 적용