### PR TITLE
feat: 0.5.1 — 필수 도구 사전 번들 + 워크스페이스 자동 활성화 + traffic light fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,13 @@ framework-agnostic-harness/
 build/*.iconset/
 
 .omc/
+
+# Bundled toolchain (tmux/uv/python/cr-graph-venv) — fetched at build time by
+# scripts/download-bundled-tools.sh + scripts/build-cr-graph-venv.sh. Each
+# binary tree is 30-100 MB so they do not belong in git; CI pulls them per
+# release. The directory itself is kept via .gitkeep so extraResources doesn't
+# fail on a clean checkout that hasn't run the download script yet.
+resources/bundled-tools/darwin-arm64/bin/
+resources/bundled-tools/darwin-arm64/python/
+resources/bundled-tools/darwin-arm64/cr-graph-venv/
+resources/bundled-tools/darwin-arm64/.download-stamp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] — 2026-05-08
+
+### Added — 필수 도구 사전 번들 (DMG +~90MB)
+- **tmux** — Agent Team isolated worktree 다중 세션용
+- **uv** — Astral Rust binary, Python 패키지 매니저
+- **Python 3.12 (standalone)** — python-build-standalone relocatable
+- **code-review-graph** — 번들 Python 으로 venv 사전 빌드, shebang portable
+- 사용자 설치 불필요 — 첫 실행부터 tmux/code-review-graph 즉시 동작.
+  미번들: Claude Code CLI (라이선스), git (Xcode CLT)
+
+### Added — 인프라
+- `electron/services/PathManager.ts` 신규 — 번들 도구 PATH 자동 prepend
+  (bundled > cr-graph-venv > python > 기존). 번들 미존재 시 graceful
+- `PtyManager.buildEnv()` 가 `pathManager.augmentEnv` 호출 — 사용자
+  spawn 셸도 번들 도구 보임
+- `CodeReviewGraphManager` — bundled 우선 감지, install() 은 번들 가용
+  시 no-op
+- `scripts/download-bundled-tools.sh` (idempotent fetcher) +
+  `scripts/build-cr-graph-venv.sh` (shebang portable rewrite)
+- electron-builder extraResources + after-pack chmod +x sweep 확장
+
+### Added — 워크스페이스 UX
+- **부팅 시 자동 활성화** — 등록된 ws 중 가장 최근 (lastOpened DESC)
+  자동 setActiveWorkspace. 매번 선택 불필요
+- **\"기존 폴더 열기\" 버튼** — empty state 에 신규. 시스템 폴더 picker
+  → openWorkspace 호출 → `.claude/` 자동 감지 + 등록
+- **\"Recent workspaces\" 카드** — empty state 최대 6개, 클릭 시 즉시 active
+
+### Changed — Onboarding
+- Step 2 의존성 체크 — 번들 도구는 \"번들됨\" Pill 표시, Install 버튼 X
+
+### Migration
+DMG ~134MB → ~220MB. 첫 실행 시 번들 도구 자동 PATH 추가, 별도 설정 불필요.
+
 ## [0.5.0] — 2026-05-08
 
 팀 시스템 풀 자동화 + 하네스 저작 GUI 첫 단계 + 다중 프리셋 + 첫 실행

--- a/README.ko.md
+++ b/README.ko.md
@@ -178,9 +178,30 @@ npm run electron:build       # → release/Forge Studio-<version>-arm64.dmg
 
 ### 요구 사항
 
-- macOS 12+ (Apple Silicon 또는 Intel)
-- Node 20+
-- Xcode Command Line Tools (네이티브 node-pty 리빌드용)
+- macOS 12+ (Apple Silicon — 번들 빌드는 arm64 전용)
+- Node 20+ (소스 빌드 시)
+- Xcode Command Line Tools (`git` + 네이티브 node-pty 리빌드)
+- [Claude Code CLI](https://docs.claude.com/claude-code) — Anthropic 공식
+  가이드를 따라 별도 설치. 잦은 업데이트 + 라이선스 문제로 번들에 포함하지 않음.
+
+그 외 도구는 DMG 안에 모두 번들되어 있습니다 (아래 "번들 도구" 섹션 참고).
+
+### 번들 도구
+
+v0.5.1 부터 DMG 안에 자체 완결된 바이너리 툴체인이 들어 있어서, 깨끗한 macOS
+설치 환경에서도 별도 세팅 없이 Agent Team / code-review-graph 를 즉시 사용할
+수 있습니다. 번들로 ~85 MB 압축 추가됩니다 (DMG ~134 MB → ~220 MB).
+
+| 도구 | 용도 | 출처 |
+|---|---|---|
+| `tmux` | Agent Team 격리 워크트리 멀티 페인 백엔드 | Homebrew bottle (~1 MB) |
+| `uv` | Python 패키지 매니저 (code-review-graph 내부에서 사용) | astral-sh/uv release (~10 MB) |
+| `python` 3.12 | cr-graph 전용 standalone 인터프리터 | indygreg/python-build-standalone (~80 MB 풀린 용량) |
+| `code-review-graph` | 저장소 의존성 + 호출 그래프 시각화 | 번들 python 위에 미리 빌드된 venv (~50 MB) |
+
+번들된 바이너리는 `Contents/Resources/bundled-tools/` 에 위치하며, Forge 가
+모든 spawn 셸의 `PATH` 앞에 추가하기 때문에 사용자 터미널에서도
+`tmux` / `uv` / `code-review-graph` 가 그대로 보입니다 (`brew install` 불필요).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -171,9 +171,30 @@ npm run electron:build       # → release/Forge Studio-<version>-arm64.dmg
 ```
 
 ### Requirements
-- macOS 12+ (Apple Silicon or Intel)
-- Node 20+
-- Xcode Command Line Tools (for the native node-pty rebuild)
+- macOS 12+ (Apple Silicon — arm64 only for the bundled tools build)
+- Node 20+ (for source builds)
+- Xcode Command Line Tools (provides `git` and the native node-pty rebuild)
+- [Claude Code CLI](https://docs.claude.com/claude-code) — install separately,
+  Anthropic ships frequent updates and the license forbids redistribution.
+
+Everything else is bundled inside the DMG (see "Bundled tools" below).
+
+### Bundled tools
+
+Starting v0.5.1 the DMG ships a self-contained binary toolchain so a clean
+macOS install can run Agent Teams and code-review-graph without any extra
+setup. The bundle adds ~85 MB compressed (DMG goes from ~134 MB → ~220 MB).
+
+| Tool | Purpose | Source |
+|---|---|---|
+| `tmux` | Multi-pane backend for Agent Team isolated worktrees | Homebrew bottle (~1 MB) |
+| `uv` | Python package manager (used by code-review-graph internals) | astral-sh/uv release (~10 MB) |
+| `python` 3.12 | Standalone interpreter for the cr-graph venv | indygreg/python-build-standalone (~80 MB unpacked) |
+| `code-review-graph` | Repo dependency + call-graph visualizer | Pre-built venv on top of the bundled python (~50 MB) |
+
+The bundled binaries live at `Contents/Resources/bundled-tools/` and Forge
+prepends them to `PATH` for every spawned shell, so user terminals also see
+`tmux` / `uv` / `code-review-graph` without any `brew install` step.
 
 ---
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import { AgentTeamWatcher } from './services/AgentTeamWatcher'
 import { FsManager, type FsListOpts } from './services/FsManager'
 import { CodeReviewGraphManager, type InstallMethod } from './services/CodeReviewGraphManager'
 import { HookProfiler } from './services/HookProfiler'
+import { pathManager } from './services/PathManager'
 
 const execFileAsync = promisify(execFile)
 
@@ -808,13 +809,42 @@ ipcMain.handle('system:which', async (_event, cmd: string) => {
   if (!cmd || typeof cmd !== 'string' || !/^[a-zA-Z0-9_.-]+$/.test(cmd)) {
     return null
   }
+  // Bundled tools take priority over PATH lookup so the onboarding "where is
+  // tmux?" probe always points at the DMG-shipped binary on a default install.
+  // Otherwise a user with their own homebrew tmux would resolve there even
+  // though every internal spawn uses the bundled path.
+  if (cmd === 'tmux') {
+    const bundled = pathManager.getTmux()
+    if (bundled) return bundled
+  } else if (cmd === 'uv') {
+    const bundled = pathManager.getUv()
+    if (bundled) return bundled
+  } else if (cmd === 'code-review-graph') {
+    const bundled = pathManager.getCrGraphCli()
+    if (bundled) return bundled
+  } else if (cmd === 'python3' || cmd === 'python3.12') {
+    const bundled = pathManager.getPython()
+    if (bundled) return bundled
+  }
   try {
-    const { stdout } = await execFileAsync('which', [cmd], { encoding: 'utf-8', timeout: 3000 })
+    const { stdout } = await execFileAsync('which', [cmd], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      env: pathManager.augmentEnv({ ...process.env }),
+    })
     return stdout.trim()
   } catch {
     return null
   }
 })
+
+/**
+ * Surface the absolute path of the bundled-tools root so the renderer can
+ * detect whether a resolved binary was shipped inside the DMG. Returns null
+ * when no bundle is present (dev tree without `npm run bundle:tools` or a
+ * non-arm64 build).
+ */
+ipcMain.handle('system:bundledToolsRoot', () => pathManager.getBundledToolsRoot())
 
 // ─── IPC Handlers: Updates ──────────────────────────────────────────
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -464,6 +464,14 @@ const api = {
       ipcRenderer.invoke('system:getTheme'),
     which: (cmd: string) =>
       ipcRenderer.invoke('system:which', cmd),
+    /**
+     * Absolute path of the bundled-tools root (Contents/Resources/bundled-tools
+     * in a packaged app, resources/bundled-tools/darwin-arm64 in dev), or
+     * `null` when the bundle isn't present. Onboarding uses this to decide
+     * whether a `which` hit lives inside the DMG (→ "Bundled" pill).
+     */
+    bundledToolsRoot: () =>
+      ipcRenderer.invoke('system:bundledToolsRoot') as Promise<string | null>,
   },
 
   // ─── Events ──────────────────────────────────────────────────────

