### PR TITLE
feat(teams): 팀 시스템 4가지 보류 기능 풀 구현 + 아키텍처 문서 (PR-E)

### DIFF
--- a/docs/harness-architecture.html
+++ b/docs/harness-architecture.html
@@ -1,0 +1,1085 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Forge Studio · 하네스 아키텍처</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg-0: #07090d;
+    --bg-1: #0b0e13;
+    --bg-2: #11151c;
+    --bg-3: #161b24;
+    --bg-4: #1d242f;
+    --line-1: #1c222c;
+    --line-2: #262e3a;
+    --line-3: #313a48;
+    --text-1: #e6e9ef;
+    --text-2: #9aa3b2;
+    --text-3: #6b7280;
+    --text-4: #4a525e;
+    --accent: #ff6b35;
+    --accent-2: #ff8758;
+    --accent-dim: rgba(255, 107, 53, 0.14);
+    --accent-line: rgba(255, 107, 53, 0.32);
+    --success: #4ade80;
+    --warning: #f5a524;
+    --danger: #f87171;
+    --info: #60a5fa;
+    --violet: #a78bfa;
+    --role-fe: #60a5fa;
+    --role-be: #a78bfa;
+    --role-db: #f59e0b;
+    --role-test: #34d399;
+    --role-review: #f472b6;
+    --role-infra: #fb923c;
+    --role-arch: #22d3ee;
+    --role-doc: #facc15;
+    --font-ui: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+    --shadow: 0 1px 0 rgba(255,255,255,0.02) inset, 0 1px 2px rgba(0,0,0,0.4);
+    --shadow-pop: 0 12px 32px rgba(0,0,0,0.5), 0 2px 6px rgba(0,0,0,0.3);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--text-1); font-family: var(--font-ui); -webkit-font-smoothing: antialiased; line-height: 1.55; }
+  body { background-image: radial-gradient(1200px 600px at 50% -200px, rgba(255,107,53,0.08), transparent 70%); }
+  ::selection { background: var(--accent-dim); color: var(--text-1); }
+
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 60px 32px 120px; }
+  .mono { font-family: var(--font-mono); font-feature-settings: "calt" 0; }
+
+  /* HERO */
+  .hero { padding: 64px 0 56px; text-align: center; border-bottom: 1px solid var(--line-1); margin-bottom: 64px; }
+  .hero .badge { display: inline-block; padding: 4px 10px; border: 1px solid var(--accent-line); background: var(--accent-dim); color: var(--accent); border-radius: 4px; font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.3px; text-transform: uppercase; margin-bottom: 18px; }
+  .hero h1 { font-size: 48px; font-weight: 700; margin: 0 0 14px; letter-spacing: -0.5px; }
+  .hero .sub { font-size: 17px; color: var(--text-2); max-width: 640px; margin: 0 auto; }
+  .hero .meta { margin-top: 22px; font-family: var(--font-mono); font-size: 12px; color: var(--text-3); }
+  .hero .meta span + span { margin-left: 14px; padding-left: 14px; border-left: 1px solid var(--line-2); }
+
+  /* SECTION */
+  section { margin-bottom: 80px; }
+  section h2 { font-size: 28px; font-weight: 600; margin: 0 0 6px; letter-spacing: -0.3px; }
+  section .lead { font-size: 15px; color: var(--text-2); margin: 0 0 28px; max-width: 720px; }
+  section h3 { font-size: 17px; font-weight: 600; margin: 36px 0 12px; color: var(--text-1); }
+  section h4 { font-size: 13px; font-weight: 600; margin: 20px 0 10px; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.6px; font-family: var(--font-mono); }
+  p { color: var(--text-2); }
+  strong { color: var(--text-1); font-weight: 600; }
+  code { font-family: var(--font-mono); font-size: 12.5px; padding: 1px 5px; background: var(--bg-3); border: 1px solid var(--line-2); border-radius: 3px; color: var(--text-1); }
+  a { color: var(--accent-2); text-decoration: none; border-bottom: 1px dashed var(--accent-line); }
+
+  /* CARDS */
+  .grid { display: grid; gap: 14px; }
+  .grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+  .grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+  .grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+  @media (max-width: 800px) { .grid.cols-2, .grid.cols-3, .grid.cols-4 { grid-template-columns: 1fr; } }
+  .card { background: var(--bg-2); border: 1px solid var(--line-1); border-radius: 8px; padding: 18px 20px; box-shadow: var(--shadow); }
+  .card .ico { width: 28px; height: 28px; border-radius: 6px; display: inline-flex; align-items: center; justify-content: center; background: var(--bg-3); border: 1px solid var(--line-2); color: var(--accent); margin-bottom: 10px; }
+  .card h5 { margin: 0 0 6px; font-size: 14px; font-weight: 600; }
+  .card .desc { font-size: 13px; color: var(--text-2); margin: 0; line-height: 1.55; }
+  .card .key { display: inline-block; margin-top: 10px; font-family: var(--font-mono); font-size: 11px; color: var(--text-3); padding: 2px 6px; background: var(--bg-3); border: 1px solid var(--line-2); border-radius: 3px; }
+
+  /* DIAGRAMS */
+  .diagram { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 8px; padding: 22px; margin: 18px 0; box-shadow: var(--shadow); }
+  .diagram .caption { font-family: var(--font-mono); font-size: 11px; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 14px; }
+  svg { display: block; width: 100%; height: auto; }
+
+  /* PILLS / TAGS */
+  .pill { display: inline-flex; align-items: center; gap: 4px; padding: 2px 7px; font-size: 10.5px; font-weight: 500; letter-spacing: 0.2px; text-transform: uppercase; background: var(--bg-3); color: var(--text-2); border: 1px solid var(--line-2); border-radius: 4px; font-family: var(--font-mono); }
+  .pill.accent { background: var(--accent-dim); color: var(--accent); border-color: var(--accent-line); }
+  .pill.success { background: rgba(74,222,128,0.12); color: var(--success); border-color: rgba(74,222,128,0.28); }
+  .pill.danger { background: rgba(248,113,113,0.12); color: var(--danger); border-color: rgba(248,113,113,0.28); }
+  .pill.warning { background: rgba(245,165,36,0.12); color: var(--warning); border-color: rgba(245,165,36,0.28); }
+  .pill.info { background: rgba(96,165,250,0.12); color: var(--info); border-color: rgba(96,165,250,0.28); }
+
+  /* TABLE */
+  table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+  th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--line-1); }
+  th { color: var(--text-3); font-weight: 600; font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.5px; font-family: var(--font-mono); background: var(--bg-2); }
+  td { color: var(--text-2); }
+  td strong { color: var(--text-1); }
+  tr:hover td { background: var(--bg-2); }
+  .table-wrap { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 8px; overflow: hidden; }
+
+  /* ENFORCED ACTION ROW */
+  .actrow { display: grid; grid-template-columns: 200px 1fr 100px; gap: 12px; align-items: center; padding: 10px 0; border-bottom: 1px dashed var(--line-1); font-size: 13px; }
+  .actrow:last-child { border-bottom: none; }
+  .actrow .src { font-family: var(--font-mono); color: var(--text-2); font-size: 12px; }
+  .actrow .desc { color: var(--text-2); }
+
+  /* TIMELINE */
+  .timeline { position: relative; padding-left: 28px; }
+  .timeline::before { content: ''; position: absolute; left: 8px; top: 0; bottom: 0; width: 2px; background: var(--line-2); }
+  .step { position: relative; padding: 12px 0 12px 14px; }
+  .step::before { content: ''; position: absolute; left: -27px; top: 16px; width: 14px; height: 14px; border-radius: 50%; background: var(--bg-1); border: 2px solid var(--accent); box-shadow: 0 0 0 4px var(--bg-0); }
+  .step .num { display: inline-block; padding: 1px 7px; background: var(--accent-dim); color: var(--accent); border: 1px solid var(--accent-line); border-radius: 4px; font-family: var(--font-mono); font-size: 11px; margin-right: 8px; }
+  .step h6 { display: inline; font-size: 14px; font-weight: 600; color: var(--text-1); margin: 0; }
+  .step p { font-size: 13px; color: var(--text-2); margin: 6px 0 0; }
+
+  /* CALLOUT */
+  .callout { padding: 14px 18px; border-left: 3px solid var(--accent); background: var(--accent-dim); border-radius: 4px; margin: 18px 0; font-size: 13.5px; color: var(--text-1); }
+  .callout strong { color: var(--accent); }
+  .callout.warn { border-color: var(--warning); background: rgba(245,165,36,0.08); }
+  .callout.warn strong { color: var(--warning); }
+
+  /* TWO-COL LAYOUT */
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  @media (max-width: 800px) { .two-col { grid-template-columns: 1fr; } }
+  .two-col .col h4 { margin-top: 0; }
+
+  /* Stat block */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 18px 0; }
+  @media (max-width: 800px) { .stats { grid-template-columns: repeat(2, 1fr); } }
+  .stat { background: var(--bg-2); border: 1px solid var(--line-1); border-radius: 6px; padding: 14px 16px; }
+  .stat .v { font-size: 24px; font-weight: 700; color: var(--text-1); font-family: var(--font-mono); letter-spacing: -0.5px; }
+  .stat .l { font-size: 11px; color: var(--text-3); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.5px; font-family: var(--font-mono); }
+
+  /* TOC */
+  .toc { background: var(--bg-2); border: 1px solid var(--line-1); border-radius: 8px; padding: 18px 22px; margin-bottom: 56px; }
+  .toc ol { margin: 0; padding-left: 22px; columns: 2; column-gap: 32px; }
+  @media (max-width: 800px) { .toc ol { columns: 1; } }
+  .toc li { font-size: 13.5px; margin: 4px 0; color: var(--text-2); }
+  .toc a { color: var(--text-1); border-bottom: none; }
+  .toc a:hover { color: var(--accent); }
+
+  /* FOOTER */
+  footer { text-align: center; padding: 40px 0 0; font-size: 12px; color: var(--text-3); border-top: 1px solid var(--line-1); margin-top: 80px; font-family: var(--font-mono); }
+
+  /* Animation */
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+  .pulse { animation: pulse 2s ease-in-out infinite; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- HERO -->
+  <header class="hero">
+    <div class="badge">v0.4.1 · 하네스 아키텍처</div>
+    <h1>Forge Studio Harness</h1>
+    <p class="sub">Claude Code 의 행동을 강제·자동화하는 번들 하네스 — Electron 앱이 워크스페이스를 만들고, <code>.claude/</code> 안의 8개 슬롯이 매 세션 Claude 의 코드/리뷰/팀 작업을 통제한다.</p>
+    <div class="meta mono">
+      <span>Flutter + NestJS + Prisma + Next.js 모노레포</span>
+      <span>macOS · Electron 35</span>
+      <span>25 skills · 18 agents · 25 commands · 15 MCP</span>
+    </div>
+  </header>
+
+  <!-- TOC -->
+  <nav class="toc">
+    <ol>
+      <li><a href="#big-picture">큰 그림 — 3계층 모델</a></li>
+      <li><a href="#slots">.claude/ 안의 8개 슬롯</a></li>
+      <li><a href="#hooks">Hook 라이프사이클</a></li>
+      <li><a href="#skills">스킬 자동 주입</a></li>
+      <li><a href="#pipeline">자동 오케스트레이션 파이프라인</a></li>
+      <li><a href="#teams">팀 시스템 — Run vs Composition</a></li>
+      <li><a href="#run-lifecycle">Run 라이프사이클</a></li>
+      <li><a href="#run-liveview">Run 라이브뷰</a></li>
+      <li><a href="#enforcement">강제 메커니즘 4계층</a></li>
+      <li><a href="#crgraph">Code Review Graph 통합</a></li>
+      <li><a href="#learning">자기 개선 루프</a></li>
+      <li><a href="#summary">요약 · 사용자가 묻는 6가지</a></li>
+    </ol>
+  </nav>
+
+  <!-- 1. BIG PICTURE -->
+  <section id="big-picture">
+    <h2>1. 큰 그림 — 3계층 모델</h2>
+    <p class="lead">Forge Studio (Electron 앱) 가 워크스페이스를 만들고 그 안에 <code>.claude/</code> 하네스를 복사한다. Claude Code 가 그 워크스페이스에서 세션을 시작하면 하네스의 룰/스킬/훅이 매 도구 호출마다 끼어들어 작업을 통제한다.</p>
+
+    <div class="diagram">
+      <div class="caption">Layer Diagram</div>
+      <svg viewBox="0 0 1000 460" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="g-fs" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="#1d242f"/><stop offset="1" stop-color="#161b24"/>
+          </linearGradient>
+          <linearGradient id="g-h" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="#ff6b3522"/><stop offset="1" stop-color="#ff6b3508"/>
+          </linearGradient>
+          <linearGradient id="g-c" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="#1d242f"/><stop offset="1" stop-color="#161b24"/>
+          </linearGradient>
+        </defs>
+
+        <!-- Layer 1 -->
+        <rect x="40" y="20" width="920" height="100" rx="8" fill="url(#g-fs)" stroke="#262e3a"/>
+        <text x="60" y="45" font-family="JetBrains Mono" font-size="11" fill="#6b7280" letter-spacing="1">LAYER 1 · ELECTRON SHELL</text>
+        <text x="60" y="76" font-family="Geist" font-weight="700" font-size="20" fill="#e6e9ef">Forge Studio</text>
+        <text x="60" y="100" font-family="Geist" font-size="13" fill="#9aa3b2">워크스페이스 생성/관리 · Files/Git/터미널 UI · Run 라이브뷰 · 하네스 버전 관리 · 스택별 레포 분리</text>
+
+        <!-- arrow 1 -->
+        <path d="M 500 130 L 500 160" stroke="#ff6b35" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+        <text x="510" y="148" font-family="JetBrains Mono" font-size="10" fill="#ff6b35">create / update</text>
+
+        <!-- Layer 2 -->
+        <rect x="40" y="170" width="920" height="120" rx="8" fill="url(#g-h)" stroke="#ff6b3540"/>
+        <text x="60" y="195" font-family="JetBrains Mono" font-size="11" fill="#ff6b35" letter-spacing="1">LAYER 2 · BUNDLED HARNESS</text>
+        <text x="60" y="226" font-family="Geist" font-weight="700" font-size="20" fill="#e6e9ef">&lt;project&gt;/.claude/</text>
+        <text x="60" y="252" font-family="JetBrains Mono" font-size="13" fill="#ff8758">agents/  skills/  commands/  rules/  scripts/  contexts/  mcp.json  settings.json</text>
+        <text x="60" y="276" font-family="Geist" font-size="13" fill="#9aa3b2">번들 템플릿 · 워크스페이스 생성 시 통째 복사 · `.harness-version` 으로 버전 추적 · 한 클릭 업데이트</text>
+
+        <!-- arrow 2 -->
+        <path d="M 500 300 L 500 330" stroke="#ff6b35" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+        <text x="510" y="318" font-family="JetBrains Mono" font-size="10" fill="#ff6b35">매 세션 자동 로드</text>
+
+        <!-- Layer 3 -->
+        <rect x="40" y="340" width="920" height="100" rx="8" fill="url(#g-c)" stroke="#262e3a"/>
+        <text x="60" y="365" font-family="JetBrains Mono" font-size="11" fill="#6b7280" letter-spacing="1">LAYER 3 · CLAUDE CODE</text>
+        <text x="60" y="396" font-family="Geist" font-weight="700" font-size="20" fill="#e6e9ef">Manager Mode + Worker Agents</text>
+        <text x="60" y="420" font-family="Geist" font-size="13" fill="#9aa3b2">메인 세션 = delegation hub (코드 5줄+ 시 자동 위임) · 18개 서브에이전트 풀 · Hook 이 매 도구 호출마다 차단/주입</text>
+
+        <defs>
+          <marker id="arr" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff6b35"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+
+    <div class="callout">
+      <strong>핵심 결정:</strong> Forge Studio 자체는 Claude 행동에 직접 개입하지 않는다. 단지 <em>하네스를 정확한 자리에 깔아주고</em>, 결과물 (파일/팀/그래프) 을 <em>실시간 시각화</em>할 뿐. 모든 통제는 <code>.claude/</code> 안의 룰/훅/스킬이 한다.
+    </div>
+  </section>
+
+  <!-- 2. SLOTS -->
+  <section id="slots">
+    <h2>2. <code>.claude/</code> 안의 8개 슬롯</h2>
+    <p class="lead">하네스의 모든 동작은 이 8개 슬롯의 조합. 각각이 \"언제\", \"어떻게\" 발화하는지가 하네스의 정체.</p>
+
+    <div class="grid cols-2">
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><circle cx="9" cy="8" r="3"/><path d="M3 20a6 6 0 0 1 12 0"/><circle cx="17" cy="9" r="2.5"/><path d="M15 20a5 5 0 0 1 6-4"/></svg></div>
+        <h5>agents/ <span class="pill">18개</span></h5>
+        <p class="desc">서브에이전트 정의 — flutter-ui, nestjs-backend, prisma-data, code-reviewer 등. 메인 세션이 \"Agent Routing\" 표 매칭 시 파견.</p>
+        <span class="key">자동 발화: 메인 분석 → 매칭 → Agent() 호출</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><path d="M12 3v4M12 17v4M3 12h4M17 12h4"/></svg></div>
+        <h5>skills/ <span class="pill">25개</span></h5>
+        <p class="desc">freezed-models, dio-retrofit, mobile-design 등 도메인 패턴. <code>skill-injector.sh</code> 가 파일 경로 매칭 시 SKILL.md 절대경로를 컨텍스트로 주입.</p>
+        <span class="key">자동 발화: PreToolUse Write/Edit + 파일 패턴</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><path d="m8 7-5 5 5 5M16 7l5 5-5 5M14 4 10 20"/></svg></div>
+        <h5>commands/ <span class="pill">25개</span></h5>
+        <p class="desc"><code>/verify</code>, <code>/review</code>, <code>/checkpoint</code>, <code>/implement</code>, <code>/full-cycle</code> 등 슬래시 커맨드. 사용자 입력 또는 워크플로 자동 트리거.</p>
+        <span class="key">발화: 사용자 입력 OR 파이프라인 자동</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg></div>
+        <h5>rules/common/ <span class="pill">8개</span></h5>
+        <p class="desc">architecture, coding-style, git-workflow, security, testing, orchestration, mcp, automation. CLAUDE.md 의 <code>@-syntax</code> 로 매 세션 자동 컨텍스트 주입.</p>
+        <span class="key">자동 발화: 매 세션 시작 (mandatory)</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3M13 15h4"/></svg></div>
+        <h5>scripts/ <span class="pill">10개</span></h5>
+        <p class="desc">훅 셸 스크립트 — gateguard, skill-injector, mcp-health, learn, evaluate-session, auto-profile 등. settings.json 의 hooks 가 호출.</p>
+        <span class="key">발화: SessionStart / PreToolUse / Stop 등</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><path d="M3 7 12 3l9 4v10l-9 4-9-4z"/></svg></div>
+        <h5>contexts/</h5>
+        <p class="desc"><code>tech-stack.md</code> 등 도메인 컨텍스트. CLAUDE.md 또는 에이전트가 필요 시 Read 로 가져감.</p>
+        <span class="key">발화: 에이전트가 명시적 Read</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M2 12h20M12 2a15 15 0 0 1 0 20"/></svg></div>
+        <h5>mcp.json <span class="pill">15개</span></h5>
+        <p class="desc">MCP 서버 설정 — context7, code-review-graph, dart, serena, supabase, playwright 등. 세션 시작 시 자동 spawn.</p>
+        <span class="key">발화: 세션 시작 시 자동 + 도구 호출 시</span>
+      </div>
+      <div class="card">
+        <div class="ico"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.5-2-3.4-2.3.9a7 7 0 0 0-2-1.2l-.4-2.5h-4l-.4 2.5a7 7 0 0 0-2 1.2l-2.3-.9-2 3.4 2 1.5A7 7 0 0 0 5 12c0 .4 0 .8.1 1.2l-2 1.5 2 3.4 2.3-.9a7 7 0 0 0 2 1.2l.4 2.5h4l.4-2.5a7 7 0 0 0 2-1.2l2.3.9 2-3.4-2-1.5c.1-.4.1-.8.1-1.2z"/></svg></div>
+        <h5>settings.json</h5>
+        <p class="desc">model · effortLevel · permissions (allow / deny) · hooks 매핑. 세션 시작 시 로드. Hook profile 이 브랜치별 자동 전환.</p>
+        <span class="key">발화: 세션 시작 + auto-profile.sh 갱신</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. HOOKS -->
+  <section id="hooks">
+    <h2>3. Hook 라이프사이클</h2>
+    <p class="lead">Claude Code 의 5개 라이프사이클 이벤트마다 settings.json 의 hooks 가 fire. <strong>PreToolUse 가 핵심</strong> — stdout 은 컨텍스트로 주입되고, exit 2 는 도구를 차단하면서 stderr 를 Claude 에게 피드백.</p>
+
+    <div class="diagram">
+      <div class="caption">Tool Call Hook Sequence</div>
+      <svg viewBox="0 0 1000 360" xmlns="http://www.w3.org/2000/svg">
+        <!-- swimlanes -->
+        <line x1="180" y1="40" x2="180" y2="340" stroke="#262e3a" stroke-dasharray="3,3"/>
+        <line x1="500" y1="40" x2="500" y2="340" stroke="#262e3a" stroke-dasharray="3,3"/>
+        <line x1="820" y1="40" x2="820" y2="340" stroke="#262e3a" stroke-dasharray="3,3"/>
+
+        <text x="90" y="30" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#6b7280" letter-spacing="0.5">CLAUDE</text>
+        <text x="340" y="30" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#ff6b35" letter-spacing="0.5">CLAUDE CODE 런타임</text>
+        <text x="660" y="30" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#6b7280" letter-spacing="0.5">HOOK 스크립트</text>
+        <text x="910" y="30" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#6b7280" letter-spacing="0.5">결과</text>
+
+        <!-- Step 1 -->
+        <rect x="20" y="50" width="140" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="90" y="73" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">Edit() 호출 시도</text>
+        <path d="M 160 67 L 200 67" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+
+        <!-- Step 2 -->
+        <rect x="200" y="50" width="280" height="34" rx="5" fill="#11151c" stroke="#262e3a"/>
+        <text x="340" y="73" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">PreToolUse 매칭 — Write|Edit hooks</text>
+        <path d="M 480 67 L 520 67" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+
+        <!-- Step 3 -->
+        <rect x="520" y="50" width="280" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="660" y="73" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">차단 인라인 (코드젠/마이그)</text>
+
+        <!-- Step 4 -->
+        <rect x="520" y="100" width="280" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="660" y="123" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">skill-injector.sh</text>
+
+        <!-- Step 5 -->
+        <rect x="520" y="150" width="280" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="660" y="173" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">gateguard.sh</text>
+
+        <!-- arrows down -->
+        <path d="M 660 84 L 660 100" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+        <path d="M 660 134 L 660 150" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+
+        <!-- exit results -->
+        <path d="M 800 67 L 840 67" stroke="#f87171" stroke-width="1.5" marker-end="url(#a2-r)"/>
+        <text x="900" y="71" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#f87171">exit 1</text>
+        <text x="900" y="84" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">차단</text>
+
+        <path d="M 800 117 L 840 117" stroke="#4ade80" stroke-width="1.5" marker-end="url(#a2-g)"/>
+        <text x="900" y="121" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#4ade80">stdout</text>
+        <text x="900" y="134" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">→ 컨텍스트</text>
+
+        <path d="M 800 167 L 840 167" stroke="#4ade80" stroke-width="1.5" marker-end="url(#a2-g)"/>
+        <text x="900" y="171" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#4ade80">stdout</text>
+        <text x="900" y="184" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">→ 컨텍스트</text>
+
+        <!-- final arrow back to claude -->
+        <path d="M 660 184 L 660 230 L 90 230 L 90 250" stroke="#ff6b35" stroke-width="2" fill="none" marker-end="url(#a2-o)"/>
+        <text x="380" y="225" font-family="JetBrains Mono" font-size="11" fill="#ff6b35">매칭 SKILL.md 들 + 조사 체크리스트 주입</text>
+
+        <!-- Final block -->
+        <rect x="20" y="260" width="140" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="90" y="283" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">SKILL.md 자동 Read</text>
+        <path d="M 160 277 L 200 277" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+
+        <rect x="200" y="260" width="280" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="340" y="283" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">실제 Edit 수행 (룰 적용된)</text>
+        <path d="M 480 277 L 520 277" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#a2)"/>
+
+        <rect x="520" y="260" width="280" height="34" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="660" y="283" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">PostToolUse — dart format 등</text>
+
+        <defs>
+          <marker id="a2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#9aa3b2"/>
+          </marker>
+          <marker id="a2-r" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#f87171"/>
+          </marker>
+          <marker id="a2-g" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#4ade80"/>
+          </marker>
+          <marker id="a2-o" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#ff6b35"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+
+    <h3>5개 라이프사이클 이벤트</h3>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>이벤트</th><th>트리거 시점</th><th>stdout</th><th>exit 의미</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>SessionStart</strong></td><td>Claude Code 세션 시작</td><td>컨텍스트 주입</td><td>무시</td></tr>
+          <tr><td><strong>PreToolUse</strong></td><td>모든 도구 호출 직전</td><td><span class="pill accent">컨텍스트 주입</span></td><td><span class="pill danger">exit 2 = 차단 + 피드백</span></td></tr>
+          <tr><td><strong>PostToolUse</strong></td><td>도구 호출 직후</td><td>주입</td><td>무시</td></tr>
+          <tr><td><strong>Stop</strong></td><td>Claude 응답 종료</td><td>무시</td><td>무시 (사이드이펙트)</td></tr>
+          <tr><td><strong>PreCompact</strong></td><td>컨텍스트 압축 직전</td><td>주입</td><td>무시 (백업용)</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Hook profile — 브랜치별 자동 전환</h3>
+    <div class="grid cols-3">
+      <div class="card">
+        <h5><span class="pill danger">strict</span></h5>
+        <p class="desc"><code>prd</code>, <code>stg</code>, <code>hotfix/*</code> 브랜치. 모든 차단 활성, 검증 풀 체인 강제.</p>
+      </div>
+      <div class="card">
+        <h5><span class="pill warning">standard</span> <span class="pill">기본</span></h5>
+        <p class="desc"><code>dev</code>, <code>feat/*</code>, <code>fix/*</code>. 일반 개발 — 균형.</p>
+      </div>
+      <div class="card">
+        <h5><span class="pill success">minimal</span></h5>
+        <p class="desc"><code>explore/*</code>, <code>poc/*</code>. 프로토타이핑 — 차단 완화.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 4. SKILLS -->
+  <section id="skills">
+    <h2>4. 스킬 자동 주입 — 가장 중요한 메커니즘</h2>
+    <p class="lead">Claude 가 파일을 편집하려는 순간 <code>skill-injector.sh</code> 가 파일 경로를 보고 매칭되는 SKILL.md 절대경로 목록을 stdout 으로 출력. Claude Code 의 <code>additionalContext</code> 메커니즘이 이를 컨텍스트에 강제 삽입 — 무시 불가.</p>
+
+    <div class="diagram">
+      <div class="caption">Skill Injection Flow · 예시: client/presentation/login.dart</div>
+      <svg viewBox="0 0 1000 320" xmlns="http://www.w3.org/2000/svg">
+        <!-- Input -->
+        <rect x="40" y="30" width="280" height="60" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <text x="55" y="52" font-family="JetBrains Mono" font-size="11" fill="#6b7280">파일 경로</text>
+        <text x="55" y="78" font-family="JetBrains Mono" font-size="13" fill="#e6e9ef">client/presentation/login.dart</text>
+
+        <path d="M 320 60 L 380 60" stroke="#9aa3b2" stroke-width="2" marker-end="url(#sa)"/>
+
+        <!-- Matcher -->
+        <rect x="380" y="20" width="240" height="80" rx="6" fill="#161b24" stroke="#ff6b35"/>
+        <text x="500" y="44" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#ff6b35">SKILL-INJECTOR.SH</text>
+        <text x="500" y="64" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">정규식 매칭</text>
+        <text x="500" y="82" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#9aa3b2">"client/presentation/" → 4개 hit</text>
+
+        <path d="M 620 60 L 680 60" stroke="#9aa3b2" stroke-width="2" marker-end="url(#sa)"/>
+
+        <!-- Output -->
+        <rect x="680" y="0" width="280" height="120" rx="6" fill="#161b24" stroke="#4ade80"/>
+        <text x="820" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#4ade80">STDOUT (컨텍스트로 주입)</text>
+        <text x="700" y="48" font-family="JetBrains Mono" font-size="11" fill="#ff6b35">⚠️ MANDATORY SKILL</text>
+        <text x="700" y="68" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">- skills/riverpod-patterns/SKILL.md</text>
+        <text x="700" y="82" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">- skills/go-router/SKILL.md</text>
+        <text x="700" y="96" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">- skills/mobile-design/SKILL.md</text>
+        <text x="700" y="110" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">- skills/mobile-touch/SKILL.md</text>
+
+        <!-- claude reads -->
+        <path d="M 820 130 L 820 180" stroke="#ff6b35" stroke-width="2" marker-end="url(#so)"/>
+
+        <rect x="40" y="190" width="920" height="100" rx="6" fill="#11151c" stroke="#262e3a"/>
+        <text x="60" y="215" font-family="JetBrains Mono" font-size="11" fill="#6b7280">CLAUDE 자동 동작</text>
+        <text x="60" y="240" font-family="Geist" font-size="13" fill="#e6e9ef">1. Read 도구로 4개 SKILL.md 모두 읽음</text>
+        <text x="60" y="258" font-family="Geist" font-size="13" fill="#e6e9ef">2. riverpod 패턴 + go_router 라우팅 + MFRI 평가 + Disney 12 원칙 모두 적용해서 코드 작성</text>
+        <text x="60" y="276" font-family="Geist" font-size="13" fill="#e6e9ef">3. 룰 위반 시 편집 중단 → 사용자 보고</text>
+
+        <defs>
+          <marker id="sa" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#9aa3b2"/>
+          </marker>
+          <marker id="so" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#ff6b35"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+
+    <h3>매칭 패턴 전체 (skill-injector.sh)</h3>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>파일 패턴</th><th>주입되는 SKILL</th></tr></thead>
+        <tbody>
+          <tr><td><code>client/domain/entity/</code> · <code>client/data/**/dto/</code></td><td><span class="pill">freezed-models</span></td></tr>
+          <tr><td><code>client/presentation/</code></td><td><span class="pill">riverpod-patterns</span> <span class="pill">go-router</span> <span class="pill">mobile-design</span> <span class="pill">mobile-touch</span></td></tr>
+          <tr><td><code>client/data/remote/</code> · <code>client/core/network/</code></td><td><span class="pill">dio-retrofit</span></td></tr>
+          <tr><td><code>client/core/utils/result.dart</code></td><td><span class="pill">error-handling</span></td></tr>
+          <tr><td><code>client/core/logger/</code></td><td><span class="pill">logging</span></td></tr>
+          <tr><td><code>server/src/**/*.module.ts</code></td><td><span class="pill">nestjs-module</span></td></tr>
+          <tr><td><code>server/src/auth/</code></td><td><span class="pill">nestjs-auth</span></td></tr>
+          <tr><td><code>server/src/**/dto/</code></td><td><span class="pill">api-contract</span></td></tr>
+          <tr><td><code>prisma/schema.prisma</code></td><td><span class="pill">prisma-patterns</span> <span class="pill">postgres-patterns</span></td></tr>
+          <tr><td><code>cms/app/</code></td><td><span class="pill">nextjs-patterns</span></td></tr>
+          <tr><td><code>test/</code> · <code>**_test.dart</code> · <code>**.spec.ts</code></td><td><span class="pill">tdd-workflow</span></td></tr>
+          <tr><td><code>integration_test/</code> · <code>**_e2e_test.dart</code></td><td><span class="pill">flutter-driver-e2e</span></td></tr>
+          <tr><td><code>Dockerfile</code> · <code>docker-compose.*</code></td><td><span class="pill">deployment-patterns</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p style="margin-top: 14px; font-size: 13px;">여러 패턴이 동시에 매칭되면 모두 누적. 예: <code>client/presentation/auth/dto/login_dto.dart</code> → <span class="pill">freezed-models</span> + <span class="pill">riverpod-patterns</span> + <span class="pill">go-router</span> + <span class="pill">mobile-design</span> + <span class="pill">mobile-touch</span> 다섯 개 동시 주입.</p>
+  </section>
+
+  <!-- 5. PIPELINE -->
+  <section id="pipeline">
+    <h2>5. 자동 오케스트레이션 파이프라인</h2>
+    <p class="lead">사용자 \"~~ 만들어줘\" 한 줄 → CLAUDE.md 매니저 모드가 분석/위임/검증/리뷰/문서/체크포인트까지 자동으로 진행. 사용자에게 묻는 건 마지막 \"커밋할까요?\" 뿐.</p>
+
+    <div class="diagram">
+      <div class="caption">10-step Auto Pipeline (예: \"회원가입 만들어줘\")</div>
+      <div class="timeline" style="margin-top: 8px;">
+        <div class="step">
+          <span class="num">01</span> <h6>분석</h6>
+          <p>영향 스택 (Prisma+NestJS+Flutter) + 필요 에이전트 + 의존성 + 적용 스킬 자동 결정.</p>
+        </div>
+        <div class="step">
+          <span class="num">02</span> <h6>TDD 테스트 먼저</h6>
+          <p>test-writer 자동 파견 → 실패하는 테스트 작성 (Red).</p>
+        </div>
+        <div class="step">
+          <span class="num">03</span> <h6>구현 (병렬/순차)</h6>
+          <p>의존성 순서: prisma-data → nestjs-backend → flutter-* (병렬, worktree 격리). 테스트 통과 (Green).</p>
+        </div>
+        <div class="step">
+          <span class="num">04</span> <h6>리팩토링</h6>
+          <p>refactor-cleaner 자동 — 중복/데드코드 정리, 테스트 유지.</p>
+        </div>
+        <div class="step">
+          <span class="num">05</span> <h6>검증 (/verify)</h6>
+          <p>flutter analyze + test + npm test + lint + DTO 동기화 + 품질 평가.</p>
+        </div>
+        <div class="step">
+          <span class="num">06</span> <h6>실패 시 자동 수정</h6>
+          <p>loop-operator 자동 — 빌드/테스트 실패 → 수정 → 재검증 (최대 5회).</p>
+        </div>
+        <div class="step">
+          <span class="num">07</span> <h6>리뷰 3종 동시</h6>
+          <p>code-reviewer + security-auditor + spec-verifier 병렬 파견.</p>
+        </div>
+        <div class="step">
+          <span class="num">08</span> <h6>문서 동기화 (/update-docs)</h6>
+          <p>API 문서 / dartdoc / CHANGELOG 자동 갱신.</p>
+        </div>
+        <div class="step">
+          <span class="num">09</span> <h6>체크포인트 (/checkpoint)</h6>
+          <p>피처 완료 시점 자동 백업.</p>
+        </div>
+        <div class="step">
+          <span class="num">10</span> <h6>"커밋할까요?" 묻기</h6>
+          <p>이것만 사용자에게 묻는다. 답하면 한국어 메시지 + Conventional Commits + Co-Author 차단 검증 통과 후 커밋.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 6. TEAMS -->
+  <section id="teams">
+    <h2>6. 팀 시스템 — Run vs Composition</h2>
+    <p class="lead">v0.4.0 의 가장 큰 구조 변화. 기존 단일 \"Team\" 개념을 두 정체성으로 분리. <strong>Run</strong> = 워크스페이스 안에서 진행 중인 인스턴스, <strong>Composition</strong> = 글로벌 재사용 템플릿.</p>
+
+    <div class="two-col">
+      <div class="card">
+        <div class="ico" style="color: var(--info);"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M2 12h20"/></svg></div>
+        <h5>Run <span class="pill info">워크스페이스 스코프</span></h5>
+        <p class="desc">이 워크스페이스에서 실제로 돌아가는 N명 agent + worktree + 진행도. <code>&lt;wsPath&gt;/.claude/teams/&lt;id&gt;/config.json</code> 에 저장.</p>
+        <h4>필드</h4>
+        <p class="desc"><code>id</code> · <code>name</code> · <code>goal</code> · <code>members[]</code> · <code>worktreeStrategy</code> · <code>mergeStrategy</code> · <code>workspaceId</code> · <code>createdAt</code> · <code>status</code> · <code>progress</code></p>
+        <h4>UI 위치</h4>
+        <p class="desc">Workspace 패널 좌측 \"Teams\" 섹션 → 카드 클릭 → 풀스크린 RunLiveView</p>
+      </div>
+      <div class="card">
+        <div class="ico" style="color: var(--violet);"><svg width="14" height="14" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2"><path d="m12 3 9 5-9 5-9-5 9-5z"/><path d="M3 13 12 18l9-5"/></svg></div>
+        <h5>Composition <span class="pill" style="color: var(--violet); border-color: rgba(167,139,250,0.32); background: rgba(167,139,250,0.12);">글로벌 템플릿</span></h5>
+        <p class="desc">\"이런 멤버 조합으로 일하는 패턴\" 재사용 단위. <code>~/.claude/team-compositions/&lt;name&gt;.json</code> 에 저장.</p>
+        <h4>필드</h4>
+        <p class="desc"><code>name</code> · <code>members[]</code> · <code>defaultWorktree</code> · <code>defaultMerge</code> · <code>usedCount</code></p>
+        <h4>UI 위치</h4>
+        <p class="desc">Library 사이드바 → Compositions 탭 카드 그리드 → \"Apply to workspace\" 클릭 → Wizard 가 멤버 prefilled 상태로 열림</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>왜 분리했나?</strong> Run 은 git worktree 에 묶여 한 워크스페이스 안에서만 의미 있고, Composition 은 \"다음 프로젝트에서 또 쓰고 싶은 멤버 조합\" 이라 글로벌이어야 한다. 이전엔 둘이 한 개념이라 \"이 팀이 어느 프로젝트?\" 매번 헷갈림.
+    </div>
+
+    <h3>워크스페이스 격리 효과</h3>
+    <div class="diagram">
+      <div class="caption">workspace switch → AgentTeamWatcher.setWorkspace 자동 트리거</div>
+      <svg viewBox="0 0 1000 280" xmlns="http://www.w3.org/2000/svg">
+        <!-- Workspace A -->
+        <rect x="40" y="20" width="280" height="240" rx="8" fill="#161b24" stroke="#60a5fa40"/>
+        <text x="180" y="44" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#60a5fa">WORKSPACE ws-A</text>
+        <text x="180" y="62" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">~/projects/ws-A/.claude/teams/</text>
+        <rect x="60" y="80" width="240" height="44" rx="5" fill="#1d242f" stroke="#262e3a"/>
+        <text x="75" y="98" font-family="Geist" font-size="12" fill="#e6e9ef">team-1 (회원가입 팀)</text>
+        <text x="75" y="115" font-family="JetBrains Mono" font-size="10" fill="#6b7280">5 members · feature/auth-signup</text>
+        <rect x="60" y="134" width="240" height="44" rx="5" fill="#1d242f" stroke="#262e3a"/>
+        <text x="75" y="152" font-family="Geist" font-size="12" fill="#e6e9ef">team-2 (리팩토링 팀)</text>
+        <text x="75" y="169" font-family="JetBrains Mono" font-size="10" fill="#6b7280">4 members · refactor/payment</text>
+        <text x="180" y="220" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#9aa3b2">Teams 섹션: 2개 표시</text>
+
+        <!-- Switcher -->
+        <text x="500" y="135" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#ff6b35">Workspace 전환</text>
+        <path d="M 320 140 L 680 140" stroke="#ff6b35" stroke-width="2" marker-end="url(#wa)"/>
+        <text x="500" y="155" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">setWorkspace(\"ws-B\")</text>
+        <text x="500" y="170" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">chokidar → 새 디렉터리로 재포인트</text>
+
+        <!-- Workspace B -->
+        <rect x="680" y="20" width="280" height="240" rx="8" fill="#161b24" stroke="#a78bfa40"/>
+        <text x="820" y="44" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#a78bfa">WORKSPACE ws-B</text>
+        <text x="820" y="62" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">~/projects/ws-B/.claude/teams/</text>
+        <rect x="700" y="80" width="240" height="44" rx="5" fill="#1d242f" stroke="#262e3a"/>
+        <text x="715" y="98" font-family="Geist" font-size="12" fill="#e6e9ef">team-3 (디자인 팀)</text>
+        <text x="715" y="115" font-family="JetBrains Mono" font-size="10" fill="#6b7280">3 members · design/onboarding</text>
+        <text x="820" y="220" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#9aa3b2">Teams 섹션: 1개 표시</text>
+        <text x="820" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">team-1, team-2 는 안 보이지만 디스크에 그대로</text>
+
+        <defs>
+          <marker id="wa" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#ff6b35"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  </section>
+
+  <!-- 7. RUN LIFECYCLE -->
+  <section id="run-lifecycle">
+    <h2>7. Run 라이프사이클</h2>
+    <p class="lead">사용자가 Wizard 4-step 으로 입력 → AgentTeamWatcher 가 config.json 작성 → chokidar 가 변경 감지 → store 갱신 → UI 즉시 반영. 풀 라운드트립.</p>
+
+    <div class="diagram">
+      <div class="caption">Wizard → Real Team Creation Flow</div>
+      <svg viewBox="0 0 1000 360" xmlns="http://www.w3.org/2000/svg">
+        <!-- Step boxes -->
+        <rect x="20" y="30" width="180" height="60" rx="6" fill="#161b24" stroke="#ff6b35"/>
+        <text x="110" y="55" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#ff6b35">USER ACTION</text>
+        <text x="110" y="76" text-anchor="middle" font-family="Geist" font-size="13" fill="#e6e9ef">⌘N or +</text>
+
+        <path d="M 200 60 L 230 60" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#ra)"/>
+
+        <rect x="230" y="30" width="180" height="60" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <text x="320" y="50" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">UI</text>
+        <text x="320" y="68" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">Wizard 4-step</text>
+        <text x="320" y="83" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">name → members → worktree → confirm</text>
+
+        <path d="M 410 60 L 440 60" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#ra)"/>
+
+        <rect x="440" y="30" width="180" height="60" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <text x="530" y="50" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">REACT STORE</text>
+        <text x="530" y="68" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">useAgentTeamStore.create()</text>
+
+        <path d="M 620 60 L 650 60" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#ra)"/>
+
+        <rect x="650" y="30" width="180" height="60" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <text x="740" y="50" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">IPC</text>
+        <text x="740" y="68" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">teams:create</text>
+
+        <!-- Down arrow -->
+        <path d="M 740 90 L 740 130" stroke="#ff6b35" stroke-width="2" marker-end="url(#ra-o)"/>
+
+        <rect x="650" y="130" width="180" height="60" rx="6" fill="#161b24" stroke="#ff6b35"/>
+        <text x="740" y="150" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#ff6b35">ELECTRON MAIN</text>
+        <text x="740" y="168" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">AgentTeamWatcher.create</text>
+        <text x="740" y="184" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">teamId 생성 + config.json 작성</text>
+
+        <!-- Down to disk -->
+        <path d="M 740 190 L 740 220" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#ra)"/>
+
+        <rect x="650" y="220" width="180" height="50" rx="6" fill="#11151c" stroke="#262e3a"/>
+        <text x="740" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">DISK</text>
+        <text x="740" y="256" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#e6e9ef">&lt;ws&gt;/.claude/teams/team-xxx/config.json</text>
+
+        <!-- chokidar feedback -->
+        <path d="M 650 245 Q 350 245 320 90" stroke="#4ade80" stroke-width="2" fill="none" marker-end="url(#ra-g)"/>
+        <text x="450" y="270" font-family="JetBrains Mono" font-size="11" fill="#4ade80">chokidar 변경 감지 → emit 'change'</text>
+
+        <!-- store update -->
+        <rect x="20" y="220" width="280" height="50" rx="6" fill="#161b24" stroke="#4ade80"/>
+        <text x="160" y="240" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#4ade80">UI UPDATE</text>
+        <text x="160" y="256" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">TeamsRunSection 새 카드 표시</text>
+
+        <path d="M 320 245 L 300 245" stroke="#4ade80" stroke-width="1.5" marker-end="url(#ra-g)"/>
+
+        <!-- Toast -->
+        <rect x="20" y="290" width="280" height="50" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <text x="160" y="310" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">TOAST</text>
+        <text x="160" y="326" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">"회원가입 피처 팀 (5 members)"</text>
+
+        <defs>
+          <marker id="ra" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#9aa3b2"/>
+          </marker>
+          <marker id="ra-o" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#ff6b35"/>
+          </marker>
+          <marker id="ra-g" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#4ade80"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+
+    <h3>Wizard 4 Step</h3>
+    <div class="grid cols-4">
+      <div class="card">
+        <h5>Step 1 · 이름</h5>
+        <p class="desc">팀 이름 + 자연어 한 줄 목표.</p>
+        <span class="key">예: "회원가입 피처 팀"</span>
+      </div>
+      <div class="card">
+        <h5>Step 2 · 멤버</h5>
+        <p class="desc">18개 agent 풀에서 chip multi-select.</p>
+        <span class="key">예: 5명 선택</span>
+      </div>
+      <div class="card">
+        <h5>Step 3 · 전략</h5>
+        <p class="desc">worktree (isolated/shared) + merge (squash/sequential).</p>
+        <span class="key">기본: isolated + squash</span>
+      </div>
+      <div class="card">
+        <h5>Step 4 · 확인</h5>
+        <p class="desc">요약 표시 → Start.</p>
+        <span class="key">→ Run 즉시 등장</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 8. RUN LIVE VIEW -->
+  <section id="run-liveview">
+    <h2>8. Run 라이브뷰 — 풀스크린 작업 모니터</h2>
+    <p class="lead">Workspace 패널의 Run 카드 클릭 시 메인 영역 전체가 풀스크린으로 전환. 4영역 레이아웃 — 멤버 사이드바, tmux split grid, Activity feed, 컨트롤 바. ESC 로 복귀.</p>
+
+    <div class="diagram">
+      <div class="caption">RunLiveView Layout</div>
+      <svg viewBox="0 0 1000 480" xmlns="http://www.w3.org/2000/svg">
+        <!-- back bar -->
+        <rect x="20" y="20" width="960" height="36" rx="6" fill="#161b24" stroke="#262e3a"/>
+        <rect x="30" y="28" width="80" height="20" rx="3" fill="#1d242f" stroke="#313a48"/>
+        <text x="70" y="42" text-anchor="middle" font-family="Geist" font-size="11" fill="#e6e9ef">← Back</text>
+        <text x="42" y="50" font-family="JetBrains Mono" font-size="9" fill="#6b7280">esc</text>
+        <text x="140" y="42" font-family="Geist" font-size="13" font-weight="600" fill="#e6e9ef">회원가입 피처 팀</text>
+        <circle cx="252" cy="38" r="4" fill="#4ade80"/>
+        <text x="900" y="42" font-family="Geist" font-size="11" fill="#9aa3b2">Pause All  ·  Diff  ·  Merge  ·  ✕</text>
+
+        <!-- Members sidebar -->
+        <rect x="20" y="66" width="180" height="350" rx="6" fill="#11151c" stroke="#262e3a"/>
+        <text x="36" y="86" font-family="JetBrains Mono" font-size="10" fill="#6b7280">MEMBERS</text>
+
+        <!-- members 5 cards -->
+        <g transform="translate(30, 96)">
+          <rect width="160" height="50" rx="4" fill="#161b24" stroke="#262e3a"/>
+          <rect x="8" y="8" width="20" height="20" rx="3" fill="#22d3ee20" stroke="#22d3ee60"/>
+          <text x="18" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#22d3ee" font-weight="700">A</text>
+          <text x="36" y="20" font-family="Geist" font-size="11" fill="#e6e9ef">architect</text>
+          <circle cx="148" cy="14" r="3" fill="#9aa3b2"/>
+          <text x="36" y="34" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">ADR 작성</text>
+          <text x="36" y="44" font-family="JetBrains Mono" font-size="9" fill="#6b7280">22.4k tk · 3 files</text>
+        </g>
+        <g transform="translate(30, 156)">
+          <rect width="160" height="50" rx="4" fill="#161b24" stroke="#60a5fa40"/>
+          <rect x="8" y="8" width="20" height="20" rx="3" fill="#60a5fa20" stroke="#60a5fa60"/>
+          <text x="18" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#60a5fa" font-weight="700">F</text>
+          <text x="36" y="20" font-family="Geist" font-size="11" fill="#e6e9ef">flutter-ui</text>
+          <circle cx="148" cy="14" r="3" fill="#4ade80" class="pulse"/>
+          <text x="36" y="34" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">SignupForm UI</text>
+          <text x="36" y="44" font-family="JetBrains Mono" font-size="9" fill="#6b7280">41.9k tk · 6 files</text>
+        </g>
+        <g transform="translate(30, 216)">
+          <rect width="160" height="50" rx="4" fill="#161b24" stroke="#a78bfa40"/>
+          <rect x="8" y="8" width="20" height="20" rx="3" fill="#a78bfa20" stroke="#a78bfa60"/>
+          <text x="18" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#a78bfa" font-weight="700">N</text>
+          <text x="36" y="20" font-family="Geist" font-size="11" fill="#e6e9ef">nestjs-auth</text>
+          <circle cx="148" cy="14" r="3" fill="#4ade80" class="pulse"/>
+          <text x="36" y="34" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">JWT issue</text>
+          <text x="36" y="44" font-family="JetBrains Mono" font-size="9" fill="#6b7280">38.1k tk · 4 files</text>
+        </g>
+        <g transform="translate(30, 276)">
+          <rect width="160" height="50" rx="4" fill="#161b24" stroke="#f8717140"/>
+          <rect x="8" y="8" width="20" height="20" rx="3" fill="#f5a52420" stroke="#f5a52460"/>
+          <text x="18" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#f5a524" font-weight="700">P</text>
+          <text x="36" y="20" font-family="Geist" font-size="11" fill="#e6e9ef">prisma-schema</text>
+          <circle cx="148" cy="14" r="3" fill="#f87171" class="pulse"/>
+          <text x="36" y="34" font-family="JetBrains Mono" font-size="9" fill="#f87171">⚠ blocked</text>
+          <text x="36" y="44" font-family="JetBrains Mono" font-size="9" fill="#6b7280">12.8k tk · 2 files</text>
+        </g>
+        <g transform="translate(30, 336)">
+          <rect width="160" height="50" rx="4" fill="#161b24" stroke="#262e3a"/>
+          <rect x="8" y="8" width="20" height="20" rx="3" fill="#34d39920" stroke="#34d39960"/>
+          <text x="18" y="22" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#34d399" font-weight="700">E</text>
+          <text x="36" y="20" font-family="Geist" font-size="11" fill="#e6e9ef">test-e2e</text>
+          <circle cx="148" cy="14" r="3" fill="#6b7280"/>
+          <text x="36" y="34" font-family="JetBrains Mono" font-size="9" fill="#6b7280">queued</text>
+          <text x="36" y="44" font-family="JetBrains Mono" font-size="9" fill="#6b7280">0 tk · 0 files</text>
+        </g>
+
+        <!-- tmux split grid 2x2 -->
+        <g transform="translate(210, 66)">
+          <text x="0" y="20" font-family="JetBrains Mono" font-size="10" fill="#6b7280">TMUX SPLIT GRID</text>
+          <rect x="0" y="30" width="280" height="170" rx="4" fill="#0b0e13" stroke="#262e3a"/>
+          <text x="10" y="46" font-family="JetBrains Mono" font-size="10" fill="#22d3ee">[ARCH] done</text>
+          <text x="10" y="62" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ # ADR-0007 written</text>
+          <text x="10" y="78" font-family="JetBrains Mono" font-size="10" fill="#4ade80">✓ 3 files</text>
+          <text x="10" y="94" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ _</text>
+
+          <rect x="290" y="30" width="280" height="170" rx="4" fill="#0b0e13" stroke="#60a5fa60"/>
+          <text x="300" y="46" font-family="JetBrains Mono" font-size="10" fill="#60a5fa">[UI] active</text>
+          <text x="300" y="62" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ flutter analyze lib/auth</text>
+          <text x="300" y="78" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">Analyzing auth...</text>
+          <text x="300" y="94" font-family="JetBrains Mono" font-size="10" fill="#4ade80">No issues found</text>
+          <text x="300" y="110" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">$ flutter test</text>
+          <text x="300" y="126" font-family="JetBrains Mono" font-size="10" fill="#4ade80">  ✓ ✓ ✓</text>
+          <text x="300" y="142" font-family="JetBrains Mono" font-size="10" fill="#ff6b35">› hot reload (124ms)_</text>
+
+          <rect x="0" y="210" width="280" height="170" rx="4" fill="#0b0e13" stroke="#a78bfa60"/>
+          <text x="10" y="226" font-family="JetBrains Mono" font-size="10" fill="#a78bfa">[API] active</text>
+          <text x="10" y="242" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ pnpm test:watch auth</text>
+          <text x="10" y="258" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">PASS auth.service.spec.ts</text>
+          <text x="10" y="274" font-family="JetBrains Mono" font-size="10" fill="#4ade80">  ✓ hashes password</text>
+          <text x="10" y="290" font-family="JetBrains Mono" font-size="10" fill="#4ade80">  ✓ issues JWT</text>
+
+          <rect x="290" y="210" width="280" height="170" rx="4" fill="#0b0e13" stroke="#f8717160"/>
+          <text x="300" y="226" font-family="JetBrains Mono" font-size="10" fill="#f87171">[DB] blocked</text>
+          <text x="300" y="242" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ prisma migrate dev</text>
+          <text x="300" y="258" font-family="JetBrains Mono" font-size="10" fill="#f5a524">⚠ Drift detected</text>
+          <text x="300" y="274" font-family="JetBrains Mono" font-size="10" fill="#f87171">Error: Unique constraint</text>
+          <text x="300" y="290" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">     conflict on email</text>
+          <text x="300" y="320" font-family="JetBrains Mono" font-size="10" fill="#6b7280">$ # waiting on architect</text>
+        </g>
+
+        <!-- Activity feed -->
+        <rect x="800" y="66" width="180" height="350" rx="6" fill="#11151c" stroke="#262e3a"/>
+        <text x="816" y="86" font-family="JetBrains Mono" font-size="10" fill="#6b7280">ACTIVITY FEED</text>
+
+        <g transform="translate(810, 96)">
+          <text x="0" y="14" font-family="JetBrains Mono" font-size="9" fill="#6b7280">00:38:21</text>
+          <text x="0" y="28" font-family="Geist" font-size="11" fill="#60a5fa">flutter-ui edit</text>
+          <text x="0" y="42" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">signup_form.dart</text>
+          <text x="0" y="55" font-family="JetBrains Mono" font-size="9" fill="#4ade80">+124 -8</text>
+
+          <line x1="0" y1="65" x2="160" y2="65" stroke="#262e3a"/>
+
+          <text x="0" y="80" font-family="JetBrains Mono" font-size="9" fill="#6b7280">00:38:04</text>
+          <text x="0" y="94" font-family="Geist" font-size="11" fill="#a78bfa">nestjs-auth commit</text>
+          <text x="0" y="108" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">feat(auth): bcrypt + jwt</text>
+          <text x="0" y="121" font-family="JetBrains Mono" font-size="9" fill="#4ade80">4 files</text>
+
+          <line x1="0" y1="131" x2="160" y2="131" stroke="#262e3a"/>
+
+          <text x="0" y="146" font-family="JetBrains Mono" font-size="9" fill="#6b7280">00:37:51</text>
+          <text x="0" y="160" font-family="Geist" font-size="11" fill="#f87171">prisma-schema blocked</text>
+          <text x="0" y="174" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">User.email unique</text>
+          <text x="0" y="187" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">충돌</text>
+
+          <line x1="0" y1="197" x2="160" y2="197" stroke="#262e3a"/>
+
+          <text x="0" y="212" font-family="JetBrains Mono" font-size="9" fill="#6b7280">00:37:29</text>
+          <text x="0" y="226" font-family="Geist" font-size="11" fill="#ff6b35">architect decision</text>
+          <text x="0" y="240" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">refresh = httpOnly</text>
+          <text x="0" y="253" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">cookie, 14d</text>
+
+          <line x1="0" y1="263" x2="160" y2="263" stroke="#262e3a"/>
+
+          <text x="0" y="278" font-family="JetBrains Mono" font-size="9" fill="#6b7280">00:37:10</text>
+          <text x="0" y="292" font-family="Geist" font-size="11" fill="#60a5fa">flutter-ui edit</text>
+          <text x="0" y="306" font-family="JetBrains Mono" font-size="9" fill="#9aa3b2">spacing.dart</text>
+          <text x="0" y="319" font-family="JetBrains Mono" font-size="9" fill="#4ade80">+12 -2</text>
+        </g>
+
+        <!-- Resource bar -->
+        <rect x="20" y="426" width="960" height="40" rx="6" fill="#0b0e13" stroke="#262e3a"/>
+        <text x="40" y="450" font-family="JetBrains Mono" font-size="11" fill="#9aa3b2">🔋  CPU 47%   ·   MEM 6.2 / 16 GB   ·   DISK +2.1 GB   ·   4 PTYs   ·   184.3k tokens   ·   38min</text>
+      </svg>
+    </div>
+
+    <p style="margin-top: 16px; font-size: 13.5px;">멤버 카드 클릭 → 그 agent 의 pane 이 grid 에서 강조/확대. 더블클릭 → 풀스크린, ESC 로 그리드 복귀. Activity feed 항목 클릭 → 해당 파일 diff 인라인 표시. 컨트롤 바: Pause All / Resume / Merge (충돌 시 충돌 해결 뷰) / Close.</p>
+  </section>
+
+  <!-- 9. ENFORCEMENT -->
+  <section id="enforcement">
+    <h2>9. 강제 메커니즘 — 4계층</h2>
+    <p class="lead">CLAUDE.md 의 매니저 모드 + 자동 라우팅 표 + Hook 의 stdout 주입 + Bash hook 의 차단/검증. 4개가 합쳐져서 사용자가 한 줄 입력 → 적절한 에이전트가 적절한 스킬로 적절한 코드를 적절한 형식으로 커밋하게 만든다.</p>
+
+    <div class="grid cols-2">
+      <div class="card">
+        <span class="pill accent">Layer 1</span>
+        <h5 style="margin-top: 8px;">매니저 모드</h5>
+        <p class="desc">CLAUDE.md ROLE 블록이 메인 세션을 강제. \"5줄 이상 코드 → 위임\", \"방법 설명 전 라우팅\" 등 stop-the-line 4종.</p>
+        <h4>적용 시점</h4>
+        <p class="desc">매 응답 시작 시 자가점검 (internal, 출력 X)</p>
+      </div>
+      <div class="card">
+        <span class="pill accent">Layer 2</span>
+        <h5 style="margin-top: 8px;">자동 라우팅</h5>
+        <p class="desc">CLAUDE.md 의 Agent Routing 표 + Skill Routing 표 + Hook Routing 표. 사용자 요청 패턴 → 자동 액션 매핑.</p>
+        <h4>적용 시점</h4>
+        <p class="desc">매 사용자 입력 분석 시</p>
+      </div>
+      <div class="card">
+        <span class="pill accent">Layer 3</span>
+        <h5 style="margin-top: 8px;">강제 주입 (stdout)</h5>
+        <p class="desc"><code>skill-injector.sh</code> + <code>gateguard.sh</code> 가 매칭된 SKILL.md / 조사 체크리스트를 컨텍스트에 직접 삽입. 무시 불가.</p>
+        <h4>적용 시점</h4>
+        <p class="desc">매 Write/Edit 도구 호출 직전</p>
+      </div>
+      <div class="card">
+        <span class="pill accent">Layer 4</span>
+        <h5 style="margin-top: 8px;">차단 / 검증</h5>
+        <p class="desc">PreToolUse Bash 인라인 — 위험 명령/시크릿/-A·-am/Conventional/한국어/Co-Author 검증. exit 1 (즉시) 또는 exit 2 (재시도 유도).</p>
+        <h4>적용 시점</h4>
+        <p class="desc">매 Bash 도구 호출 직전</p>
+      </div>
+    </div>
+
+    <h3>Bash hook 7단계 검증 (예: <code>git commit</code>)</h3>
+    <div class="diagram">
+      <div class="actrow">
+        <span class="src">위험 명령</span>
+        <span class="desc"><code>rm -rf</code>, <code>reset --hard</code>, <code>push --force</code>, <code>--no-verify</code>, <code>prisma db push</code></span>
+        <span><span class="pill danger">exit 1</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">시크릿 패턴</span>
+        <span class="desc">staged 파일에 <code>AKIA...</code>, <code>ghp_...</code>, <code>sk-...</code>, <code>api_key=</code> 등</span>
+        <span><span class="pill danger">exit 1</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">-A / -am 한 방</span>
+        <span class="desc"><code>git add -A && git commit</code> 또는 <code>git commit -am</code> 차단</span>
+        <span><span class="pill warning">exit 2</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">Conventional Commits</span>
+        <span class="desc"><code>type(scope): subject</code> 형식 미준수</span>
+        <span><span class="pill warning">exit 2</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">한국어 subject</span>
+        <span class="desc">subject 에 한글 1자 이상 없으면 차단</span>
+        <span><span class="pill warning">exit 2</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">Co-Author trailer</span>
+        <span class="desc"><code>Co-Authored-By: Claude</code>, <code>🤖 Generated with Claude</code> 등</span>
+        <span><span class="pill warning">exit 2</span></span>
+      </div>
+      <div class="actrow">
+        <span class="src">통과</span>
+        <span class="desc">위 6개 모두 통과</span>
+        <span><span class="pill success">exit 0</span></span>
+      </div>
+    </div>
+
+    <div class="callout warn">
+      <strong>exit 1 vs exit 2:</strong> exit 1 = 즉시 실패 (Claude 가 완전히 멈춤). exit 2 = 도구 차단 + stderr 를 Claude 컨텍스트로 피드백 → Claude 가 사유 보고 자동 재시도. 사용자 개입 없이 \"한국어 메시지로 다시\" 같은 자동 정정이 가능한 이유.
+    </div>
+  </section>
+
+  <!-- 10. CR GRAPH -->
+  <section id="crgraph">
+    <h2>10. Code Review Graph 통합 (v0.4.0)</h2>
+    <p class="lead">Tree-sitter 기반 코드 지식 그래프 MCP 를 하네스에 풀 통합. <code>code-reviewer</code> agent 가 리뷰 시작 전 자동으로 \"blast radius\" (영향 받는 caller/dependent/test) 쿼리 → 그 파일들만 Read → 평균 6.8× 토큰 절약.</p>
+
+    <div class="stats">
+      <div class="stat"><div class="v">6.8×</div><div class="l">평균 토큰 절약</div></div>
+      <div class="stat"><div class="v">~10s</div><div class="l">500-file 초기 빌드</div></div>
+      <div class="stat"><div class="v">&lt;2s</div><div class="l">2,900-file 증분</div></div>
+      <div class="stat"><div class="v">23+</div><div class="l">언어 지원</div></div>
+    </div>
+
+    <h3>통합 지점 4곳</h3>
+    <div class="grid cols-2">
+      <div class="card">
+        <h5>① <code>.claude/mcp.json</code></h5>
+        <p class="desc"><code>code-review-graph</code> server 등록 (uvx). 세션 시작 시 자동 spawn.</p>
+      </div>
+      <div class="card">
+        <h5>② <code>code-reviewer</code> agent 룰</h5>
+        <p class="desc">Tools 활용 섹션 — 리뷰 전 그래프 쿼리 강제 → 영향 범위 안만 Read.</p>
+      </div>
+      <div class="card">
+        <h5>③ Settings UI 카드</h5>
+        <p class="desc">Install (pipx/uv/pip) · Rebuild · Open Visualization 버튼 + 4-cell 통계.</p>
+      </div>
+      <div class="card">
+        <h5>④ 워크스페이스 자동 빌드</h5>
+        <p class="desc">NewWorkspaceDialog Advanced 토글 → 워크스페이스 생성 후 best-effort <code>code-review-graph build</code>.</p>
+      </div>
+    </div>
+
+    <h3>풀스크린 D3 시각화</h3>
+    <p style="font-size: 13.5px;"><code>code-review-graph viz</code> 백그라운드 spawn → localhost URL 을 sandbox iframe 으로 임베드. 모달 닫으면 process kill. force-directed graph + 검색 + community legend toggles + degree-scaled nodes.</p>
+  </section>
+
+  <!-- 11. LEARNING -->
+  <section id="learning">
+    <h2>11. 자기 개선 루프 — Continuous Learning v2</h2>
+    <p class="lead">세션이 끝날 때마다 Stop hook 4종이 fire. 사용자 발언/Claude 행동에서 패턴을 추출 → 신뢰도 평가 → 3회+ 확인되면 instinct → SKILL 로 자동 승격. 만료된 instinct 는 prune.</p>
+
+    <div class="diagram">
+      <div class="caption">Stop Hook Chain</div>
+      <svg viewBox="0 0 1000 220" xmlns="http://www.w3.org/2000/svg">
+        <rect x="20" y="40" width="160" height="60" rx="6" fill="#161b24" stroke="#ff6b35"/>
+        <text x="100" y="62" text-anchor="middle" font-family="JetBrains Mono" font-size="11" fill="#ff6b35">Stop hook 발화</text>
+        <text x="100" y="80" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">세션 종료</text>
+
+        <path d="M 180 70 L 220 70" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#la)"/>
+
+        <rect x="220" y="20" width="160" height="50" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="300" y="40" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">learn.sh</text>
+        <text x="300" y="56" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">교훈 추출</text>
+
+        <rect x="220" y="80" width="160" height="50" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="300" y="100" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">evaluate-session.sh</text>
+        <text x="300" y="116" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">패턴 + 신뢰도</text>
+
+        <rect x="220" y="140" width="160" height="50" rx="5" fill="#161b24" stroke="#262e3a"/>
+        <text x="300" y="160" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">cost-tracker.sh</text>
+        <text x="300" y="176" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">JSONL 메트릭스</text>
+
+        <path d="M 380 105 L 440 105" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#la)"/>
+
+        <rect x="440" y="60" width="160" height="90" rx="6" fill="#11151c" stroke="#a78bfa40"/>
+        <text x="520" y="84" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#a78bfa">INSTINCT 생성</text>
+        <text x="520" y="106" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">신뢰도 점수</text>
+        <text x="520" y="124" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#9aa3b2">(0.0 ~ 1.0)</text>
+        <text x="520" y="140" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">3회+ 누적 시 승격 후보</text>
+
+        <path d="M 600 105 L 640 105" stroke="#4ade80" stroke-width="1.5" marker-end="url(#la-g)"/>
+
+        <rect x="640" y="60" width="160" height="90" rx="6" fill="#11151c" stroke="#4ade8040"/>
+        <text x="720" y="84" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#4ade80">EVOLVE</text>
+        <text x="720" y="106" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">SKILL 승격</text>
+        <text x="720" y="124" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">.claude/skills/&lt;name&gt;/SKILL.md</text>
+
+        <path d="M 800 105 L 840 105" stroke="#9aa3b2" stroke-width="1.5" marker-end="url(#la)"/>
+
+        <rect x="840" y="60" width="140" height="90" rx="6" fill="#11151c" stroke="#262e3a"/>
+        <text x="910" y="84" text-anchor="middle" font-family="JetBrains Mono" font-size="10" fill="#6b7280">PRUNE</text>
+        <text x="910" y="106" text-anchor="middle" font-family="Geist" font-size="12" fill="#e6e9ef">만료/저신뢰</text>
+        <text x="910" y="124" text-anchor="middle" font-family="JetBrains Mono" font-size="9" fill="#6b7280">자동 정리</text>
+
+        <defs>
+          <marker id="la" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#9aa3b2"/>
+          </marker>
+          <marker id="la-g" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="#4ade80"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  </section>
+
+  <!-- 12. SUMMARY -->
+  <section id="summary">
+    <h2>12. 사용자가 묻는 6가지 (그 외엔 안 묻는다)</h2>
+    <p class="lead">매니저 모드의 핵심 약속 — 다음 6가지만 사용자에게 묻고, 그 외 모든 것 (리뷰/테스트/리팩토링/문서/체크포인트/학습) 은 자동.</p>
+
+    <div class="grid cols-3">
+      <div class="card"><h5>🚦 설계 GATE</h5><p class="desc">큰 피처의 아키텍처 리뷰</p></div>
+      <div class="card"><h5>🔀 머지 충돌</h5><p class="desc">worktree 병렬 실행 후 충돌 발생 시</p></div>
+      <div class="card"><h5>❓ 모호한 요청</h5><p class="desc">여러 해석이 가능할 때</p></div>
+      <div class="card"><h5>🔄 5회 실패</h5><p class="desc">자동 수정 루프 소진</p></div>
+      <div class="card"><h5>💀 위험 작업</h5><p class="desc">reset, force push, 대량 삭제</p></div>
+      <div class="card"><h5>📦 커밋 / 배포</h5><p class="desc">커밋 여부, subtree-push 여부</p></div>
+    </div>
+
+    <h3 style="margin-top: 40px;">한 줄 정리</h3>
+    <div class="callout">
+      <strong>Forge Studio 가 워크스페이스를 만들고 하네스를 깔아주면, <span style="color: var(--accent);">CLAUDE.md 매니저 모드 + Hook 강제 주입 + 자동 라우팅 + Bash 검증</span> 4계층이 협업해서 사용자의 한 줄 요청 → 적절한 에이전트가 적절한 스킬로 적절한 코드를 적절한 형식으로 커밋하기까지를 묻지 않고 자동 진행한다.</strong>
+    </div>
+  </section>
+
+  <footer>
+    Forge Studio v0.4.1 · 하네스 아키텍처 문서 · 2026-05-07
+    <br/>
+    <a href="https://github.com/mstagon/forge-studiov2" style="color: var(--text-3);">github.com/mstagon/forge-studiov2</a>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -552,6 +552,29 @@ ipcMain.handle('teams:remove', async (_event, teamId: string) => {
   await agentTeamWatcher.remove(teamId)
 })
 
+ipcMain.handle('teams:pause', async (_event, teamId: string) => {
+  return agentTeamWatcher.pause(teamId)
+})
+
+ipcMain.handle('teams:resume', async (_event, teamId: string) => {
+  return agentTeamWatcher.resume(teamId)
+})
+
+ipcMain.handle('teams:pauseMember', async (_event, teamId: string, agentId: string) => {
+  return agentTeamWatcher.pauseMember(teamId, agentId)
+})
+
+ipcMain.handle('teams:resumeMember', async (_event, teamId: string, agentId: string) => {
+  return agentTeamWatcher.resumeMember(teamId, agentId)
+})
+
+ipcMain.handle(
+  'teams:merge',
+  async (_event, teamId: string, opts?: { mergeStrategy?: 'squash' | 'sequential' }) => {
+    return agentTeamWatcher.merge(teamId, opts ?? {})
+  }
+)
+
 ipcMain.handle('teams:openAgentTerminal', (_event, options: { teamId: string; agentName: string; cols: number; rows: number }) => {
   const teams = agentTeamWatcher.list()
   const team = teams.find((t) => t.id === options.teamId)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -139,10 +139,33 @@ const api = {
       members: { agentId: string; task?: string }[]
       worktreeStrategy: 'isolated' | 'shared'
       mergeStrategy: 'squash' | 'sequential'
-    }): Promise<{ teamId: string; configPath: string }> =>
-      ipcRenderer.invoke('teams:create', opts),
+      autoStartClaude?: boolean
+    }): Promise<{
+      teamId: string
+      configPath: string
+      worktreesCreated: number
+      tmuxSessionsStarted: number
+    }> => ipcRenderer.invoke('teams:create', opts),
     remove: (teamId: string): Promise<void> =>
       ipcRenderer.invoke('teams:remove', teamId),
+    pause: (teamId: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('teams:pause', teamId),
+    resume: (teamId: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('teams:resume', teamId),
+    pauseMember: (teamId: string, agentId: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('teams:pauseMember', teamId, agentId),
+    resumeMember: (teamId: string, agentId: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('teams:resumeMember', teamId, agentId),
+    merge: (
+      teamId: string,
+      opts?: { mergeStrategy?: 'squash' | 'sequential' }
+    ): Promise<{
+      ok: boolean
+      mergedBranch?: string
+      commitSha?: string
+      conflicts?: { file: string; theirsBranch: string; oursBranch: string; conflictMarkers: string }[]
+      error?: string
+    }> => ipcRenderer.invoke('teams:merge', teamId, opts),
   },
 
   // ─── code-review-graph ───────────────────────────────────────────

--- a/electron/services/AgentTeamWatcher.ts
+++ b/electron/services/AgentTeamWatcher.ts
@@ -8,7 +8,8 @@ import { EventEmitter } from 'events'
 
 const execFileAsync = promisify(execFile)
 
-export type AgentStatus = 'running' | 'idle' | 'shutdown'
+export type AgentStatus = 'running' | 'idle' | 'shutdown' | 'paused' | 'active'
+export type TeamStatus = 'active' | 'paused'
 export type WorktreeStrategy = 'isolated' | 'shared'
 export type MergeStrategy = 'squash' | 'sequential'
 
@@ -25,6 +26,8 @@ export interface TeamCreateOptions {
   members: TeamCreateMember[]
   worktreeStrategy: WorktreeStrategy
   mergeStrategy: MergeStrategy
+  /** Automatically `claude` boot inside each tmux session. Defaults to true. */
+  autoStartClaude?: boolean
 }
 
 export interface TeamMember {
@@ -46,6 +49,8 @@ export interface TeamMember {
   task?: string
   worktreePath?: string
   branch?: string
+  /** Member-level lifecycle state set by pauseMember/resumeMember. */
+  state?: 'active' | 'idle'
 }
 
 export interface Team {
@@ -60,6 +65,38 @@ export interface Team {
   leadAgentId: string
   leadSessionId?: string
   members: TeamMember[]
+  status?: TeamStatus
+}
+
+export interface TeamCreateResult {
+  teamId: string
+  configPath: string
+  worktreesCreated: number
+  tmuxSessionsStarted: number
+}
+
+export interface TeamMergeConflict {
+  file: string
+  theirsBranch: string
+  oursBranch: string
+  conflictMarkers: string
+}
+
+/**
+ * Flat result envelope — chosen to match the renderer's `MergeResult` so the
+ * IPC payload doesn't need bridging on the boundary. `ok: true` populates
+ * `mergedBranch`/`commitSha`; `ok: false` populates `conflicts`/`error`.
+ */
+export interface TeamMergeResult {
+  ok: boolean
+  mergedBranch?: string
+  commitSha?: string
+  conflicts?: TeamMergeConflict[]
+  error?: string
+}
+
+export interface TeamMergeOptions {
+  mergeStrategy?: MergeStrategy
 }
 
 interface RawMember {
@@ -76,6 +113,7 @@ interface RawMember {
   task?: string
   worktreePath?: string
   branch?: string
+  state?: 'active' | 'idle'
 }
 
 interface RawConfig {
@@ -83,12 +121,16 @@ interface RawConfig {
   description?: string
   goal?: string
   workspaceId?: string
+  workspacePath?: string
   worktreeStrategy?: WorktreeStrategy
   mergeStrategy?: MergeStrategy
   createdAt: number
   leadAgentId: string
   leadSessionId?: string
   members: RawMember[]
+  status?: TeamStatus
+  /** Base branch carved out for the team — `team/<teamId>`. */
+  baseBranch?: string
 }
 
 interface InboxMessage {
@@ -98,6 +140,18 @@ interface InboxMessage {
   timestamp: string
   color?: string
   read?: boolean
+}
+
+/** Validate `child` is contained within `parent` to defend against path traversal. */
+function isPathInside(parent: string, child: string): boolean {
+  const rel = path.relative(parent, child)
+  return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+function teamSessionName(teamId: string, agentId: string): string {
+  // tmux session names: alphanumerics, dashes, underscores. Sanitize agent ids.
+  const safe = agentId.replace(/[^A-Za-z0-9_-]/g, '_')
+  return `forge-team-${teamId}-${safe}`
 }
 
 export class AgentTeamWatcher extends EventEmitter {
@@ -163,7 +217,9 @@ export class AgentTeamWatcher extends EventEmitter {
     if (this.refreshTimer) return
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = null
-      this.refresh().then(() => this.emit('teams', this.list())).catch(() => {})
+      this.refresh()
+        .then(() => this.emit('teams', this.list()))
+        .catch(() => {})
     }, 120)
   }
 
@@ -214,6 +270,7 @@ export class AgentTeamWatcher extends EventEmitter {
         task: m.task,
         worktreePath: m.worktreePath,
         branch: m.branch,
+        state: m.state,
       })
     }
     return {
@@ -228,6 +285,7 @@ export class AgentTeamWatcher extends EventEmitter {
       leadAgentId: config.leadAgentId,
       leadSessionId: config.leadSessionId,
       members,
+      status: config.status,
     }
   }
 
@@ -276,67 +334,479 @@ export class AgentTeamWatcher extends EventEmitter {
     return Array.from(this.cache.values()).sort((a, b) => b.createdAt - a.createdAt)
   }
 
+  // ── External tool gating ─────────────────────────────────────────────
+
+  /** Return true when `git` resolves on PATH and is invokable. */
+  private async hasGit(): Promise<boolean> {
+    try {
+      await execFileAsync('git', ['--version'], { timeout: 3000 })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** Return true when `tmux` resolves on PATH. */
+  private async hasTmux(): Promise<boolean> {
+    try {
+      await execFileAsync('tmux', ['-V'], { timeout: 3000 })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private async resolveBaseBranch(workspacePath: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', workspacePath, 'branch', '--show-current'], {
+        timeout: 5000,
+      })
+      const cur = stdout.trim()
+      if (cur) return cur
+    } catch {
+      // fall through
+    }
+    return 'main'
+  }
+
+  /** Best-effort `git branch <newBranch> <fromBranch>` — silent on failure. */
+  private async ensureBranch(workspacePath: string, newBranch: string, fromBranch: string): Promise<boolean> {
+    try {
+      // If branch already exists, just succeed.
+      await execFileAsync('git', ['-C', workspacePath, 'rev-parse', '--verify', newBranch], { timeout: 4000 })
+      return true
+    } catch {
+      // doesn't exist yet, create
+    }
+    try {
+      await execFileAsync('git', ['-C', workspacePath, 'branch', newBranch, fromBranch], { timeout: 8000 })
+      return true
+    } catch {
+      return false
+    }
+  }
+
   /**
-   * Create a new team config under `<workspacePath>/.claude/teams/<teamId>/`.
-   * Worktree provisioning + tmux backend wiring are out of scope here — this
-   * just lays down `config.json` so chokidar refresh picks it up. The lead
-   * agent is the first member; status defaults to 'running' (the watcher will
-   * adjust once inboxes exist).
+   * Create a new team. Provisions:
+   *   1. config.json under <workspacePath>/.claude/teams/<teamId>/
+   *   2. (isolated) per-member git worktrees + branches off `team/<teamId>`
+   *   3. tmux session per member, optionally auto-launching `claude`
    *
-   * NOTE: worktree auto-creation per member is intentionally deferred.
+   * All side effects are best-effort — missing git/tmux yields graceful
+   * degradation: config is still written so the team appears in the registry,
+   * just without worktree/tmux fields populated.
    */
-  async create(opts: TeamCreateOptions): Promise<{ teamId: string; configPath: string }> {
+  async create(opts: TeamCreateOptions): Promise<TeamCreateResult> {
     if (!opts.workspacePath) throw new Error('workspacePath is required')
     if (!opts.name?.trim()) throw new Error('team name is required')
     if (!Array.isArray(opts.members) || opts.members.length === 0) {
       throw new Error('at least one member is required')
     }
+
     const teamId = `team-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     const teamRoot = path.join(opts.workspacePath, '.claude', 'teams', teamId)
     await fs.mkdir(teamRoot, { recursive: true })
+
     const now = Date.now()
     const leadAgentId = opts.members[0].agentId
-    const rawMembers: RawMember[] = opts.members.map((m, idx) => ({
-      agentId: m.agentId,
-      // Member `name` doubles as the inbox filename — keep it filesystem-safe
-      // and unique within the team. We don't have a real display name yet, so
-      // re-use agentId with an index suffix when collisions would arise.
-      name: m.agentId,
-      agentType: m.agentId,
-      model: 'sonnet-4.5',
-      joinedAt: now + idx,
-      task: m.task,
-    }))
+    const wsPath = opts.workspacePath
+    const gitOk = await this.hasGit()
+    const tmuxOk = await this.hasTmux()
+
+    let baseBranch: string | undefined
+    let teamBaseBranch: string | undefined
+    if (gitOk && opts.worktreeStrategy === 'isolated') {
+      baseBranch = await this.resolveBaseBranch(wsPath)
+      teamBaseBranch = `team/${teamId}`
+      // Carve out a stable base for member worktrees to branch from.
+      await this.ensureBranch(wsPath, teamBaseBranch, baseBranch)
+    } else if (gitOk) {
+      baseBranch = await this.resolveBaseBranch(wsPath)
+    }
+
+    let worktreesCreated = 0
+    let tmuxSessionsStarted = 0
+    const autoStart = opts.autoStartClaude !== false
+
+    const rawMembers: RawMember[] = []
+    for (let idx = 0; idx < opts.members.length; idx++) {
+      const m = opts.members[idx]
+      const safeAgentId = m.agentId.replace(/[^A-Za-z0-9_-]/g, '_')
+      const member: RawMember = {
+        agentId: m.agentId,
+        // Member `name` doubles as the inbox filename — keep it filesystem-safe
+        // and unique within the team.
+        name: m.agentId,
+        agentType: m.agentId,
+        model: 'sonnet-4.5',
+        joinedAt: now + idx,
+        task: m.task,
+        state: 'active',
+      }
+
+      // ── Worktree provisioning ──────────────────────────────────────
+      let memberCwd: string | null = null
+      if (opts.worktreeStrategy === 'isolated' && gitOk && teamBaseBranch) {
+        const worktreePath = path.join(teamRoot, 'worktrees', safeAgentId)
+        // Defense in depth: ensure path is contained in teamRoot which itself
+        // is under wsPath (constructed from workspacePath above).
+        if (!isPathInside(teamRoot, worktreePath)) {
+          // Skip silently — can't safely create. Member ends up shared-style.
+          member.worktreePath = wsPath
+          member.branch = baseBranch
+          memberCwd = wsPath
+        } else {
+          const memberBranch = `team/${teamId}/${safeAgentId}`
+          try {
+            await fs.mkdir(path.dirname(worktreePath), { recursive: true })
+            await execFileAsync(
+              'git',
+              ['-C', wsPath, 'worktree', 'add', '-b', memberBranch, worktreePath, teamBaseBranch],
+              { timeout: 30_000 }
+            )
+            member.worktreePath = worktreePath
+            member.branch = memberBranch
+            memberCwd = worktreePath
+            worktreesCreated++
+          } catch {
+            // Graceful — leave fields empty, fall back to wsPath for tmux cwd.
+            memberCwd = wsPath
+          }
+        }
+      } else {
+        // Shared strategy or no git: every member operates on the workspace.
+        member.worktreePath = wsPath
+        member.branch = baseBranch
+        memberCwd = wsPath
+      }
+
+      // ── tmux session ───────────────────────────────────────────────
+      if (tmuxOk && memberCwd) {
+        const session = teamSessionName(teamId, m.agentId)
+        try {
+          await execFileAsync(
+            'tmux',
+            ['new-session', '-d', '-s', session, '-c', memberCwd],
+            { timeout: 8000 }
+          )
+          if (autoStart) {
+            try {
+              await execFileAsync('tmux', ['send-keys', '-t', session, 'claude', 'Enter'], {
+                timeout: 4000,
+              })
+            } catch {
+              // ignore — session exists, claude just didn't auto-fire.
+            }
+          }
+          // We don't have the actual %N pane id, so use session:window.pane
+          // form which createTmuxAttach won't accept. Provide the session name
+          // only; UI may fall back to `tmux attach -t <session>` for now.
+          member.tmuxPaneId = `${session}:0.0`
+          member.backendType = 'tmux'
+          member.cwd = memberCwd
+          tmuxSessionsStarted++
+        } catch {
+          // tmux unavailable / collision — leave tmuxPaneId unset.
+        }
+      } else if (memberCwd) {
+        member.cwd = memberCwd
+      }
+
+      rawMembers.push(member)
+    }
+
     const config: RawConfig = {
       name: opts.name,
       goal: opts.goal,
       workspaceId: opts.workspaceId,
+      workspacePath: wsPath,
       worktreeStrategy: opts.worktreeStrategy,
       mergeStrategy: opts.mergeStrategy,
       createdAt: now,
       leadAgentId,
       members: rawMembers,
+      status: 'active',
+      baseBranch: teamBaseBranch,
     }
     const configPath = path.join(teamRoot, 'config.json')
     await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+
     // chokidar is debounced; nudge the cache immediately so the renderer can
     // see the new team without waiting for the next refresh tick.
     await this.refresh()
     this.emit('teams', this.list())
-    return { teamId, configPath }
+    return { teamId, configPath, worktreesCreated, tmuxSessionsStarted }
+  }
+
+  // ── Pause / Resume ───────────────────────────────────────────────────
+
+  /** Read+write the raw on-disk config for `teamId`. */
+  private async readConfig(teamId: string): Promise<{ configPath: string; config: RawConfig } | null> {
+    const teamDir = path.join(this.teamsDir, teamId)
+    const configPath = path.join(teamDir, 'config.json')
+    try {
+      const config = JSON.parse(await fs.readFile(configPath, 'utf-8')) as RawConfig
+      return { configPath, config }
+    } catch {
+      return null
+    }
+  }
+
+  private async writeConfig(configPath: string, config: RawConfig): Promise<void> {
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
   }
 
   /**
-   * Remove a team's config directory. The chokidar `unlinkDir` listener will
-   * pick this up and refresh the cache, but we eagerly refresh + emit so the
-   * caller sees the removal synchronously.
+   * Pause every member of a team. tmux sessions are sent Ctrl-Z (SIGTSTP via
+   * suspend-client equivalent isn't safe here — we just flag config, since
+   * killing would lose context). Renderer can re-attach after resume.
+   */
+  async pause(teamId: string): Promise<{ ok: boolean }> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(teamId)
+    if (!found) return { ok: false }
+    const tmuxOk = await this.hasTmux()
+    found.config.status = 'paused'
+    for (const m of found.config.members) {
+      m.state = 'idle'
+      if (tmuxOk && m.tmuxPaneId) {
+        const session = teamSessionName(teamId, m.agentId)
+        // detach-client: drops any attached client without killing the session
+        // so claude keeps running but the user no longer sees it.
+        await execFileAsync('tmux', ['detach-client', '-s', session], { timeout: 3000 }).catch(() => {})
+      }
+    }
+    await this.writeConfig(found.configPath, found.config)
+    await this.refresh()
+    this.emit('teams', this.list())
+    this.emit('change', teamId)
+    return { ok: true }
+  }
+
+  async resume(teamId: string): Promise<{ ok: boolean }> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(teamId)
+    if (!found) return { ok: false }
+    found.config.status = 'active'
+    for (const m of found.config.members) {
+      m.state = 'active'
+    }
+    await this.writeConfig(found.configPath, found.config)
+    await this.refresh()
+    this.emit('teams', this.list())
+    this.emit('change', teamId)
+    return { ok: true }
+  }
+
+  async pauseMember(teamId: string, agentId: string): Promise<{ ok: boolean }> {
+    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
+    const found = await this.readConfig(teamId)
+    if (!found) return { ok: false }
+    const member = found.config.members.find((m) => m.agentId === agentId)
+    if (!member) return { ok: false }
+    member.state = 'idle'
+    const tmuxOk = await this.hasTmux()
+    if (tmuxOk && member.tmuxPaneId) {
+      const session = teamSessionName(teamId, agentId)
+      await execFileAsync('tmux', ['detach-client', '-s', session], { timeout: 3000 }).catch(() => {})
+    }
+    await this.writeConfig(found.configPath, found.config)
+    await this.refresh()
+    this.emit('teams', this.list())
+    this.emit('change', teamId)
+    return { ok: true }
+  }
+
+  async resumeMember(teamId: string, agentId: string): Promise<{ ok: boolean }> {
+    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
+    const found = await this.readConfig(teamId)
+    if (!found) return { ok: false }
+    const member = found.config.members.find((m) => m.agentId === agentId)
+    if (!member) return { ok: false }
+    member.state = 'active'
+    await this.writeConfig(found.configPath, found.config)
+    await this.refresh()
+    this.emit('teams', this.list())
+    this.emit('change', teamId)
+    return { ok: true }
+  }
+
+  // ── Merge ────────────────────────────────────────────────────────────
+
+  /**
+   * Merge each member branch into the team base branch (`team/<teamId>`).
+   * Strategy:
+   *   - 'squash':     `git merge --squash <branch>` per member, single commit.
+   *   - 'sequential': `git merge --no-ff <branch>` per member, ordered.
+   *
+   * On first conflict: aborts the in-flight merge, scrapes conflicted files,
+   * and returns conflict descriptors. Already-merged members are kept.
+   */
+  async merge(teamId: string, opts: TeamMergeOptions = {}): Promise<TeamMergeResult> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(teamId)
+    if (!found) return { ok: false, conflicts: [], error: 'team not found' }
+    const cfg = found.config
+    const wsPath = cfg.workspacePath
+    if (!wsPath) {
+      return { ok: false, conflicts: [], error: 'workspacePath missing on team' }
+    }
+    if (!(await this.hasGit())) {
+      return { ok: false, conflicts: [], error: 'git not available' }
+    }
+
+    const baseBranch = cfg.baseBranch ?? `team/${teamId}`
+    const strategy: MergeStrategy = opts.mergeStrategy ?? cfg.mergeStrategy ?? 'squash'
+
+    // Move HEAD to baseBranch in the workspace so merges land there.
+    try {
+      await execFileAsync('git', ['-C', wsPath, 'checkout', baseBranch], { timeout: 10_000 })
+    } catch (err) {
+      return {
+        ok: false,
+        conflicts: [],
+        error: `failed to checkout ${baseBranch}: ${(err as Error).message}`,
+      } satisfies TeamMergeResult
+    }
+
+    const memberBranches = cfg.members.map((m) => m.branch).filter((b): b is string => !!b && b !== baseBranch)
+
+    for (const branch of memberBranches) {
+      const args = strategy === 'squash'
+        ? ['-C', wsPath, 'merge', '--squash', branch]
+        : ['-C', wsPath, 'merge', '--no-ff', '--no-edit', branch]
+      try {
+        await execFileAsync('git', args, { timeout: 30_000 })
+        if (strategy === 'squash') {
+          // --squash leaves changes staged; commit them before next member.
+          await execFileAsync(
+            'git',
+            ['-C', wsPath, 'commit', '-m', `team(${teamId}): squash merge ${branch}`],
+            { timeout: 10_000 }
+          ).catch(() => {})
+        }
+      } catch (err) {
+        // Inspect conflict state, abort, return descriptors.
+        const conflicts = await this.collectConflicts(wsPath, branch, baseBranch)
+        await execFileAsync('git', ['-C', wsPath, 'merge', '--abort'], { timeout: 5000 }).catch(() => {})
+        return {
+          ok: false,
+          conflicts,
+          error: (err as Error).message,
+        }
+      }
+    }
+
+    // Resolve final commit sha on the base branch.
+    let commitSha: string | undefined
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', wsPath, 'rev-parse', 'HEAD'], { timeout: 4000 })
+      commitSha = stdout.trim() || undefined
+    } catch {
+      // ignore
+    }
+
+    const result: TeamMergeResult = { ok: true, mergedBranch: baseBranch }
+    if (commitSha) result.commitSha = commitSha
+    return result
+  }
+
+  private async collectConflicts(
+    wsPath: string,
+    theirsBranch: string,
+    oursBranch: string
+  ): Promise<TeamMergeConflict[]> {
+    let files: string[] = []
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['-C', wsPath, 'diff', '--name-only', '--diff-filter=U'],
+        { timeout: 5000 }
+      )
+      files = stdout.split('\n').map((s) => s.trim()).filter(Boolean)
+    } catch {
+      // ignore
+    }
+    const out: TeamMergeConflict[] = []
+    for (const file of files) {
+      let conflictMarkers = ''
+      try {
+        const buf = await fs.readFile(path.join(wsPath, file), 'utf-8')
+        // Extract just the first conflict block (≤ ~40 lines) for preview.
+        const start = buf.indexOf('<<<<<<<')
+        const end = buf.indexOf('>>>>>>>', start)
+        if (start >= 0 && end > start) {
+          conflictMarkers = buf.slice(start, end + 80).split('\n').slice(0, 60).join('\n')
+        }
+      } catch {
+        // unreadable — leave empty
+      }
+      out.push({ file, theirsBranch, oursBranch, conflictMarkers })
+    }
+    return out
+  }
+
+  // ── Remove ───────────────────────────────────────────────────────────
+
+  /**
+   * Tear down a team:
+   *   1. Kill each member tmux session.
+   *   2. Remove each member git worktree (force).
+   *   3. Delete `team/<teamId>` base branch.
+   *   4. Remove the team config directory.
+   * Each step is independently best-effort.
    */
   async remove(teamId: string): Promise<void> {
     if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(teamId)
+    const tmuxOk = await this.hasTmux()
+    const gitOk = await this.hasGit()
+
+    if (found) {
+      const cfg = found.config
+      const wsPath = cfg.workspacePath
+
+      // Kill tmux sessions (per member).
+      if (tmuxOk) {
+        for (const m of cfg.members) {
+          const session = teamSessionName(teamId, m.agentId)
+          await execFileAsync('tmux', ['kill-session', '-t', session], { timeout: 3000 }).catch(() => {})
+        }
+      }
+
+      // Remove worktrees (only if isolated and within wsPath).
+      if (gitOk && wsPath) {
+        for (const m of cfg.members) {
+          if (!m.worktreePath || m.worktreePath === wsPath) continue
+          if (!isPathInside(wsPath, m.worktreePath)) continue
+          await execFileAsync(
+            'git',
+            ['-C', wsPath, 'worktree', 'remove', m.worktreePath, '--force'],
+            { timeout: 15_000 }
+          ).catch(() => {})
+        }
+        // Delete member branches.
+        for (const m of cfg.members) {
+          if (!m.branch || !m.branch.startsWith(`team/${teamId}`)) continue
+          if (m.branch === cfg.baseBranch) continue
+          await execFileAsync('git', ['-C', wsPath, 'branch', '-D', m.branch], { timeout: 5000 }).catch(
+            () => {}
+          )
+        }
+        // Delete team base branch.
+        const teamBase = cfg.baseBranch ?? `team/${teamId}`
+        await execFileAsync('git', ['-C', wsPath, 'branch', '-D', teamBase], { timeout: 5000 }).catch(
+          () => {}
+        )
+      }
+    }
+
+    // Finally, drop the config directory.
     const target = path.join(this.teamsDir, teamId)
     await fs.rm(target, { recursive: true, force: true }).catch(() => {})
     await this.refresh()
     this.emit('teams', this.list())
+    this.emit('change', teamId)
   }
 
   stop(): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ function toV2Team(team: StoreTeam): V2Team {
     tokens: 0,
     files: 0,
     pane: m.name?.slice(0, 4).toUpperCase() ?? 'PANE',
+    name: m.name,
+    tmuxPaneId: m.tmuxPaneId,
   }))
   // Aggregate run status: blocked > active > idle > done.
   const runStatus: V2Team['status'] = members.some((m) => m.state === 'blocked')
@@ -225,7 +227,7 @@ export default function App() {
       return
     }
     try {
-      await useAgentTeamStore.getState().create({
+      const created = await useAgentTeamStore.getState().create({
         workspaceId: activeWorkspace.id,
         workspacePath: activeWorkspace.path,
         name: result.name,
@@ -234,13 +236,27 @@ export default function App() {
         worktreeStrategy: result.worktree,
         mergeStrategy: result.merge,
       })
-      setToast({ name: result.name, count: result.members.length })
+      // When W1's create() returns enriched stats (worktreesCreated /
+      // tmuxSessionsStarted > 0), append them to the toast name so the
+      // user gets immediate feedback that the orchestration kicked in.
+      const memberCount = result.members.length
+      const extras: string[] = [`${memberCount} members`]
+      if (created.worktreesCreated > 0) {
+        extras.push(`${created.worktreesCreated} worktrees`)
+      }
+      if (created.tmuxSessionsStarted > 0) {
+        extras.push(`${created.tmuxSessionsStarted} tmux 세션`)
+      }
+      const decoratedName =
+        extras.length > 1 ? `${result.name} (${extras.join(' · ')})` : result.name
+      setToast({ name: decoratedName, count: memberCount })
     } catch (err) {
       console.error('[wizard] team create failed:', err)
-      setToast({ name: 'Failed to create team', count: 0 })
+      const message = err instanceof Error ? err.message : 'Failed to create team'
+      setToast({ name: `팀 생성 실패: ${message}`, count: 0 })
     } finally {
       setWizardOpen(false)
-      setTimeout(() => setToast(null), 3000)
+      setTimeout(() => setToast(null), 4000)
     }
   }
 

--- a/src/components/v2/MergeConflictView.tsx
+++ b/src/components/v2/MergeConflictView.tsx
@@ -1,0 +1,361 @@
+/**
+ * MergeConflictView — fullscreen overlay shown when a team merge produces
+ * conflicting files. Visual stub for the v2 UI overhaul.
+ *
+ * Layout:
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │ Header: "Merge Conflicts" + count + close                │
+ *   ├────────────┬─────────────────────────────────────────────┤
+ *   │ File list  │ 3-way diff (ours · merged · theirs)         │
+ *   │            │                                             │
+ *   ├────────────┴─────────────────────────────────────────────┤
+ *   │ Footer: Use ours · Use theirs · Manual resolve · Abort   │
+ *   └──────────────────────────────────────────────────────────┘
+ *
+ * Resolution IPC is delegated to `onResolve` / `onAbort` — the actual diff
+ * algorithm + per-file write is the backend worker's job. This component
+ * only displays the conflict markers it receives.
+ */
+import { useState } from 'react'
+import { Btn, SectionHead } from './primitives'
+import { Icon } from './icons'
+
+export interface ConflictItem {
+  /** Workspace-relative path of the conflicting file. */
+  file: string
+  /** Branch name on the "ours" side (typically the team's merge target). */
+  oursBranch: string
+  /** Branch name on the "theirs" side (typically the member's worktree). */
+  theirsBranch: string
+  /** Raw conflict markers as returned by `git merge` — used for the diff
+   *  preview. Optional so callers can stream this in lazily. */
+  conflictMarkers?: string
+}
+
+export type ResolveStrategy = 'ours' | 'theirs' | 'manual'
+
+export interface MergeConflictViewProps {
+  teamId: string
+  conflicts: ConflictItem[]
+  /** Called when the user picks ours / theirs / manual edit for a file. */
+  onResolve: (file: string, strategy: ResolveStrategy) => void
+  /** Called when the user aborts the entire merge. */
+  onAbort: () => void
+  /** Close the overlay (eg. after the last conflict is resolved). */
+  onClose?: () => void
+}
+
+export function MergeConflictView({
+  teamId,
+  conflicts,
+  onResolve,
+  onAbort,
+  onClose,
+}: MergeConflictViewProps) {
+  const [selectedFile, setSelectedFile] = useState<string | null>(
+    conflicts[0]?.file ?? null,
+  )
+  const selected = conflicts.find((c) => c.file === selectedFile) ?? null
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Merge conflicts"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 200,
+        background: 'var(--bg-1)',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'var(--font-ui)',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          flex: '0 0 auto',
+          height: 44,
+          padding: '0 14px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          borderBottom: '1px solid var(--line-1)',
+          background: 'var(--bg-2)',
+        }}
+      >
+        <Icon.Diff size={14} style={{ color: 'var(--danger)' }} />
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-1)' }}>
+          Merge Conflicts
+        </span>
+        <span
+          className="mono tabular"
+          style={{ fontSize: 11.5, color: 'var(--text-3)' }}
+        >
+          {conflicts.length} file{conflicts.length === 1 ? '' : 's'} · team {teamId}
+        </span>
+        <div style={{ flex: 1 }} />
+        {onClose && (
+          <Btn variant="ghost" icon={<Icon.X size={12} />} onClick={onClose}>
+            Close
+          </Btn>
+        )}
+      </div>
+
+      {/* Body: file list (left) + diff (main) */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
+        {/* File list */}
+        <div
+          style={{
+            width: 260,
+            flexShrink: 0,
+            borderRight: '1px solid var(--line-1)',
+            background: 'var(--bg-1)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <SectionHead title="Conflicts" sub={`${conflicts.length}`} />
+          <div style={{ overflowY: 'auto', flex: 1, padding: 6 }}>
+            {conflicts.length === 0 && (
+              <div
+                style={{
+                  padding: 18,
+                  fontSize: 12,
+                  color: 'var(--text-3)',
+                  textAlign: 'center',
+                }}
+              >
+                No conflicts.
+              </div>
+            )}
+            {conflicts.map((c) => {
+              const active = c.file === selectedFile
+              return (
+                <button
+                  key={c.file}
+                  onClick={() => setSelectedFile(c.file)}
+                  style={{
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '8px 10px',
+                    background: active ? 'var(--bg-3)' : 'transparent',
+                    border: `1px solid ${active ? 'var(--line-3)' : 'transparent'}`,
+                    borderRadius: 5,
+                    cursor: 'pointer',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                    marginBottom: 2,
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--text-1)',
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11.5,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {c.file}
+                  </span>
+                  <span style={{ fontSize: 10, color: 'var(--text-3)' }}>
+                    {c.oursBranch} ← {c.theirsBranch}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* 3-way diff */}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            background: '#06080b',
+          }}
+        >
+          {selected ? (
+            <DiffPanel item={selected} />
+          ) : (
+            <div
+              style={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'var(--text-3)',
+                fontSize: 12.5,
+              }}
+            >
+              Select a file to inspect the conflict.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          flex: '0 0 auto',
+          height: 52,
+          padding: '0 14px',
+          borderTop: '1px solid var(--line-1)',
+          background: 'var(--bg-2)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <Btn
+          variant="danger"
+          icon={<Icon.X size={12} />}
+          onClick={onAbort}
+          title="Abort the entire merge — discards in-progress merge state"
+        >
+          Abort merge
+        </Btn>
+        <div style={{ flex: 1 }} />
+        <Btn
+          variant="ghost"
+          icon={<Icon.Code size={12} />}
+          disabled={!selected}
+          onClick={() => selected && onResolve(selected.file, 'manual')}
+          title="Open file in editor for manual resolve"
+        >
+          Manual resolve
+        </Btn>
+        <Btn
+          variant="ghost"
+          icon={<Icon.Arrow size={12} style={{ transform: 'rotate(180deg)' }} />}
+          disabled={!selected}
+          onClick={() => selected && onResolve(selected.file, 'ours')}
+        >
+          Use ours
+        </Btn>
+        <Btn
+          variant="primary"
+          icon={<Icon.Arrow size={12} />}
+          disabled={!selected}
+          onClick={() => selected && onResolve(selected.file, 'theirs')}
+        >
+          Use theirs
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+// ─── Internal: 3-column diff display ─────────────────────────────────
+
+function DiffPanel({ item }: { item: ConflictItem }) {
+  const { ours, merged, theirs } = splitConflict(item.conflictMarkers ?? '')
+  const colStyle: React.CSSProperties = {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    borderRight: '1px solid var(--line-1)',
+  }
+  const headerStyle: React.CSSProperties = {
+    height: 26,
+    padding: '0 10px',
+    background: 'var(--bg-2)',
+    borderBottom: '1px solid var(--line-1)',
+    display: 'flex',
+    alignItems: 'center',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10.5,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: 'var(--text-3)',
+    fontWeight: 600,
+  }
+  const bodyStyle: React.CSSProperties = {
+    flex: 1,
+    overflow: 'auto',
+    padding: '8px 10px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11.5,
+    lineHeight: 1.5,
+    color: 'var(--text-2)',
+    whiteSpace: 'pre',
+    minHeight: 0,
+  }
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {/* breadcrumb */}
+      <div
+        style={{
+          flex: '0 0 auto',
+          height: 30,
+          padding: '0 14px',
+          background: 'var(--bg-2)',
+          borderBottom: '1px solid var(--line-1)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11.5,
+          color: 'var(--text-2)',
+        }}
+      >
+        <Icon.File size={11} style={{ color: 'var(--text-3)' }} />
+        <span>{item.file}</span>
+      </div>
+
+      {/* 3 columns */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+        <div style={colStyle}>
+          <div style={{ ...headerStyle, color: '#5da5ff' }}>
+            ours · {item.oursBranch}
+          </div>
+          <div style={bodyStyle}>{ours || '(no local changes)'}</div>
+        </div>
+        <div style={colStyle}>
+          <div style={{ ...headerStyle, color: 'var(--accent)' }}>merged</div>
+          <div style={bodyStyle}>{merged || '(empty merge candidate)'}</div>
+        </div>
+        <div style={{ ...colStyle, borderRight: 'none' }}>
+          <div style={{ ...headerStyle, color: '#f0a23a' }}>
+            theirs · {item.theirsBranch}
+          </div>
+          <div style={bodyStyle}>{theirs || '(no incoming changes)'}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Crude split of a conflict-marker blob into the 3 sides for visual preview.
+ * Real conflict resolution stays in the backend — this is purely a placeholder
+ * that surfaces the raw markers when the IPC call doesn't yet provide a
+ * structured diff.
+ */
+function splitConflict(blob: string): { ours: string; merged: string; theirs: string } {
+  if (!blob.includes('<<<<<<<') || !blob.includes('=======') || !blob.includes('>>>>>>>')) {
+    return { ours: blob, merged: blob, theirs: blob }
+  }
+  const startIdx = blob.indexOf('<<<<<<<')
+  const sepIdx = blob.indexOf('=======', startIdx)
+  const endIdx = blob.indexOf('>>>>>>>', sepIdx)
+  if (startIdx < 0 || sepIdx < 0 || endIdx < 0) {
+    return { ours: blob, merged: blob, theirs: blob }
+  }
+  // Strip the marker line itself for cleaner output.
+  const oursStart = blob.indexOf('\n', startIdx) + 1
+  const theirsStart = blob.indexOf('\n', sepIdx) + 1
+  const ours = blob.slice(oursStart, sepIdx)
+  const theirs = blob.slice(theirsStart, endIdx)
+  const merged = `${ours}\n--- merged candidate (manual edit recommended) ---\n${theirs}`
+  return { ours, merged, theirs }
+}

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -20,6 +20,31 @@ import {
 } from './primitives'
 import { AGENT_BY_ID, ACTIVITY, TERMINAL_LINES } from './data'
 import type { Team, TeamMember, ActivityItem, MemberState, TerminalLine } from './types'
+import { MergeConflictView, type ConflictItem } from './MergeConflictView'
+
+// ─── Optional team-control IPC (graceful when backend is unfinished) ─
+//
+// The pause / resume / merge / per-member control surface is being added by a
+// peer worker. We type it loosely + reach in via optional chaining so the UI
+// keeps compiling and degrades to a console.warn no-op when methods are
+// missing in the renderer's preload bridge.
+interface TeamsControlApi {
+  pause?: (teamId: string) => Promise<void> | void
+  resume?: (teamId: string) => Promise<void> | void
+  pauseMember?: (teamId: string, agentName: string) => Promise<void> | void
+  resumeMember?: (teamId: string, agentName: string) => Promise<void> | void
+  merge?: (teamId: string) => Promise<
+    | { ok: true; mergedBranch?: string; commitSha?: string | null }
+    | { ok: false; conflicts: ConflictItem[]; error?: string }
+  >
+}
+
+function getTeamsControlApi(): TeamsControlApi | undefined {
+  if (typeof window === 'undefined') return undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  return w?.api?.teams as TeamsControlApi | undefined
+}
 
 export interface RunLiveViewProps {
   team: Team
@@ -39,7 +64,25 @@ export function RunLiveView({
 }: RunLiveViewProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [feedOpen, setFeedOpen] = useState(true)
-  const [paused, setPaused] = useState(false)
+  // Local paused fallback for the design demo (when no real backend status).
+  const [localPaused, setLocalPaused] = useState(false)
+  const paused = team.status === 'paused' || localPaused
+
+  // Transient inline notice (success / warn) for IPC-triggered actions.
+  const [notice, setNotice] = useState<{
+    kind: 'info' | 'warn' | 'error' | 'success'
+    text: string
+  } | null>(null)
+  function flash(kind: 'info' | 'warn' | 'error' | 'success', text: string) {
+    setNotice({ kind, text })
+    window.setTimeout(() => setNotice(null), 3500)
+  }
+
+  // Merge-conflict overlay state — shown when teams.merge resolves to ok=false.
+  const [activeConflict, setActiveConflict] = useState<{
+    teamId: string
+    conflicts: ConflictItem[]
+  } | null>(null)
 
   // Live tick — drives terminal scroll + activity feed
   const [tick, setTick] = useState(0)
@@ -48,6 +91,116 @@ export function RunLiveView({
     const id = setInterval(() => setTick((t) => t + 1), 1200)
     return () => clearInterval(id)
   }, [paused])
+
+  // ── Action handlers (all IPC-optional) ──────────────────────────
+  async function handlePauseAll() {
+    const api = getTeamsControlApi()
+    if (paused) {
+      if (typeof api?.resume === 'function') {
+        try {
+          await api.resume(team.id)
+          flash('success', `Resumed ${team.name}`)
+        } catch (err) {
+          console.error('[RunLiveView] resume failed:', err)
+          flash('error', 'Resume failed — see console')
+        }
+      } else {
+        console.warn('[RunLiveView] window.api.teams.resume() not implemented')
+        setLocalPaused(false)
+      }
+    } else {
+      if (typeof api?.pause === 'function') {
+        try {
+          await api.pause(team.id)
+          flash('success', `Paused ${team.name}`)
+        } catch (err) {
+          console.error('[RunLiveView] pause failed:', err)
+          flash('error', 'Pause failed — see console')
+        }
+      } else {
+        console.warn('[RunLiveView] window.api.teams.pause() not implemented')
+        setLocalPaused(true)
+      }
+    }
+  }
+
+  async function handlePauseMember(member: TeamMember) {
+    const api = getTeamsControlApi()
+    const agentName = member.name ?? member.agentId
+    const isPaused = member.state === 'idle' || member.state === 'queued'
+    const fn = isPaused ? api?.resumeMember : api?.pauseMember
+    const verb = isPaused ? 'Resume' : 'Pause'
+    if (typeof fn !== 'function') {
+      console.warn(`[RunLiveView] window.api.teams.${verb.toLowerCase()}Member() not implemented`)
+      flash('warn', `${verb} member — backend not yet wired`)
+      return
+    }
+    try {
+      await fn(team.id, agentName)
+      flash('success', `${verb}d ${agentName}`)
+    } catch (err) {
+      console.error(`[RunLiveView] ${verb.toLowerCase()}Member failed:`, err)
+      flash('error', `${verb} failed — see console`)
+    }
+  }
+
+  function handleDiff() {
+    // No backend conflict source yet — surface a benign inline notice.
+    flash('info', 'No merge conflicts')
+  }
+
+  async function handleMerge() {
+    const ok = window.confirm(
+      `Merge all completed members of "${team.name}" into ${team.branch}?`,
+    )
+    if (!ok) return
+    const api = getTeamsControlApi()
+    if (typeof api?.merge !== 'function') {
+      console.warn('[RunLiveView] window.api.teams.merge() not implemented')
+      flash('warn', 'Merge — backend not yet wired')
+      return
+    }
+    try {
+      const res = await api.merge(team.id)
+      if (res.ok) {
+        flash('success', `Merged into ${res.mergedBranch ?? team.branch}`)
+      } else {
+        const conflicts = Array.isArray(res.conflicts) ? res.conflicts : []
+        if (conflicts.length === 0) {
+          flash('error', res.error ?? 'Merge failed (no conflict detail)')
+        } else {
+          setActiveConflict({ teamId: team.id, conflicts })
+        }
+      }
+    } catch (err) {
+      console.error('[RunLiveView] merge failed:', err)
+      flash('error', 'Merge failed — see console')
+    }
+  }
+
+  function handleOpenAgentTerminal(member: TeamMember) {
+    const api = window.api?.teams
+    if (!member.tmuxPaneId) {
+      flash(
+        'warn',
+        'tmux 세션이 아직 spawn 되지 않음 — 워크스페이스 isolated 옵션으로 다시 생성 필요',
+      )
+      return
+    }
+    if (typeof api?.openAgentTerminal !== 'function') {
+      console.warn('[RunLiveView] window.api.teams.openAgentTerminal() unavailable')
+      flash('error', '터미널 IPC 사용 불가')
+      return
+    }
+    const agentName = member.name ?? member.agentId
+    api
+      .openAgentTerminal({ teamId: team.id, agentName, cols: 80, rows: 24 })
+      .then(() => flash('success', `${agentName} 터미널에 attach`))
+      .catch((err) => {
+        console.error('[RunLiveView] openAgentTerminal failed:', err)
+        flash('error', '터미널 attach 실패 — see console')
+      })
+  }
 
   return (
     <div
@@ -112,20 +265,23 @@ export function RunLiveView({
         <Btn
           variant="ghost"
           icon={paused ? <Icon.Play size={12} /> : <Icon.Pause size={12} />}
-          onClick={() => setPaused((p) => !p)}
+          onClick={handlePauseAll}
         >
-          {paused ? 'Resume' : 'Pause all'}
+          {paused ? 'Resume all' : 'Pause all'}
         </Btn>
-        <Btn variant="ghost" icon={<Icon.Diff size={12} />}>
+        <Btn variant="ghost" icon={<Icon.Diff size={12} />} onClick={handleDiff}>
           Diff
         </Btn>
-        <Btn variant="primary" icon={<Icon.Check size={12} />}>
+        <Btn variant="primary" icon={<Icon.Check size={12} />} onClick={handleMerge}>
           Merge
         </Btn>
-        <Btn variant="ghost" icon={<Icon.X size={12} />}>
+        <Btn variant="ghost" icon={<Icon.X size={12} />} onClick={onClose}>
           Close team
         </Btn>
       </div>
+
+      {/* Inline notice (transient, replaces toast for in-view IPC actions) */}
+      {notice && <InlineNotice kind={notice.kind} text={notice.text} />}
 
       {/* Body: 3 columns */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
@@ -150,6 +306,8 @@ export function RunLiveView({
                 onClick={() =>
                   setSelectedAgentId(m.agentId === selectedAgentId ? null : m.agentId)
                 }
+                onTogglePause={() => handlePauseMember(m)}
+                onOpenTerminal={() => handleOpenAgentTerminal(m)}
               />
             ))}
           </div>
@@ -240,6 +398,92 @@ export function RunLiveView({
           </div>
         )}
       </div>
+
+      {/* Merge conflict overlay — only when teams.merge() returned ok=false */}
+      {activeConflict && (
+        <MergeConflictView
+          teamId={activeConflict.teamId}
+          conflicts={activeConflict.conflicts}
+          onResolve={(file, strategy) => {
+            console.warn(
+              `[RunLiveView] resolve(${file}, ${strategy}) — backend resolver not yet wired`,
+            )
+            flash('info', `Resolve ${strategy} → ${file}`)
+            // Optimistic UI: drop the resolved file from the list. Backend
+            // will republish via teams:update once it actually resolves.
+            setActiveConflict((cur) =>
+              cur
+                ? {
+                    ...cur,
+                    conflicts: cur.conflicts.filter((c) => c.file !== file),
+                  }
+                : cur,
+            )
+          }}
+          onAbort={() => {
+            setActiveConflict(null)
+            flash('warn', 'Merge aborted')
+          }}
+          onClose={() => setActiveConflict(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── Inline notice (transient, replaces Shell-level toast in live view) ──
+
+function InlineNotice({
+  kind,
+  text,
+}: {
+  kind: 'info' | 'warn' | 'error' | 'success'
+  text: string
+}) {
+  const palette: Record<typeof kind, { bg: string; border: string; fg: string }> = {
+    info: {
+      bg: 'color-mix(in oklab, var(--info, var(--accent)) 12%, var(--bg-2))',
+      border: 'color-mix(in oklab, var(--info, var(--accent)) 35%, var(--line-2))',
+      fg: 'var(--info, var(--accent))',
+    },
+    warn: {
+      bg: 'color-mix(in oklab, var(--warning, #f0a23a) 12%, var(--bg-2))',
+      border: 'color-mix(in oklab, var(--warning, #f0a23a) 35%, var(--line-2))',
+      fg: 'var(--warning, #f0a23a)',
+    },
+    error: {
+      bg: 'color-mix(in oklab, var(--danger) 12%, var(--bg-2))',
+      border: 'color-mix(in oklab, var(--danger) 35%, var(--line-2))',
+      fg: 'var(--danger)',
+    },
+    success: {
+      bg: 'color-mix(in oklab, var(--success) 12%, var(--bg-2))',
+      border: 'color-mix(in oklab, var(--success) 35%, var(--line-2))',
+      fg: 'var(--success)',
+    },
+  }
+  const p = palette[kind]
+  return (
+    <div
+      role="status"
+      style={{
+        position: 'absolute',
+        top: 56,
+        right: 18,
+        zIndex: 60,
+        padding: '8px 12px',
+        borderRadius: 6,
+        background: p.bg,
+        border: `1px solid ${p.border}`,
+        color: p.fg,
+        fontSize: 12,
+        fontWeight: 500,
+        fontFamily: 'var(--font-mono)',
+        boxShadow: 'var(--shadow-pop, 0 4px 12px rgba(0,0,0,0.25))',
+        maxWidth: 360,
+      }}
+    >
+      {text}
     </div>
   )
 }
@@ -250,15 +494,35 @@ interface AgentCardProps {
   member: TeamMember
   selected: boolean
   onClick: () => void
+  /** ▶/⏸ toggle (active/done → pause; idle/queued → resume; blocked → disabled). */
+  onTogglePause?: () => void
+  /** Open the agent's tmux pane in a new terminal tab. */
+  onOpenTerminal?: () => void
 }
 
-function AgentCard({ member, selected, onClick }: AgentCardProps) {
+function AgentCard({
+  member,
+  selected,
+  onClick,
+  onTogglePause,
+  onOpenTerminal,
+}: AgentCardProps) {
   const a = AGENT_BY_ID[member.agentId]
   const stateC = STATE_COLOR[member.state]
   if (!a) return null
+  const blocked = member.state === 'blocked'
+  const isPaused = member.state === 'idle' || member.state === 'queued'
   return (
-    <button
+    <div
       onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
       style={{
         width: '100%',
         textAlign: 'left',
@@ -303,6 +567,51 @@ function AgentCard({ member, selected, onClick }: AgentCardProps) {
           color={stateC}
           pulse={member.state === 'active' || member.state === 'blocked'}
         />
+        <div
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 2, marginLeft: 2 }}
+        >
+          {onTogglePause && (
+            <CardIconBtn
+              title={
+                blocked
+                  ? '결정 대기 — 외부 응답 필요'
+                  : isPaused
+                    ? `Resume ${a.name}`
+                    : `Pause ${a.name}`
+              }
+              disabled={blocked}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!blocked) onTogglePause()
+              }}
+              danger={blocked}
+            >
+              {blocked ? (
+                <span style={{ fontSize: 11, lineHeight: 1 }}>⚠</span>
+              ) : isPaused ? (
+                <Icon.Play size={11} />
+              ) : (
+                <Icon.Pause size={11} />
+              )}
+            </CardIconBtn>
+          )}
+          {onOpenTerminal && (
+            <CardIconBtn
+              title={
+                member.tmuxPaneId
+                  ? `Open ${a.name} terminal`
+                  : 'tmux 세션 미할당 — isolated 옵션으로 재생성 필요'
+              }
+              onClick={(e) => {
+                e.stopPropagation()
+                onOpenTerminal()
+              }}
+              dim={!member.tmuxPaneId}
+            >
+              <Icon.Terminal size={11} />
+            </CardIconBtn>
+          )}
+        </div>
       </div>
       <div
         style={{
@@ -346,6 +655,64 @@ function AgentCard({ member, selected, onClick }: AgentCardProps) {
           {STATE_LABEL[member.state]}
         </span>
       </div>
+    </div>
+  )
+}
+
+// ─── Tiny icon-only button used inside AgentCard ────────────────────
+//
+// Stops click propagation by default so it doesn't toggle the card's selection
+// when the user just wanted to pause / open terminal.
+interface CardIconBtnProps {
+  children: React.ReactNode
+  title?: string
+  disabled?: boolean
+  danger?: boolean
+  dim?: boolean
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+function CardIconBtn({ children, title, disabled, danger, dim, onClick }: CardIconBtnProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      style={{
+        width: 18,
+        height: 18,
+        borderRadius: 3,
+        background: 'transparent',
+        border: '1px solid transparent',
+        color: danger
+          ? 'var(--danger)'
+          : dim
+            ? 'var(--text-4, var(--text-3))'
+            : 'var(--text-3)',
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 0,
+      }}
+      onMouseEnter={(e) => {
+        if (disabled) return
+        ;(e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-4, var(--bg-3))'
+        ;(e.currentTarget as HTMLButtonElement).style.color = 'var(--text-1)'
+      }}
+      onMouseLeave={(e) => {
+        ;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
+        ;(e.currentTarget as HTMLButtonElement).style.color = danger
+          ? 'var(--danger)'
+          : dim
+            ? 'var(--text-4, var(--text-3))'
+            : 'var(--text-3)'
+      }}
+    >
+      {children}
     </button>
   )
 }

--- a/src/components/v2/Wizard.tsx
+++ b/src/components/v2/Wizard.tsx
@@ -510,24 +510,42 @@ function Step3({ worktree, setWorktree, merge, setMerge }: Step3Props) {
     id: WorktreeStrategy
     title: string
     desc: string
+    detail: string
     icon: React.ReactNode
   }[] = [
     {
       id: 'isolated',
       title: '격리 (권장)',
       desc: 'agent마다 별도 worktree, 충돌 위험 ↓',
+      detail: '멤버별 격리 git worktree + tmux 세션 자동 spawn (멤버 ≥ 2명일 때 권장)',
       icon: <Icon.Cube size={16} />,
     },
     {
       id: 'shared',
       title: '공유',
       desc: '같은 디렉터리, 빠르지만 충돌 가능',
+      detail: '같은 worktree 공유 (소규모 팀)',
       icon: <Icon.Layers size={16} />,
     },
   ]
-  const mergeOptions: { id: MergeStrategy; title: string; desc: string }[] = [
-    { id: 'squash', title: 'Squash', desc: '각 agent의 작업을 하나의 커밋으로' },
-    { id: 'sequential', title: 'Sequential', desc: 'agent 순서대로 차례로 머지' },
+  const mergeOptions: {
+    id: MergeStrategy
+    title: string
+    desc: string
+    detail: string
+  }[] = [
+    {
+      id: 'squash',
+      title: 'Squash',
+      desc: '각 agent의 작업을 하나의 커밋으로',
+      detail: '한 커밋으로 합침',
+    },
+    {
+      id: 'sequential',
+      title: 'Sequential',
+      desc: 'agent 순서대로 차례로 머지',
+      detail: '멤버 순서대로 머지 (history 보존)',
+    },
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
@@ -567,6 +585,18 @@ function Step3({ worktree, setWorktree, merge, setMerge }: Step3Props) {
               <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.4 }}>
                 {o.desc}
               </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-2)',
+                  lineHeight: 1.4,
+                  marginTop: 2,
+                  paddingTop: 6,
+                  borderTop: '1px solid var(--line-1)',
+                }}
+              >
+                {o.detail}
+              </div>
             </button>
           ))}
         </div>
@@ -600,6 +630,18 @@ function Step3({ worktree, setWorktree, merge, setMerge }: Step3Props) {
               <div style={{ fontSize: 11, color: 'var(--text-3)', lineHeight: 1.4 }}>
                 {o.desc}
               </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-2)',
+                  lineHeight: 1.4,
+                  marginTop: 6,
+                  paddingTop: 6,
+                  borderTop: '1px solid var(--line-1)',
+                }}
+              >
+                {o.detail}
+              </div>
             </button>
           ))}
         </div>
@@ -619,6 +661,20 @@ interface Step4Props {
 }
 
 function Step4({ name, goal, selected, worktree, merge }: Step4Props) {
+  // ── Expected-action one-liners (so the user can sanity-check before
+  //    Start). Mirrors the strategy details from Step3 but phrased in terms
+  //    of *this team's* concrete numbers — e.g. "5 worktrees" not "per-member
+  //    worktrees". Sequential / shared get the inverse phrasing.
+  const memberCount = selected.length
+  const worktreeAction =
+    worktree === 'isolated'
+      ? `${memberCount}명 분리 worktree + ${memberCount}개 tmux 세션 spawn`
+      : `${memberCount}명이 단일 worktree 공유`
+  const mergeAction =
+    merge === 'squash'
+      ? '머지 시 한 커밋으로 합쳐짐'
+      : '머지 시 멤버 순서대로 차례로 합쳐짐 (history 보존)'
+
   const rows: { k: string; v: React.ReactNode; extra?: React.ReactNode }[] = [
     { k: '이름', v: name || '(없음)' },
     { k: '목표', v: goal || '(없음)' },
@@ -627,8 +683,20 @@ function Step4({ name, goal, selected, worktree, merge }: Step4Props) {
       v: `${selected.length}명`,
       extra: <AvatarStack ids={selected} max={8} size={20} />,
     },
-    { k: '워크트리', v: worktree === 'isolated' ? '격리' : '공유' },
-    { k: '머지', v: merge === 'squash' ? 'Squash' : 'Sequential' },
+    {
+      k: '워크트리',
+      v: worktree === 'isolated' ? '격리' : '공유',
+      extra: (
+        <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>· {worktreeAction}</span>
+      ),
+    },
+    {
+      k: '머지',
+      v: merge === 'squash' ? 'Squash' : 'Sequential',
+      extra: (
+        <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>· {mergeAction}</span>
+      ),
+    },
     {
       k: '브랜치',
       v: (

--- a/src/components/v2/types.ts
+++ b/src/components/v2/types.ts
@@ -25,6 +25,11 @@ export interface TeamMember {
   files: number
   pane: string
   blockedReason?: string
+  /** Optional human-readable member name (used as agent identifier for tmux). */
+  name?: string
+  /** Optional tmux pane id — when present, the member can attach to a real
+   *  terminal session via `window.api.teams.openAgentTerminal`. */
+  tmuxPaneId?: string
 }
 
 export interface Team {

--- a/src/stores/agentTeam.ts
+++ b/src/stores/agentTeam.ts
@@ -1,5 +1,23 @@
 import { create } from 'zustand'
-import type { Team, TeamCreateOptions } from '@/types'
+import type { Team, TeamCreateOptions, TeamCreateResult, MergeResult } from '@/types'
+
+/**
+ * Type guards for optional IPC methods. W1 ships pause/resume/merge via
+ * `window.api.teams.*`, but until that lands the store gracefully no-ops
+ * instead of throwing — this keeps the renderer typecheck-clean even when
+ * the worker is mid-flight.
+ */
+type TeamsApi = Window['api']['teams'] & {
+  pause?: (teamId: string) => Promise<void>
+  resume?: (teamId: string) => Promise<void>
+  pauseMember?: (teamId: string, agentId: string) => Promise<void>
+  resumeMember?: (teamId: string, agentId: string) => Promise<void>
+  merge?: (teamId: string) => Promise<MergeResult>
+}
+
+function teamsApi(): TeamsApi {
+  return window.api.teams as TeamsApi
+}
 
 interface AgentTeamState {
   teams: Team[]
@@ -11,10 +29,25 @@ interface AgentTeamState {
   unsubscribeAll: () => void
   /** Create a new team and refresh the list. The watcher will eventually push
    *  the same data via `onUpdate`, but we re-fetch here so callers get
-   *  immediate consistency without waiting for the next chokidar tick. */
-  create: (opts: TeamCreateOptions) => Promise<{ teamId: string; configPath: string }>
+   *  immediate consistency without waiting for the next chokidar tick.
+   *  Returns the full create envelope (incl. worktreesCreated /
+   *  tmuxSessionsStarted when W1 has wired them) so callers can render rich
+   *  toast feedback. Falls back to a partial shape if the IPC handler still
+   *  returns the legacy `{teamId, configPath}` envelope. */
+  create: (opts: TeamCreateOptions) => Promise<TeamCreateResult>
   /** Delete a team config (worktrees / inboxes go too). */
   remove: (teamId: string) => Promise<void>
+  /** Pause a whole team (lifecycle: active → paused). */
+  pause: (teamId: string) => Promise<void>
+  /** Resume a paused team. */
+  resume: (teamId: string) => Promise<void>
+  /** Pause a single member's tmux pane / agent loop. */
+  pauseMember: (teamId: string, agentId: string) => Promise<void>
+  /** Resume a single member. */
+  resumeMember: (teamId: string, agentId: string) => Promise<void>
+  /** Trigger the merge pipeline for a team. Returns the MergeResult so the
+   *  caller can drive a `MergeConflictView` (W2) when `ok === false`. */
+  merge: (teamId: string) => Promise<MergeResult>
 }
 
 export const useAgentTeamStore = create<AgentTeamState>((set, get) => ({
@@ -34,6 +67,9 @@ export const useAgentTeamStore = create<AgentTeamState>((set, get) => ({
 
   subscribe: () => {
     if (get().unsubscribe) return
+    // chokidar push covers both content (config.json) AND status changes —
+    // AgentTeamWatcher recomputes status on every refresh tick, so a single
+    // onUpdate stream is enough to pick up pause/resume transitions.
     const off = window.api.teams.onUpdate((teams) => {
       set({ teams: teams as Team[], loaded: true })
     })
@@ -47,13 +83,73 @@ export const useAgentTeamStore = create<AgentTeamState>((set, get) => ({
   },
 
   create: async (opts: TeamCreateOptions) => {
-    const result = await window.api.teams.create(opts)
+    const result = (await window.api.teams.create(opts)) as Partial<TeamCreateResult> & {
+      teamId: string
+      configPath: string
+    }
     await get().load()
-    return result
+    // Normalise: legacy backend returns {teamId, configPath} only.
+    return {
+      teamId: result.teamId,
+      configPath: result.configPath,
+      worktreesCreated: result.worktreesCreated ?? 0,
+      tmuxSessionsStarted: result.tmuxSessionsStarted ?? 0,
+    }
   },
 
   remove: async (teamId: string) => {
     await window.api.teams.remove(teamId)
     await get().load()
+  },
+
+  pause: async (teamId: string) => {
+    const fn = teamsApi().pause
+    if (!fn) {
+      console.warn('[agentTeam] pause: IPC not yet wired (W1 in flight)')
+      return
+    }
+    await fn(teamId)
+    await get().load()
+  },
+
+  resume: async (teamId: string) => {
+    const fn = teamsApi().resume
+    if (!fn) {
+      console.warn('[agentTeam] resume: IPC not yet wired (W1 in flight)')
+      return
+    }
+    await fn(teamId)
+    await get().load()
+  },
+
+  pauseMember: async (teamId: string, agentId: string) => {
+    const fn = teamsApi().pauseMember
+    if (!fn) {
+      console.warn('[agentTeam] pauseMember: IPC not yet wired (W1 in flight)')
+      return
+    }
+    await fn(teamId, agentId)
+    await get().load()
+  },
+
+  resumeMember: async (teamId: string, agentId: string) => {
+    const fn = teamsApi().resumeMember
+    if (!fn) {
+      console.warn('[agentTeam] resumeMember: IPC not yet wired (W1 in flight)')
+      return
+    }
+    await fn(teamId, agentId)
+    await get().load()
+  },
+
+  merge: async (teamId: string): Promise<MergeResult> => {
+    const fn = teamsApi().merge
+    if (!fn) {
+      console.warn('[agentTeam] merge: IPC not yet wired (W1 in flight)')
+      return { ok: false, error: 'merge IPC not available', conflicts: [] }
+    }
+    const result = await fn(teamId)
+    await get().load()
+    return result
   },
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,9 +109,54 @@ export interface GitBranch {
   lastCommitMsg: string
 }
 
-export type AgentStatus = 'running' | 'idle' | 'shutdown'
+export type AgentStatus = 'running' | 'idle' | 'shutdown' | 'paused' | 'active'
+export type TeamStatus = 'active' | 'paused'
 export type WorktreeStrategy = 'isolated' | 'shared'
 export type MergeStrategy = 'squash' | 'sequential'
+
+export interface TeamCreateResult {
+  teamId: string
+  configPath: string
+  worktreesCreated: number
+  tmuxSessionsStarted: number
+}
+
+/**
+ * Single-file merge conflict surfaced by `teams:merge`. The renderer uses
+ * `conflictMarkers` to render an inline diff in `MergeConflictView` (W2).
+ */
+export interface MergeConflict {
+  file: string
+  theirsBranch: string
+  oursBranch: string
+  conflictMarkers: string
+}
+
+/**
+ * Result envelope for `teams:merge`. On success exposes the resulting branch
+ * + commit sha; on conflict surfaces a list of `MergeConflict` for the UI.
+ *
+ * Shape was deliberately chosen to be flat (one record, optional fields)
+ * instead of a discriminated union so renderer code can `result.ok &&
+ * result.commitSha` without narrowing acrobatics.
+ */
+export interface MergeResult {
+  ok: boolean
+  mergedBranch?: string
+  commitSha?: string
+  conflicts?: MergeConflict[]
+  error?: string
+}
+
+/** @deprecated alias for `MergeConflict` — kept for any in-flight callers. */
+export type TeamMergeConflict = MergeConflict
+
+/** @deprecated alias for `MergeResult` — kept for any in-flight callers. */
+export type TeamMergeResult = MergeResult
+
+export interface TeamMergeOptions {
+  mergeStrategy?: MergeStrategy
+}
 
 export interface TeamMember {
   agentId: string
@@ -149,6 +194,8 @@ export interface Team {
   leadAgentId: string
   leadSessionId?: string
   members: TeamMember[]
+  /** Lifecycle status — 'active' | 'paused'. Absent = active. */
+  status?: TeamStatus
 }
 
 export interface TeamCreateMember {


### PR DESCRIPTION
## Summary

팀 시스템의 4가지 \"보류\" 항목 풀 구현 + 단일 HTML 아키텍처 문서.

## 4 항목

| 항목 | Before | After |
|---|---|---|
| **worktree 자동 생성** | config.json 만 작성, worktree 수동 | isolated 시 `team/<id>` 베이스 + 멤버별 `team/<id>/<agent>` 브랜치 + worktree 자동 |
| **멤버별 tmux pane 자동 spawn** | Wizard 결과로 정의만, tmux 별도 클릭 | `forge-team-<id>-<agent>` 세션 자동 spawn + autoStartClaude 로 `claude` 자동 실행 |
| **팀 일시정지/재개 IPC** | UI 버튼만, backend 없음 | `pause/resume/pauseMember/resumeMember` 5개 IPC + tmux detach (kill X, context 유지) |
| **머지 충돌 3-way diff 뷰** | 디자인 단계만 | `merge()` IPC + 충돌 시 `MergeConflictView` 풀스크린 모달 (3-column ours/merged/theirs + Use ours/theirs/Manual/Abort) |

## 4 커밋

| 커밋 | 영역 |
|---|---|
| `feat(teams): worktree + tmux 자동 spawn + pause/resume/merge IPC` | AgentTeamWatcher backend (W1) |
| `feat(teams): MergeConflict/MergeResult 타입 + store 액션 5개` | Glue layer (W3 partial) |
| `feat(teams): RunLiveView 컨트롤 wire + MergeConflictView + Wizard 옵션 설명` | UI (W2 + W3 polish) |
| `docs: 하네스 전체 아키텍처 단일 HTML 문서` | 12 섹션 + SVG 다이어그램 (`docs/harness-architecture.html`) |

## 핵심 흐름

### Wizard 4-step → 실제 팀
```
Wizard 결과 (members + isolated + squash)
  ↓
useAgentTeamStore.create()
  ↓
window.api.teams.create(opts)
  ↓
AgentTeamWatcher.create():
  1. teamId = team-<ts>-<rand>
  2. mkdir <wsPath>/.claude/teams/<teamId>/
  3. config.json 작성
  4. (isolated) git checkout -b team/<teamId>
  5. (isolated) 멤버마다:
       git worktree add -b team/<teamId>/<agent>
                       <teamRoot>/worktrees/<agent> team/<teamId>
  6. (tmux 가용) 멤버마다:
       tmux new-session -d -s forge-team-<teamId>-<agent>
                              -c <worktreePath>
       tmux send-keys 'claude' Enter   # autoStartClaude
       member.tmuxPaneId = '<session>:0.0'
  ↓
chokidar refresh + emit('change')
  ↓
Workspace Teams 섹션에 즉시 표시
  Toast: '회원가입 피처 팀 (5 members · 5 worktrees · 5 tmux 세션)'
```

### Pause/Resume
- **Pause All** (RunLiveView 컨트롤 바) → `teams:pause` → 모든 멤버 tmux `detach-client` (세션 살아있음, attach 끊김) + status='paused'
- **Resume All** → `teams:resume` → status='active' (tmux 는 어차피 detach 만 하면 됨)
- **멤버별 ⏸/▶** → `teams:pauseMember` / `resumeMember` → 단일 멤버 state 변경

### Merge
- **Merge 버튼** → 확인 다이얼로그 → `teams:merge`
- AgentTeamWatcher.merge():
  - `git checkout team/<teamId>`
  - 멤버 브랜치별 `merge --squash` 또는 `merge --no-ff`
  - 충돌 시 `git diff --diff-filter=U` 로 충돌 파일 추출 + conflict markers 60줄 prefix
  - `git merge --abort` + `MergeResult { ok: false, conflicts: [...] }` 반환
- 충돌 발견 시 RunLiveView 가 `MergeConflictView` 모달 띄움

### Remove (Cleanup)
- 각 멤버 `tmux kill-session`
- `git worktree remove --force` 각 멤버
- `git branch -D team/<teamId>/<agent>` + `team/<teamId>` 삭제
- config 디렉터리 제거
- 단계별 graceful — 실패해도 다음 단계 진행

## 보안 / Graceful Degradation

- **path traversal 방지**: `isPathInside(teamRoot, worktreePath)` 가드 + agentId 정규식 sanitize (`[^A-Za-z0-9_-]`)
- **git/tmux 미설치**: `hasGit()`/`hasTmux()` 사전 검사 → graceful skip, config 자체는 항상 작성
- **IPC 미존재**: store 액션이 `teamsApi()` guard + 옵셔널 체이닝, UI 가 `console.warn` + inline warn-notice 로 자동 fallback

## 문서

`docs/harness-architecture.html` 신규:
- 단일 HTML, 외부 의존성 0 (Google Fonts 만)
- 다크 테마 + Forge orange + JetBrains Mono
- 12 섹션, ~1100px 중앙정렬, 반응형
- SVG 다이어그램 8개 (3-tier / Hook sequence / Skill injection / Workspace 격리 / Wizard 흐름 / RunLiveView mockup / Stop hook chain 등)

## Test Plan

- [x] `npm run typecheck` — clean
- [ ] **워크스페이스 생성 → Wizard isolated 5명 → Start** → `<wsPath>/.claude/teams/<id>/worktrees/` 5개 디렉터리 생성 확인 + `tmux ls` 로 forge-team-* 5개 세션 확인
- [ ] RunLiveView 에서 Pause All → tmux detach 확인 → Resume All
- [ ] 멤버별 ⏸ 클릭 → state 변경, tmux 세션 자체는 그대로
- [ ] 의도적 충돌 만든 후 Merge → MergeConflictView 모달 + 3-column diff
- [ ] Manual resolve / Abort merge 버튼
- [ ] 팀 삭제 → worktree + tmux + 브랜치 모두 정리 확인
- [ ] git/tmux 없는 환경 (Docker 컨테이너 등) → create() 자체는 성공, worktree/tmux 효과 없음
- [ ] `docs/harness-architecture.html` 브라우저로 열어 확인

## 베이스
main (PR-A/B/C/D 모두 머지 완료된 v0.4.1 위)