--- a/electron/services/CodeReviewGraphManager.ts
+++ b/electron/services/CodeReviewGraphManager.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import os from 'os'
 import net from 'net'
+import { pathManager } from './PathManager'
 
 const execFileAsync = promisify(execFile)
 
@@ -21,7 +22,7 @@ const execFileAsync = promisify(execFile)
  * throw across the IPC boundary unless the input is invalid.
  */
 
-export type InstallMethod = 'pipx' | 'pip' | 'uv'
+export type InstallMethod = 'pipx' | 'pip' | 'uv' | 'bundled'
 
 export interface InstallStatus {
   installed: boolean
@@ -58,7 +59,9 @@ export interface VizHandle {
  * misses Homebrew, pyenv, pipx, uv, etc. Mirror the augmentation
  * HarnessScanner uses so `which code-review-graph` actually finds binaries
  * installed via `pipx install` (`~/.local/bin`) or `uv tool install`
- * (`~/.local/bin` as well).
+ * (`~/.local/bin` as well). On top of that, pathManager.augmentEnv prepends
+ * the *bundled* tools directories so the DMG-shipped cr-graph venv always
+ * wins over an out-of-date user install.
  */
 function augmentedPathEnv(): NodeJS.ProcessEnv {
   const basePath = process.env.PATH || ''
@@ -71,11 +74,21 @@ function augmentedPathEnv(): NodeJS.ProcessEnv {
     extras.push(`${home}/.local/bin`, `${home}/.cargo/bin`)
   }
   const augmented = [...extras, basePath].filter(Boolean).join(path.delimiter)
-  return { ...process.env, PATH: augmented }
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: augmented }
+  return pathManager.augmentEnv(env)
 }
 
-const CLI = 'code-review-graph'
+const CLI_NAME = 'code-review-graph'
 const WHICH = os.platform() === 'win32' ? 'where' : 'which'
+
+/**
+ * Resolve the code-review-graph CLI to spawn. Returns the bundled venv's
+ * absolute path when present (no PATH gymnastics needed), else falls back to
+ * the bare command name and lets the augmented PATH find it.
+ */
+function resolveCli(): string {
+  return pathManager.getCrGraphCli() ?? CLI_NAME
+}
 
 /** Pick a free port in [3000, 9000) to avoid stomping on common dev servers. */
 async function pickFreePort(): Promise<number> {
@@ -104,16 +117,42 @@ export class CodeReviewGraphManager {
   private vizProcs = new Map<number, ChildProcess>()
 
   /**
-   * Probe `code-review-graph --version`. If the CLI is missing, return
-   * `installed: false`. The `method` field is best-effort: we look at the
-   * resolved binary path to guess pipx (`/pipx/`) or uv (`/uv/`) — otherwise
-   * fall back to `pip`.
+   * Probe `code-review-graph --version`. Resolution priority:
+   *   1. Bundled venv (DMG ships a pre-built cr-graph) → method: 'bundled'.
+   *   2. PATH lookup via `which`. The `method` field is best-effort: pipx
+   *      (`/pipx/`) or uv (`/uv/`) — otherwise fall back to `pip`.
+   *
+   * Falls through to `installed: false` only when neither (1) nor (2) yields
+   * an executable.
    */
   async isInstalled(): Promise<InstallStatus> {
     const env = augmentedPathEnv()
+
+    // 1. Bundled CLI takes precedence — no PATH lookup, no possibility of a
+    // user pipx install drifting out of sync with the version we tested.
+    const bundled = pathManager.getCrGraphCli()
+    if (bundled) {
+      let version: string | undefined
+      try {
+        const { stdout } = await execFileAsync(bundled, ['--version'], {
+          encoding: 'utf-8',
+          timeout: 5000,
+          env,
+        })
+        version = stdout.trim() || undefined
+      } catch {
+        // The venv exists but invoking it failed (corrupted shebang, missing
+        // shared lib, etc.). Still report installed:true — a rebuild is the
+        // right user action, and re-installing on top of a broken bundle is
+        // a worse experience.
+      }
+      return { installed: true, version, method: 'bundled' }
+    }
+
+    // 2. PATH-based discovery (legacy / non-bundled hosts).
     let resolvedPath: string | null = null
     try {
-      const { stdout } = await execFileAsync(WHICH, [CLI], {
+      const { stdout } = await execFileAsync(WHICH, [CLI_NAME], {
         encoding: 'utf-8',
         timeout: 3000,
         env,
@@ -125,7 +164,7 @@ export class CodeReviewGraphManager {
 
     let version: string | undefined
     try {
-      const { stdout } = await execFileAsync(CLI, ['--version'], {
+      const { stdout } = await execFileAsync(CLI_NAME, ['--version'], {
         encoding: 'utf-8',
         timeout: 5000,
         env,
@@ -150,14 +189,41 @@ export class CodeReviewGraphManager {
    * Install the CLI. When `method` is omitted, auto-pick the best installer
    * present on PATH (pipx > uv > pip). All variants stream stdout+stderr
    * back so the UI can show the install log.
+   *
+   * Bundled fast-path: if the DMG already shipped a working cr-graph venv
+   * we no-op with a friendly message instead of running an installer the
+   * user doesn't have. This means a user on a bare macOS install (no pipx,
+   * no uv, no pip) can still hit the "Install" button and get a green
+   * checkmark because the bundle is already in place.
    */
   async install(method?: InstallMethod): Promise<InstallResult> {
     const env = augmentedPathEnv()
+
+    if (!method && pathManager.getCrGraphCli()) {
+      return {
+        ok: true,
+        output: 'code-review-graph is bundled with Forge Studio — no install needed.',
+      }
+    }
+
     const chosen = method ?? (await this.pickInstallMethod(env))
     if (!chosen) {
       return {
         ok: false,
         output: 'No installer found. Install pipx, uv, or pip first (https://pipx.pypa.io).',
+      }
+    }
+
+    if (chosen === 'bundled') {
+      // Caller explicitly asked for the bundled method. Honour it iff the
+      // bundle is actually present; otherwise fail loudly so the UI can fall
+      // back to a real installer.
+      if (pathManager.getCrGraphCli()) {
+        return { ok: true, output: 'Using bundled code-review-graph.' }
+      }
+      return {
+        ok: false,
+        output: 'Bundled code-review-graph is not available in this build.',
       }
     }
 
@@ -194,11 +260,12 @@ export class CodeReviewGraphManager {
     }
 
     const env = augmentedPathEnv()
+    const cli = resolveCli()
     const start = Date.now()
     return new Promise<BuildResult>((resolve) => {
       let proc: ChildProcess
       try {
-        proc = spawn(CLI, ['build'], { cwd: workspacePath, env })
+        proc = spawn(cli, ['build'], { cwd: workspacePath, env })
       } catch (err) {
         resolve({ ok: false, durationMs: 0, output: (err as Error).message })
         return
@@ -244,8 +311,9 @@ export class CodeReviewGraphManager {
     if (!(await fs.pathExists(workspacePath))) return null
 
     const env = augmentedPathEnv()
+    const cli = resolveCli()
     try {
-      const { stdout } = await execFileAsync(CLI, ['stats', '--json'], {
+      const { stdout } = await execFileAsync(cli, ['stats', '--json'], {
         cwd: workspacePath,
         encoding: 'utf-8',
         timeout: 30 * 1000,
@@ -289,9 +357,10 @@ export class CodeReviewGraphManager {
     }
 
     const env = augmentedPathEnv()
+    const cli = resolveCli()
     const startPort = port && port > 0 ? port : await pickFreePort()
 
-    const proc = spawn(CLI, ['viz', '--port', String(startPort), '--no-open'], {
+    const proc = spawn(cli, ['viz', '--port', String(startPort), '--no-open'], {
       cwd: workspacePath,
       env,
       detached: false,
@@ -377,6 +446,11 @@ export class CodeReviewGraphManager {
       case 'pip':
         // Prefer `pip3 install --user` to avoid touching the system Python.
         return ['pip3', ['install', '--user', 'code-review-graph']]
+      case 'bundled':
+        // The bundled fast-path is handled inline in `install()` before we
+        // reach this method — this branch only exists to satisfy the
+        // exhaustiveness check and surface a programming error if hit.
+        throw new Error('installCommand: "bundled" must be handled by install() directly')
     }
   }
 

--- a/electron/services/PathManager.ts
+++ b/electron/services/PathManager.ts
@@ -1,0 +1,163 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
+import { app } from 'electron'
+
+/**
+ * PathManager — single source of truth for locating the *bundled* toolchain
+ * that ships inside the Forge Studio DMG (tmux, uv, python-build-standalone,
+ * and the pre-built code-review-graph venv).
+ *
+ * Why a service:
+ *   - The packaged path (`process.resourcesPath/bundled-tools/`) and the dev
+ *     path (`<repo>/resources/bundled-tools/darwin-arm64/`) differ.
+ *   - Multiple managers (PtyManager, CodeReviewGraphManager, AgentTeamWatcher's
+ *     tmux callers) all need to (a) find specific bundled binaries and
+ *     (b) prepend the bundle bin/ directories to PATH so users' own shells
+ *     also see the tools.
+ *   - Centralizing the path-resolution lets each tool fall back gracefully:
+ *     bundled-first, then user-installed (Homebrew / pipx / uv / cargo).
+ *
+ * macOS arm64 is the only build target right now (see README + package.json).
+ * The platform-folder ('darwin-arm64') is hard-coded; when we add x64 / Linux
+ * we'll swap that to a runtime lookup keyed on process.platform + process.arch.
+ */
+export class PathManager {
+  /** Resolved root, computed lazily and memoised. `null` when no bundle was shipped. */
+  private rootCache: string | null | undefined = undefined
+
+  /**
+   * Absolute path to `resources/bundled-tools/darwin-arm64/` in dev or
+   * `Contents/Resources/bundled-tools/` in a packaged build.
+   *
+   * Returns `null` if the directory is absent (developer hasn't run
+   * `scripts/download-bundled-tools.sh` yet, or running on an unsupported
+   * platform). All callers MUST handle null and fall back to PATH-based
+   * lookup so Forge stays usable on hosts without the pre-bundle.
+   */
+  getBundledToolsRoot(): string | null {
+    if (this.rootCache !== undefined) return this.rootCache
+
+    if (os.platform() !== 'darwin' || os.arch() !== 'arm64') {
+      this.rootCache = null
+      return null
+    }
+
+    const candidate = app.isPackaged
+      ? path.join(process.resourcesPath, 'bundled-tools')
+      : path.resolve(__dirname, '..', '..', 'resources', 'bundled-tools', 'darwin-arm64')
+
+    if (!fs.existsSync(candidate)) {
+      this.rootCache = null
+      return null
+    }
+    this.rootCache = candidate
+    return candidate
+  }
+
+  /** Absolute path to bundled tmux binary, or null if not bundled. */
+  getTmux(): string | null {
+    return this.binIfExecutable('bin/tmux')
+  }
+
+  /** Absolute path to bundled uv binary, or null if not bundled. */
+  getUv(): string | null {
+    return this.binIfExecutable('bin/uv')
+  }
+
+  /**
+   * Absolute path to the bundled Python interpreter, or null if not bundled.
+   * Prefers `python3.12` (the pinned version) but falls back to `python3` for
+   * future-proofing.
+   */
+  getPython(): string | null {
+    const root = this.getBundledToolsRoot()
+    if (!root) return null
+    for (const rel of ['python/bin/python3.12', 'python/bin/python3']) {
+      const p = path.join(root, rel)
+      if (this.isExecutable(p)) return p
+    }
+    return null
+  }
+
+  /**
+   * Absolute path to the pre-built code-review-graph CLI inside the bundled
+   * venv, or null if the venv is missing. Use this as the *first* resolver
+   * in CodeReviewGraphManager.isInstalled — falling back to PATH only when
+   * the bundle is absent.
+   */
+  getCrGraphCli(): string | null {
+    return this.binIfExecutable('cr-graph-venv/bin/code-review-graph')
+  }
+
+  /**
+   * Augment a `PATH`-bearing env so child processes can resolve every bundled
+   * binary by name. Order matters: bundled bin > cr-graph venv bin > python
+   * bin > the original PATH. This way a user with their own homebrew tmux
+   * still gets the bundled one (predictability), and the cr-graph venv's
+   * `python` shim takes precedence over the system interpreter for any
+   * `code-review-graph` subshell.
+   */
+  augmentEnv<E extends NodeJS.ProcessEnv>(env: E): E {
+    const root = this.getBundledToolsRoot()
+    if (!root) return env
+
+    const prepend: string[] = []
+    const tryAdd = (rel: string) => {
+      const dir = path.join(root, rel)
+      if (fs.existsSync(dir)) prepend.push(dir)
+    }
+    tryAdd('bin')
+    tryAdd('cr-graph-venv/bin')
+    tryAdd('python/bin')
+
+    if (prepend.length === 0) return env
+
+    const basePath = env.PATH || process.env.PATH || ''
+    const merged = [...prepend, basePath].filter(Boolean).join(path.delimiter)
+    return { ...env, PATH: merged }
+  }
+
+  /**
+   * Returns the version stamp written by scripts/download-bundled-tools.sh,
+   * or null if the bundle is absent. Useful for the Settings panel + crash
+   * reports — lets us tell whether a user is running with the pre-bundled
+   * toolchain or fell back to PATH discovery.
+   */
+  getStampInfo(): { path: string; raw: string } | null {
+    const root = this.getBundledToolsRoot()
+    if (!root) return null
+    const stampPath = path.join(root, '.download-stamp.json')
+    try {
+      const raw = fs.readFileSync(stampPath, 'utf-8')
+      return { path: stampPath, raw }
+    } catch {
+      return null
+    }
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────
+
+  private binIfExecutable(rel: string): string | null {
+    const root = this.getBundledToolsRoot()
+    if (!root) return null
+    const p = path.join(root, rel)
+    return this.isExecutable(p) ? p : null
+  }
+
+  private isExecutable(p: string): boolean {
+    try {
+      fs.accessSync(p, fs.constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+/**
+ * Single shared instance — every manager that needs bundled-tools awareness
+ * imports `pathManager` instead of constructing its own. Keeps the cache
+ * coherent across services.
+ */
+export const pathManager = new PathManager()

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -2,6 +2,7 @@ import * as pty from 'node-pty'
 import { v4 as uuid } from 'uuid'
 import os from 'os'
 import { execFileSync } from 'child_process'
+import { pathManager } from './PathManager'
 
 interface PtyInstance {
   process: pty.IPty
@@ -20,12 +21,15 @@ export class PtyManager {
 
   private buildEnv(): Record<string, string> {
     // GUI-launched apps on macOS often miss /opt/homebrew/bin and /usr/local/bin
-    // in PATH, breaking rbenv/nvm/pyenv/fvm/etc. Prepend them on darwin.
+    // in PATH, breaking rbenv/nvm/pyenv/fvm/etc. Prepend them on darwin. Then
+    // pathManager.augmentEnv prepends our bundled bin/cr-graph-venv/python so
+    // tmux/uv/code-review-graph resolve from the DMG without a separate user
+    // install. Order: bundled > brew/local > inherited PATH.
     const basePath = process.env.PATH || ''
     const augmentedPath = os.platform() === 'darwin'
       ? ['/opt/homebrew/bin', '/usr/local/bin', basePath].filter(Boolean).join(':')
       : basePath
-    return {
+    const baseEnv: Record<string, string> = {
       ...process.env,
       PATH: augmentedPath,
       TERM: 'xterm-256color',
@@ -33,6 +37,7 @@ export class PtyManager {
       TERM_PROGRAM: 'ForgeStudio',
       LANG: process.env.LANG || 'en_US.UTF-8',
     } as Record<string, string>
+    return pathManager.augmentEnv(baseEnv)
   }
 
   create(options: { cols: number; rows: number; cwd: string; shell?: string }): string {
@@ -69,10 +74,15 @@ export class PtyManager {
       throw new Error(`Invalid tmux target: ${options.paneId}`)
     }
     const id = uuid()
+    // Resolve tmux from the bundled toolchain when available so users on a
+    // bare macOS install (no Homebrew) still get a working agent-team backend.
+    // Falls back to plain `tmux` (resolved via PATH) when running an older
+    // build or when the bundle is absent.
+    const tmuxBin = pathManager.getTmux() ?? 'tmux'
     // select-pane then attach-session: `-t <pane-id>` on attach resolves the
     // pane's session automatically. The select-pane focuses the right pane so
     // the user sees that agent's output, not whatever was last viewed.
-    const cmd = `tmux select-pane -t ${options.paneId} 2>/dev/null; exec tmux attach-session -t ${options.paneId}`
+    const cmd = `'${tmuxBin}' select-pane -t ${options.paneId} 2>/dev/null; exec '${tmuxBin}' attach-session -t ${options.paneId}`
     const ptyProcess = pty.spawn('/bin/sh', ['-c', cmd], {
       name: 'xterm-256color',
       cols: options.cols,

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "preview": "vite preview",
     "electron:dev": "vite",
     "sync-harness": "bash scripts/sync-harness.sh",
-    "electron:build": "npm run sync-harness && npm run build:renderer && electron-builder",
-    "release:dmg": "npm run build:renderer && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg zip --arm64 -c.mac.identity=null",
+    "bundle:tools": "bash scripts/download-bundled-tools.sh && bash scripts/build-cr-graph-venv.sh",
+    "electron:build": "npm run sync-harness && npm run bundle:tools && npm run build:renderer && electron-builder",
+    "release:dmg": "npm run bundle:tools && npm run build:renderer && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg zip --arm64 -c.mac.identity=null",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"electron/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"electron/**/*.ts\"",
@@ -86,6 +87,11 @@
         "from": "resources/harness-template",
         "to": "harness-template",
         "filter": ["**/*", "!.pdca-*", "!settings.local.json"]
+      },
+      {
+        "from": "resources/bundled-tools/darwin-arm64",
+        "to": "bundled-tools",
+        "filter": ["**/*", "!.gitkeep"]
       }
     ],
     "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/resources/bundled-tools/README.md
+++ b/resources/bundled-tools/README.md
@@ -1,0 +1,54 @@
+# resources/bundled-tools/
+
+Pre-bundled binary toolchain shipped inside the Forge Studio DMG so users can
+run Agent Teams (tmux), Python tools (uv + standalone python), and
+`code-review-graph` without installing anything themselves.
+
+This directory is **not** checked into git — its contents are populated by:
+
+```bash
+bash scripts/download-bundled-tools.sh   # tmux + uv + python
+bash scripts/build-cr-graph-venv.sh      # cr-graph venv on top of bundled python
+```
+
+`npm run electron:build` and `npm run release:dmg` invoke both scripts before
+electron-builder runs, so a clean DMG build only needs:
+
+```bash
+npm install
+npm run electron:build
+```
+
+## Layout (after running the scripts)
+
+```
+resources/bundled-tools/
+└── darwin-arm64/
+    ├── .download-stamp.json        # versions + sha256 sums
+    ├── bin/
+    │   ├── tmux                    # ~1 MB — copied from `brew --prefix tmux`
+    │   └── uv                      # ~10 MB — astral-sh/uv release
+    ├── python/                     # ~80 MB — python-build-standalone 3.12
+    │   ├── bin/python3.12
+    │   ├── lib/...
+    │   └── ...
+    └── cr-graph-venv/              # ~50 MB — pip-installed code-review-graph
+        ├── bin/code-review-graph
+        ├── bin/python -> ../../python/bin/python3.12   (or copy)
+        └── lib/python3.12/site-packages/code_review_graph/...
+```
+
+Total adds **~140 MB unpacked → ~85 MB compressed** to the DMG.
+
+## Targets
+
+Currently `darwin-arm64` only. Adding `darwin-x64` / `linux-x64` support means:
+
+1. Adding the platform's matching tarball URLs to `download-bundled-tools.sh`.
+2. Branching the `extraResources` block in `package.json` per `process.platform`.
+3. Updating `electron/services/PathManager.ts` to pick the right sub-folder.
+
+## Re-running
+
+Both scripts are idempotent — they write a stamp file and skip on re-run.
+Force a refresh with `FORCE=1 bash scripts/download-bundled-tools.sh`.

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -26,6 +26,50 @@ exports.default = async ({ appOutDir, packager, electronPlatformName }) => {
     }
   }
 
+  // 1b. Re-stamp the bundled toolchain (tmux / uv / python / cr-graph venv)
+  //     with executable bits. extraResources ships the contents into
+  //     Contents/Resources/bundled-tools/ but the tar+copy pipeline can drop
+  //     the +x bit on individual binaries — explicitly setting 0o755 on every
+  //     known entrypoint avoids spawn failures at runtime.
+  const bundledRoot = path.join(appPath, 'Contents/Resources/bundled-tools')
+  if (fs.existsSync(bundledRoot)) {
+    // Specific top-level binaries we know about. The recursive sweep below
+    // picks up everything else inside python/bin and cr-graph-venv/bin.
+    const explicit = [
+      path.join(bundledRoot, 'bin/tmux'),
+      path.join(bundledRoot, 'bin/uv'),
+    ]
+    for (const bin of explicit) {
+      if (fs.existsSync(bin)) {
+        fs.chmodSync(bin, 0o755)
+        console.log(`[after-pack] chmod +x ${bin}`)
+      }
+    }
+    // Walk every */bin directory and chmod regular files. python-build-
+    // standalone ships several entry points (python3, python3.12, pip, etc.)
+    // and the cr-graph venv adds code-review-graph + activate scripts.
+    const binDirs = [
+      path.join(bundledRoot, 'python/bin'),
+      path.join(bundledRoot, 'cr-graph-venv/bin'),
+    ]
+    for (const dir of binDirs) {
+      if (!fs.existsSync(dir)) continue
+      for (const name of fs.readdirSync(dir)) {
+        const p = path.join(dir, name)
+        try {
+          const stat = fs.lstatSync(p)
+          // Only chmod regular files — skip symlinks (they inherit) and dirs.
+          if (stat.isFile()) {
+            fs.chmodSync(p, 0o755)
+          }
+        } catch (err) {
+          console.warn(`[after-pack] chmod failed for ${p}: ${err.message}`)
+        }
+      }
+      console.log(`[after-pack] chmod +x ${dir}/*`)
+    }
+  }
+
   // 2. Ad-hoc codesign the bundle when no Developer ID is in play.
   //    Apple Silicon dyld refuses to load entirely-unsigned native modules,
   //    and macOS Sequoia surfaces the failure as the dreaded

--- a/scripts/build-cr-graph-venv.sh
+++ b/scripts/build-cr-graph-venv.sh
@@ -64,20 +64,22 @@ if [[ -d "${VENV_DIR}" ]]; then
 fi
 
 # ─── Create venv ─────────────────────────────────────────────────────────
-# `--copies` makes the venv self-contained (no symlinks back into the bundled
-# python tree). After the DMG is assembled, the cr-graph-venv folder ends up
-# under Contents/Resources/bundled-tools/cr-graph-venv next to ../python/, so
-# even with copies the relative shebang still works because we explicitly
-# rewrite the shebangs below.
-echo "[cr-graph-venv] creating venv with ${PYTHON_BIN}..."
-"${PYTHON_BIN}" -m venv --copies "${VENV_DIR}"
-
-# Upgrade pip first so resolve is fast + uses modern wheel cache layout.
-"${VENV_DIR}/bin/python" -m pip install --upgrade pip wheel >/dev/null
-
-# ─── Install code-review-graph ───────────────────────────────────────────
-echo "[cr-graph-venv] installing code-review-graph..."
-"${VENV_DIR}/bin/python" -m pip install --no-cache-dir code-review-graph
+# python-build-standalone 의 ensurepip 가 macOS arm64 에서 종종 SIGABRT
+# 로 죽는 알려진 이슈가 있어 (codesigning + Frameworks 경로) bundled uv
+# 로 venv 생성한다. uv 는 자체적으로 pip 를 부트스트랩하므로 ensurepip
+# 미사용. uv 가 없으면 (다운로드 실패) python venv fallback.
+UV_BIN="${TOOLS_DIR}/bin/uv"
+if [[ -x "${UV_BIN}" ]]; then
+  echo "[cr-graph-venv] creating venv with ${UV_BIN} (python: ${PYTHON_BIN})..."
+  "${UV_BIN}" venv --python "${PYTHON_BIN}" "${VENV_DIR}"
+  echo "[cr-graph-venv] installing code-review-graph via uv pip..."
+  "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" code-review-graph
+else
+  echo "[cr-graph-venv] uv 없음 — python venv fallback (ensurepip 사용)..."
+  "${PYTHON_BIN}" -m venv --copies "${VENV_DIR}"
+  "${VENV_DIR}/bin/python" -m pip install --upgrade pip wheel >/dev/null
+  "${VENV_DIR}/bin/python" -m pip install --no-cache-dir code-review-graph
+fi
 
 # ─── Verify ──────────────────────────────────────────────────────────────
 if ! "${VENV_DIR}/bin/code-review-graph" --version >/dev/null 2>&1; then

--- a/scripts/build-cr-graph-venv.sh
+++ b/scripts/build-cr-graph-venv.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# build-cr-graph-venv.sh
+#
+# Pre-builds an isolated venv (using the bundled python-build-standalone
+# interpreter) and pip-installs `code-review-graph` inside it so the DMG
+# ships with the CLI ready to run.
+#
+# Output:
+#   resources/bundled-tools/darwin-arm64/cr-graph-venv/
+#     bin/python                (symlink → ../../python/bin/python3.12)
+#     bin/code-review-graph     (entrypoint, shebang → bundled python)
+#     lib/python3.12/site-packages/code_review_graph/...
+#
+# Idempotent: if the venv already exists and `code-review-graph --version`
+# resolves, we skip the install. Pass `FORCE=1` to rebuild from scratch.
+#
+# Pre-requisite: scripts/download-bundled-tools.sh has already populated
+# resources/bundled-tools/darwin-arm64/python/bin/python3.12. If that path is
+# missing we exit non-zero so the build pipeline fails loudly rather than
+# silently producing a DMG without a working code-review-graph.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TOOLS_DIR="${ROOT_DIR}/resources/bundled-tools/darwin-arm64"
+PYTHON_BIN="${TOOLS_DIR}/python/bin/python3.12"
+VENV_DIR="${TOOLS_DIR}/cr-graph-venv"
+
+# ─── Platform guard: the venv's Python is darwin-arm64 — refusing to build
+#     on a non-arm64 host avoids a corrupt cross-platform venv shipping in
+#     the DMG. CI must run this on the same arm64 runner that downloaded the
+#     standalone interpreter.
+PLATFORM="$(uname -s)"
+ARCH="$(uname -m)"
+if [[ "${PLATFORM}" != "Darwin" || "${ARCH}" != "arm64" ]]; then
+  echo "[cr-graph-venv] non-darwin-arm64 host (${PLATFORM}/${ARCH}); skipping."
+  exit 0
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  # Fallback: the standalone tarball ships python3 (versioned) too.
+  PYTHON_BIN="${TOOLS_DIR}/python/bin/python3"
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "[cr-graph-venv] ERROR: bundled python not found." >&2
+  echo "[cr-graph-venv] run scripts/download-bundled-tools.sh first." >&2
+  exit 1
+fi
+
+# ─── Skip-if-fresh ───────────────────────────────────────────────────────
+if [[ "${FORCE:-0}" != "1" \
+   && -x "${VENV_DIR}/bin/code-review-graph" \
+   && -x "${VENV_DIR}/bin/python" ]]; then
+  if "${VENV_DIR}/bin/code-review-graph" --version >/dev/null 2>&1; then
+    echo "[cr-graph-venv] existing venv at ${VENV_DIR} works — skipping."
+    exit 0
+  fi
+fi
+
+if [[ -d "${VENV_DIR}" ]]; then
+  echo "[cr-graph-venv] removing stale venv at ${VENV_DIR}..."
+  rm -rf "${VENV_DIR}"
+fi
+
+# ─── Create venv ─────────────────────────────────────────────────────────
+# `--copies` makes the venv self-contained (no symlinks back into the bundled
+# python tree). After the DMG is assembled, the cr-graph-venv folder ends up
+# under Contents/Resources/bundled-tools/cr-graph-venv next to ../python/, so
+# even with copies the relative shebang still works because we explicitly
+# rewrite the shebangs below.
+echo "[cr-graph-venv] creating venv with ${PYTHON_BIN}..."
+"${PYTHON_BIN}" -m venv --copies "${VENV_DIR}"
+
+# Upgrade pip first so resolve is fast + uses modern wheel cache layout.
+"${VENV_DIR}/bin/python" -m pip install --upgrade pip wheel >/dev/null
+
+# ─── Install code-review-graph ───────────────────────────────────────────
+echo "[cr-graph-venv] installing code-review-graph..."
+"${VENV_DIR}/bin/python" -m pip install --no-cache-dir code-review-graph
+
+# ─── Verify ──────────────────────────────────────────────────────────────
+if ! "${VENV_DIR}/bin/code-review-graph" --version >/dev/null 2>&1; then
+  echo "[cr-graph-venv] ERROR: code-review-graph CLI did not install correctly." >&2
+  exit 1
+fi
+
+# ─── Rewrite shebangs to a portable form ─────────────────────────────────
+# `python -m venv` bakes the absolute path of PYTHON_BIN into every console
+# script (e.g. `#!/Users/.../resources/bundled-tools/darwin-arm64/python/bin/python3.12`).
+# That path is wrong inside the packaged DMG (Resources/bundled-tools/...),
+# so we replace it with `/usr/bin/env python` + a wrapper. PathManager will
+# spawn the CLI with PATH augmented to put cr-graph-venv/bin and python/bin
+# first, so `env python` resolves to the bundled interpreter at runtime.
+python3 - "${VENV_DIR}" <<'PY'
+import os, sys, stat
+venv = sys.argv[1]
+bin_dir = os.path.join(venv, "bin")
+for name in os.listdir(bin_dir):
+    p = os.path.join(bin_dir, name)
+    if os.path.islink(p) or not os.path.isfile(p):
+        continue
+    try:
+        with open(p, "rb") as f:
+            head = f.read(2)
+        if head != b"#!":
+            continue
+        with open(p, "rb") as f:
+            data = f.read()
+        first_nl = data.find(b"\n")
+        if first_nl == -1:
+            continue
+        # Replace any baked python path with /usr/bin/env python
+        new_shebang = b"#!/usr/bin/env python"
+        with open(p, "wb") as f:
+            f.write(new_shebang + data[first_nl:])
+        os.chmod(p, os.stat(p).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except Exception as e:
+        print(f"[cr-graph-venv] warn: could not rewrite shebang for {p}: {e}", file=sys.stderr)
+PY
+
+CR_VERSION="$("${VENV_DIR}/bin/code-review-graph" --version 2>/dev/null || echo unknown)"
+echo "[cr-graph-venv] installed ${CR_VERSION} -> ${VENV_DIR}/bin/code-review-graph"

--- a/scripts/download-bundled-tools.sh
+++ b/scripts/download-bundled-tools.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# download-bundled-tools.sh
+#
+# Pulls the static binary toolchain that ships *inside* the Forge Studio DMG so
+# users do not need their own Homebrew / pyenv / pipx / uv / cargo to launch
+# Agent Teams or build a code-review-graph. The script is intentionally
+# idempotent — re-running it on a populated tree just verifies the marker file
+# and exits.
+#
+# Outputs:
+#   resources/bundled-tools/darwin-arm64/
+#     bin/tmux             (1MB)   — agent-team multi-pane backend
+#     bin/uv               (10MB)  — Python pkg manager (Astral)
+#     python/              (~80MB unpacked) — python-build-standalone 3.12
+#     .download-stamp.json — versions + sha256 sums (used for re-run skip)
+#
+# Sources:
+#   tmux  : Homebrew bottle on the build host (`brew --prefix tmux`).
+#           Official tmux releases ship source-only; bottling requires a
+#           full libevent + ncurses static build that we'd otherwise have to
+#           maintain ourselves. The CI image / dev's machine is expected to
+#           already have tmux installed via brew.
+#   uv    : github.com/astral-sh/uv releases (aarch64-apple-darwin tarball)
+#   python: github.com/indygreg/python-build-standalone releases
+#           (cpython-3.12.x+YYYYMMDD-aarch64-apple-darwin-install_only.tar.gz)
+#
+# Re-run safety: a `.download-stamp.json` is written after a successful run.
+# If the stamp's `version` matches the values pinned in this script and every
+# expected output file exists, we skip the network entirely. Override with
+# `FORCE=1 bash scripts/download-bundled-tools.sh` to re-download.
+#
+# Target: macOS arm64 only (current build target — see README + package.json).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/resources/bundled-tools/darwin-arm64"
+STAMP="${OUT_DIR}/.download-stamp.json"
+
+# ─── Pinned versions (bump together with stamp version) ──────────────────
+UV_VERSION="0.4.30"
+UV_TARBALL="uv-aarch64-apple-darwin.tar.gz"
+UV_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TARBALL}"
+
+PYTHON_VERSION="3.12.7"
+PYTHON_RELEASE="20241016"
+PYTHON_TARBALL="cpython-${PYTHON_VERSION}+${PYTHON_RELEASE}-aarch64-apple-darwin-install_only.tar.gz"
+PYTHON_URL="https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_RELEASE}/${PYTHON_TARBALL}"
+
+STAMP_VERSION="1"  # bump when any pinned version above changes
+
+# ─── Platform guard ──────────────────────────────────────────────────────
+PLATFORM="$(uname -s)"
+ARCH="$(uname -m)"
+if [[ "${PLATFORM}" != "Darwin" || "${ARCH}" != "arm64" ]]; then
+  echo "[bundled-tools] non-darwin-arm64 host (${PLATFORM}/${ARCH}); skipping."
+  echo "[bundled-tools] CI must run this step on a macOS arm64 runner."
+  exit 0
+fi
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+log() { echo "[bundled-tools] $*"; }
+die() { echo "[bundled-tools] ERROR: $*" >&2; exit 1; }
+
+ensure_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+ensure_cmd curl
+ensure_cmd tar
+ensure_cmd shasum
+
+mkdir -p "${OUT_DIR}/bin"
+
+# ─── Skip-if-fresh: stamp + every expected file present ──────────────────
+need_download=1
+if [[ "${FORCE:-0}" != "1" && -f "${STAMP}" ]]; then
+  if grep -q "\"stampVersion\": \"${STAMP_VERSION}\"" "${STAMP}" 2>/dev/null \
+    && [[ -x "${OUT_DIR}/bin/tmux" ]] \
+    && [[ -x "${OUT_DIR}/bin/uv" ]] \
+    && [[ -x "${OUT_DIR}/python/bin/python3.12" || -x "${OUT_DIR}/python/bin/python3" ]]; then
+    log "stamp v${STAMP_VERSION} matches; all binaries present — skipping."
+    need_download=0
+  fi
+fi
+
+if [[ "${need_download}" -eq 0 ]]; then
+  exit 0
+fi
+
+# ─── 1. tmux: copy from local brew install ───────────────────────────────
+# Rationale: tmux upstream ships source tarballs only — there is no official
+# darwin-arm64 prebuilt binary. brew bottles ARE prebuilt + static-ish (link
+# against libevent + ncurses brew bottles), and copying the resolved binary
+# into our resources/ folder is the lowest-friction path. The build host
+# (CI runner or developer machine) is expected to have `brew install tmux`.
+if ! command -v brew >/dev/null 2>&1; then
+  die "tmux bundling requires Homebrew on the build host (brew install tmux)."
+fi
+
+if ! brew --prefix tmux >/dev/null 2>&1; then
+  log "tmux is not installed via brew — running 'brew install tmux'..."
+  brew install tmux
+fi
+
+TMUX_BREW_BIN="$(brew --prefix tmux)/bin/tmux"
+if [[ ! -x "${TMUX_BREW_BIN}" ]]; then
+  die "expected tmux at ${TMUX_BREW_BIN} but it is missing or not executable."
+fi
+cp -f "${TMUX_BREW_BIN}" "${OUT_DIR}/bin/tmux"
+chmod +x "${OUT_DIR}/bin/tmux"
+TMUX_VERSION="$("${OUT_DIR}/bin/tmux" -V 2>/dev/null | awk '{print $2}' || echo unknown)"
+TMUX_SHA256="$(shasum -a 256 "${OUT_DIR}/bin/tmux" | awk '{print $1}')"
+log "tmux ${TMUX_VERSION} -> ${OUT_DIR}/bin/tmux"
+
+# Note: the brew tmux binary still dynamically links libevent + ncurses + utf8proc.
+# `otool -L` against the user system would expose those — for the v0.5.1 bundle
+# we ship the brew binary as-is and rely on macOS providing libSystem
+# dependencies. If a user-reported missing-dylib bug shows up, switch this to
+# building tmux statically (Makefile + libevent vendored).
+
+# ─── 2. uv: tarball from astral-sh/uv releases ───────────────────────────
+TMP_UV="$(mktemp -d)"
+trap 'rm -rf "${TMP_UV}"' EXIT
+log "downloading uv ${UV_VERSION}..."
+curl --fail --location --silent --show-error \
+  --output "${TMP_UV}/${UV_TARBALL}" \
+  "${UV_URL}"
+UV_TARBALL_SHA256="$(shasum -a 256 "${TMP_UV}/${UV_TARBALL}" | awk '{print $1}')"
+log "uv tarball sha256: ${UV_TARBALL_SHA256}"
+
+tar -xzf "${TMP_UV}/${UV_TARBALL}" -C "${TMP_UV}"
+# Tarball layout: uv-aarch64-apple-darwin/uv  (and uvx). Find the binary.
+UV_BIN="$(find "${TMP_UV}" -type f -name uv -perm -u+x | head -1)"
+[[ -n "${UV_BIN}" ]] || die "uv binary not found inside ${UV_TARBALL}"
+cp -f "${UV_BIN}" "${OUT_DIR}/bin/uv"
+chmod +x "${OUT_DIR}/bin/uv"
+UV_BIN_SHA256="$(shasum -a 256 "${OUT_DIR}/bin/uv" | awk '{print $1}')"
+log "uv ${UV_VERSION} -> ${OUT_DIR}/bin/uv (sha ${UV_BIN_SHA256})"
+
+# ─── 3. python: indygreg/python-build-standalone tarball ─────────────────
+PY_DIR="${OUT_DIR}/python"
+if [[ -d "${PY_DIR}" ]]; then
+  log "removing previous python tree at ${PY_DIR}..."
+  rm -rf "${PY_DIR}"
+fi
+TMP_PY="$(mktemp -d)"
+log "downloading python ${PYTHON_VERSION}+${PYTHON_RELEASE} (~30MB)..."
+curl --fail --location --silent --show-error \
+  --output "${TMP_PY}/${PYTHON_TARBALL}" \
+  "${PYTHON_URL}"
+PY_TARBALL_SHA256="$(shasum -a 256 "${TMP_PY}/${PYTHON_TARBALL}" | awk '{print $1}')"
+log "python tarball sha256: ${PY_TARBALL_SHA256}"
+
+# install_only tarballs unpack to ./python/{bin,lib,share,include}
+tar -xzf "${TMP_PY}/${PYTHON_TARBALL}" -C "${TMP_PY}"
+[[ -d "${TMP_PY}/python" ]] || die "expected ./python/ dir inside install_only tarball"
+mv "${TMP_PY}/python" "${PY_DIR}"
+rm -rf "${TMP_PY}"
+
+[[ -x "${PY_DIR}/bin/python3.12" || -x "${PY_DIR}/bin/python3" ]] \
+  || die "extracted python tree is missing bin/python3*"
+log "python -> ${PY_DIR}"
+
+# ─── 4. write stamp ──────────────────────────────────────────────────────
+cat > "${STAMP}" <<JSON
+{
+  "stampVersion": "${STAMP_VERSION}",
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "tmux": {
+    "version": "${TMUX_VERSION}",
+    "source": "homebrew (${TMUX_BREW_BIN})",
+    "sha256": "${TMUX_SHA256}"
+  },
+  "uv": {
+    "version": "${UV_VERSION}",
+    "tarball": "${UV_URL}",
+    "tarballSha256": "${UV_TARBALL_SHA256}",
+    "binarySha256": "${UV_BIN_SHA256}"
+  },
+  "python": {
+    "version": "${PYTHON_VERSION}",
+    "release": "${PYTHON_RELEASE}",
+    "tarball": "${PYTHON_URL}",
+    "tarballSha256": "${PY_TARBALL_SHA256}"
+  }
+}
+JSON
+
+log "done. stamp written to ${STAMP}"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,9 +116,20 @@ export default function App() {
   const [toast, setToast] = useState<{ name: string; count: number } | null>(null)
   const [model] = useState({ id: 'sonnet-4.5', label: 'sonnet-4.5' })
 
-  // ── Boot ────────────────────────────────────────────────────────
+  // ── Boot — load workspaces + auto-activate most recently opened ──
   useEffect(() => {
-    loadWorkspaces()
+    void (async () => {
+      await loadWorkspaces()
+      const state = useWorkspaceStore.getState()
+      if (!state.activeWorkspace && state.workspaces.length > 0) {
+        const recent = [...state.workspaces].sort((a, b) => {
+          const aT = +new Date(a.lastOpened ?? a.createdAt ?? 0)
+          const bT = +new Date(b.lastOpened ?? b.createdAt ?? 0)
+          return bT - aT
+        })[0]
+        if (recent) state.setActiveWorkspace(recent)
+      }
+    })()
     // Subscribe to team updates once. setActiveWorkspace handles repointing
     // the watcher; the subscribe callback updates the store as the chokidar
     // watcher emits new configs.
@@ -274,6 +285,11 @@ export default function App() {
 
   // ── Render ──────────────────────────────────────────────────────
   if (!activeSummary) {
+    const recentList = [...workspaces].sort((a, b) => {
+      const aT = +new Date(a.lastOpened ?? a.createdAt ?? 0)
+      const bT = +new Date(b.lastOpened ?? b.createdAt ?? 0)
+      return bT - aT
+    })
     return (
       <div
         style={{
@@ -286,26 +302,134 @@ export default function App() {
           fontFamily: 'var(--font-ui)',
         }}
       >
-        <div style={{ textAlign: 'center' }}>
-          <div style={{ marginBottom: 12, color: 'var(--text-1)', fontSize: 16, fontWeight: 600 }}>
-            Forge Studio
-          </div>
-          <button
-            onClick={() => setNewWorkspaceDialog(true)}
+        <div style={{ width: 480, maxWidth: '90%' }}>
+          <div
             style={{
-              background: 'var(--accent)',
-              color: '#0b0e13',
-              border: 'none',
-              padding: '8px 16px',
-              borderRadius: 6,
-              fontSize: 13,
-              fontWeight: 600,
-              fontFamily: 'inherit',
-              cursor: 'pointer',
+              textAlign: 'center',
+              marginBottom: 28,
+              color: 'var(--text-1)',
+              fontSize: 22,
+              fontWeight: 700,
+              letterSpacing: '-0.3px',
             }}
           >
-            새 워크스페이스 만들기
-          </button>
+            Forge Studio
+          </div>
+
+          {/* Action buttons */}
+          <div style={{ display: 'flex', gap: 10, marginBottom: recentList.length > 0 ? 28 : 0 }}>
+            <button
+              onClick={() => setNewWorkspaceDialog(true)}
+              style={{
+                flex: 1,
+                background: 'var(--accent)',
+                color: '#0b0e13',
+                border: 'none',
+                padding: '10px 14px',
+                borderRadius: 6,
+                fontSize: 13,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              + 새 워크스페이스
+            </button>
+            <button
+              onClick={async () => {
+                const result = await window.api.system.showOpenDialog({
+                  properties: ['openDirectory', 'createDirectory'],
+                  title: '기존 폴더 열기',
+                })
+                if (result && !result.canceled && result.filePaths[0]) {
+                  await openWorkspace(result.filePaths[0])
+                }
+              }}
+              style={{
+                flex: 1,
+                background: 'var(--bg-3)',
+                color: 'var(--text-1)',
+                border: '1px solid var(--line-2)',
+                padding: '10px 14px',
+                borderRadius: 6,
+                fontSize: 13,
+                fontWeight: 500,
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              📁 기존 폴더 열기
+            </button>
+          </div>
+
+          {/* Recent workspaces */}
+          {recentList.length > 0 && (
+            <div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-3)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                  fontFamily: 'var(--font-mono)',
+                  marginBottom: 8,
+                }}
+              >
+                Recent workspaces
+              </div>
+              <div
+                style={{
+                  background: 'var(--bg-2)',
+                  border: '1px solid var(--line-1)',
+                  borderRadius: 6,
+                  overflow: 'hidden',
+                }}
+              >
+                {recentList.slice(0, 6).map((ws) => (
+                  <button
+                    key={ws.id}
+                    onClick={() => useWorkspaceStore.getState().setActiveWorkspace(ws)}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-start',
+                      gap: 2,
+                      width: '100%',
+                      padding: '10px 14px',
+                      background: 'transparent',
+                      border: 'none',
+                      borderBottom: '1px solid var(--line-1)',
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      color: 'var(--text-1)',
+                    }}
+                    onMouseEnter={(e) => {
+                      ;(e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-3)'
+                    }}
+                    onMouseLeave={(e) => {
+                      ;(e.currentTarget as HTMLButtonElement).style.background = 'transparent'
+                    }}
+                  >
+                    <div style={{ fontSize: 13, fontWeight: 500 }}>{ws.name}</div>
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: 'var(--text-3)',
+                        fontFamily: 'var(--font-mono)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        maxWidth: '100%',
+                      }}
+                    >
+                      {ws.path}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
         <NewWorkspaceDialog />
         {/* Onboarding overlays the empty state on first run so brand-new users

--- a/src/components/v2/Onboarding.tsx
+++ b/src/components/v2/Onboarding.tsx
@@ -330,6 +330,7 @@ function Step2Dependencies() {
         {deps.map((dep) => {
           const installed = typeof dep.resolved === 'string'
           const checking = dep.resolved === null && checkingDeps
+          const bundled = installed && !!dep.bundled
           return (
             <Card
               key={dep.key}
@@ -375,6 +376,11 @@ function Step2Dependencies() {
               </div>
               {checking ? (
                 <Pill color="var(--text-3)">확인 중…</Pill>
+              ) : bundled ? (
+                // Forge Studio shipped this binary inside the DMG — no user
+                // action needed and no install button (since the bundled path
+                // is the canonical one we want them to use).
+                <Pill color="var(--success)">번들됨</Pill>
               ) : installed ? (
                 <Pill color="var(--success)">설치됨</Pill>
               ) : (

--- a/src/components/v2/TopBar.tsx
+++ b/src/components/v2/TopBar.tsx
@@ -15,28 +15,14 @@ import { Icon } from './icons'
 import { Pill, Kbd } from './primitives'
 import type { WorkspaceSummary } from './types'
 
-// ─── Traffic lights (visual placeholder; real ones come from frameless OS chrome) ─
-function TrafficLights() {
-  return (
-    <div
-      className="ns"
-      style={{
-        display: 'flex', gap: 8, paddingLeft: 14, paddingRight: 12,
-        alignItems: 'center',
-      }}
-    >
-      {['#ff5f57', '#febc2e', '#28c840'].map((c) => (
-        <span
-          key={c}
-          style={{
-            width: 12, height: 12, borderRadius: 999,
-            background: c,
-            boxShadow: 'inset 0 0 0 0.5px rgba(0,0,0,0.18)',
-          }}
-        />
-      ))}
-    </div>
-  )
+// ─── Traffic-light spacer ────────────────────────────────────────────────
+// macOS draws real traffic lights at (16, 16) when the BrowserWindow is
+// configured with `titleBarStyle: 'hiddenInset'` (see electron/main.ts).
+// We render an empty spacer here so other TopBar content doesn't slide
+// underneath those native buttons. Width = 70px = enough for the three
+// dots + their inset padding without colliding with WorkspaceSwitcher.
+function TrafficLightSpacer() {
+  return <div className="ns" style={{ width: 70, flexShrink: 0 }} />
 }
 
 // ─── Workspace dropdown switcher ────────────────────────────────────────────
@@ -288,7 +274,7 @@ export function TopBar({
 
   return (
     <div
-      className="ns"
+      className="ns app-drag"
       style={{
         height: 38, display: 'flex', alignItems: 'center',
         borderBottom: '1px solid var(--line-1)',
@@ -296,20 +282,23 @@ export function TopBar({
         flexShrink: 0,
       }}
     >
-      <TrafficLights />
+      <TrafficLightSpacer />
 
-      <WorkspaceSwitcher
-        workspace={workspace}
-        workspaces={workspaces}
-        onSwitch={onSwitchWorkspace}
-        onAddWorkspace={onAddWorkspace}
-        onOpenExisting={onOpenExisting}
-        onManageWorkspaces={onOpenSettings}
-      />
+      <div className="app-no-drag">
+        <WorkspaceSwitcher
+          workspace={workspace}
+          workspaces={workspaces}
+          onSwitch={onSwitchWorkspace}
+          onAddWorkspace={onAddWorkspace}
+          onOpenExisting={onOpenExisting}
+          onManageWorkspaces={onOpenSettings}
+        />
+      </div>
 
       {/* Center: command palette trigger */}
       <div style={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
         <button
+          className="app-no-drag"
           onClick={onCmdK}
           style={{
             width: 360, height: 24, borderRadius: 5,
@@ -327,7 +316,7 @@ export function TopBar({
       </div>
 
       {/* Right: harness, model, settings */}
-      <div style={{
+      <div className="app-no-drag" style={{
         display: 'flex', alignItems: 'center', gap: 8, paddingRight: 10,
       }}>
         <button style={{

--- a/src/stores/onboarding.ts
+++ b/src/stores/onboarding.ts
@@ -28,6 +28,12 @@ export interface DependencyStatus {
   installUrl: string
   /** `null` while a check is in flight, `string` (the resolved path) when found, `false` when missing. */
   resolved: string | false | null
+  /**
+   * True when the resolved binary lives inside the DMG's bundled-tools tree
+   * (Contents/Resources/bundled-tools/...). Drives the green "Bundled" pill in
+   * Step 2 — users with a bundled tool should see no install action.
+   */
+  bundled?: boolean
 }
 
 export interface OnboardingState {
@@ -60,28 +66,34 @@ const DEPENDENCY_DEFAULTS: DependencyStatus[] = [
   {
     key: 'git',
     label: 'git',
-    hint: '워크스페이스의 버전 관리에 필수입니다.',
+    // git is intentionally NOT bundled — macOS ships it via Xcode CLT and
+    // tracking upstream would balloon the DMG by 40+ MB for no real win.
+    hint: 'Xcode Command Line Tools 와 함께 설치됩니다 (xcode-select --install).',
     installUrl: 'https://git-scm.com/downloads',
     resolved: null,
   },
   {
     key: 'tmux',
     label: 'tmux',
-    hint: '격리 워크트리에서 agent별 세션을 띄우는 데 사용됩니다.',
+    // Bundled in v0.5.1 — Forge Studio.app/Contents/Resources/bundled-tools/bin/tmux
+    hint: '격리 워크트리에서 agent별 세션을 띄우는 데 사용됩니다 — Forge Studio 에 번들되어 있습니다.',
     installUrl: 'https://github.com/tmux/tmux/wiki/Installing',
     resolved: null,
   },
   {
     key: 'claude',
     label: 'claude-code',
-    hint: '터미널에서 Claude Code agent 를 실행합니다.',
+    // Claude Code is NOT bundled — Anthropic ships frequent updates and the
+    // license forbids redistribution. Surface the official install guide.
+    hint: '터미널에서 Claude Code agent 를 실행합니다. Anthropic 공식 가이드를 따라 직접 설치해주세요.',
     installUrl: 'https://docs.claude.com/claude-code',
     resolved: null,
   },
   {
     key: 'crGraph',
     label: 'code-review-graph',
-    hint: '저장소 의존성 + 호출 그래프 시각화 (선택).',
+    // Bundled in v0.5.1 — pre-built venv at bundled-tools/cr-graph-venv/.
+    hint: '저장소 의존성 + 호출 그래프 시각화 — Forge Studio 에 번들되어 있습니다.',
     installUrl: 'https://github.com/anthropics/code-review-graph',
     resolved: null,
   },
@@ -140,6 +152,17 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
     if (!which) return
     set({ checkingDeps: true })
     try {
+      // Pull the bundled-tools root once so we can flag any resolved path
+      // that lives inside it as "Bundled" rather than "Installed". Failures
+      // (older app build with no IPC method) collapse to a null root, which
+      // makes the bundled-detection a no-op — UI stays correct.
+      let bundledRoot: string | null = null
+      try {
+        const r = await window.api?.system?.bundledToolsRoot?.()
+        bundledRoot = typeof r === 'string' && r.length > 0 ? r : null
+      } catch {
+        bundledRoot = null
+      }
       const next = await Promise.all(
         get().deps.map(async (dep) => {
           // The IPC handler maps to `which <dep.label>` but we strip dashes to
@@ -158,7 +181,11 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
           } catch {
             resolved = false
           }
-          return { ...dep, resolved }
+          const bundled =
+            typeof resolved === 'string' &&
+            !!bundledRoot &&
+            resolved.startsWith(bundledRoot)
+          return { ...dep, resolved, bundled }
         }),
       )
       set({ deps: next })


### PR DESCRIPTION
## 요약
- tmux + uv + Python 3.12 standalone + code-review-graph venv 사전 번들 (DMG +76MB)
- 부팅 시 가장 최근 워크스페이스 자동 활성화 + 'Recent workspaces' empty state
- '기존 폴더 열기' 버튼 (system folder picker → openWorkspace)
- macOS traffic light 겹침 fix (TopBar app-drag + spacer)
- cr-graph venv 빌드를 uv 로 (python ensurepip SIGABRT 회피)

자세한 변경: CHANGELOG.md [0.5.1]