### PR TITLE
feat: 0.5.3 — RunLiveView 진짜 동작 (mock 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.5.3] — 2026-05-08
+
+\"진짜 동작\" 라운드 — RunLiveView 의 mock 영역 3개 (grid + Activity feed
++ ResourceBar) 를 모두 실 데이터로 교체.
+
+### Changed — RunLiveView 풀 라이브 동작
+- **tmux split grid 실제 PTY attach** — 기존 fake TERMINAL_LINES cycling
+  → 멤버 tmux 세션의 라이브 PTY 표시. `LiveTerminalGrid.tsx` 신규,
+  paneId(=agentName) 별 single XTerminal 인스턴스 + persistent host
+  portal (TerminalAreaV2 패턴 재사용) 로 grid ↔ focus mode ↔ fullscreen
+  레이아웃 전환 시에도 PTY 보존. ResizeObserver + FitAddon. tmux 미설치
+  / queued 멤버는 기존 fake cycling fallback
+- **Activity feed 실 데이터** — chokidar 가 멤버 worktreePath watch +
+  1s 간격 git HEAD polling + config.json state 추적. edit/commit/
+  state-change 이벤트 stream. `~/.claude-forge/team-activity/<id>.jsonl`
+  미러링 (영속성). 빈 상태 \"활동 없음 — 첫 변경을 기다리는 중\"
+- **ResourceBar 실 메트릭** — 5s polling. CPU `ps -A -o %cpu` 코어 정규화,
+  MEM `vm_stat + sysctl`, DISK 워크스페이스 `du -sk` baseline delta,
+  PTY `ptyManager.activeCount()`. 임계 색상 (CPU>80% warning/>90%
+  danger, MEM>85% warning/>95% danger)
+
+### Added — 인프라
+- `electron/services/TeamActivityTracker.ts` — chokidar + git polling +
+  jsonl 영속화. teams:create/remove 에 자동 wire
+- `electron/services/ResourceMonitor.ts` — 5s 캐시. macOS 명령 + non-
+  darwin os.loadavg fallback
+- `PtyManager.activeCount()` 헬퍼
+- IPC: `team-activity:list/event`, `resource:snapshot`
+- `src/stores/teamActivity.ts` — refcounted subscribe + 팀별 ring buffer
+  (max 200, 최신순). 단일 글로벌 IPC 리스너 fanout
+
+### Fixed — Graceful degradation
+- chokidar/git 미가용 — 이벤트 stream 정지 (앱 안 죽음)
+- system.resourceSnapshot 미존재 — 0 값 표시 (fake 안 띄움)
+- team-activity:list 실패 — 빈 상태 + 라이브 stream 시도 계속
+
 ## [0.5.2] — 2026-05-08
 
 \"진짜 완벽\" 라운드 — 4개 영역의 미완성 부분 풀.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,8 @@ import { FsManager, type FsListOpts } from './services/FsManager'
 import { CodeReviewGraphManager, type InstallMethod } from './services/CodeReviewGraphManager'
 import { HookProfiler } from './services/HookProfiler'
 import { pathManager } from './services/PathManager'
+import { TeamActivityTracker, type ActivityEvent, type MemberSpec } from './services/TeamActivityTracker'
+import { ResourceMonitor } from './services/ResourceMonitor'
 
 const execFileAsync = promisify(execFile)
 
@@ -36,6 +38,18 @@ const updateChecker = new UpdateChecker()
 const agentTeamWatcher = new AgentTeamWatcher()
 const fsManager = new FsManager()
 const hookProfiler = new HookProfiler()
+const teamActivityTracker = new TeamActivityTracker()
+/**
+ * ResourceMonitor reads the active workspace path lazily so a swap doesn't
+ * leave us measuring a stale folder. Disk baseline is reset whenever the
+ * workspace pointer moves (see workspaceManager listener below).
+ */
+let activeWorkspacePathForMetrics: string | null = null
+const resourceMonitor = new ResourceMonitor({
+  cacheMs: 5000,
+  getPtyCount: () => ptyManager.activeCount(),
+  getWorkspacePath: () => activeWorkspacePathForMetrics,
+})
 harnessScanner.setProfiler(hookProfiler)
 
 /**
@@ -1022,6 +1036,13 @@ ipcMain.handle('teams:list', () => agentTeamWatcher.list())
 ipcMain.handle(
   'teams:setWorkspace',
   async (_event, workspacePath: string | null) => {
+    // Track the active workspace so ResourceMonitor measures the right
+    // directory for `du` baseline. Switching workspaces resets the baseline
+    // so the bar doesn't show a phantom "free GB" bump.
+    if (activeWorkspacePathForMetrics !== workspacePath) {
+      activeWorkspacePathForMetrics = workspacePath
+      resourceMonitor.resetDiskBaseline()
+    }
     await agentTeamWatcher.setWorkspace(workspacePath)
   }
 )
@@ -1040,11 +1061,33 @@ ipcMain.handle(
       mergeStrategy: 'squash' | 'sequential'
     }
   ) => {
-    return agentTeamWatcher.create(opts)
+    const result = await agentTeamWatcher.create(opts)
+    // Spin up the activity tracker for the brand-new team. The watcher's
+    // create() already wrote config.json + worktrees, so we read the live
+    // member list back out instead of recomputing.
+    try {
+      const teams = agentTeamWatcher.list()
+      const team = teams.find((t) => t.id === result.teamId)
+      if (team) {
+        const memberSpecs: MemberSpec[] = team.members.map((m) => ({
+          agentId: m.agentId,
+          name: m.name,
+          worktreePath: m.worktreePath,
+          state: m.state,
+        }))
+        await teamActivityTracker.start(result.teamId, memberSpecs, result.configPath)
+      }
+    } catch (err) {
+      console.warn('[teamActivityTracker] start failed (non-fatal):', err)
+    }
+    return result
   }
 )
 
 ipcMain.handle('teams:remove', async (_event, teamId: string) => {
+  // Tear down activity tracking before the watcher rm's the team config so
+  // the JSONL stream flushes its tail line cleanly.
+  await teamActivityTracker.stop(teamId).catch(() => {})
   await agentTeamWatcher.remove(teamId)
 })
 
@@ -1096,6 +1139,39 @@ ipcMain.handle('teams:openAgentTerminal', (_event, options: { teamId: string; ag
   })
 
   return id
+})
+
+// ─── IPC Handlers: Team Activity ────────────────────────────────────
+
+ipcMain.handle('team-activity:list', async (_event, teamId: string, limit?: number) => {
+  if (!teamId || typeof teamId !== 'string') return []
+  const cap = typeof limit === 'number' && limit > 0 ? Math.min(limit, 1000) : 100
+  return teamActivityTracker.list(teamId, cap)
+})
+
+// ─── IPC Handlers: Resource Snapshot ────────────────────────────────
+
+ipcMain.handle('resource:snapshot', async () => {
+  try {
+    return await resourceMonitor.getSnapshot()
+  } catch (err) {
+    pushErrorToRenderer({
+      code: 'RESOURCE_SNAPSHOT_FAILED',
+      category: 'SYSTEM',
+      message: err instanceof Error ? err.message : String(err),
+    })
+    // Always return a well-formed snapshot so the renderer never has to
+    // defend against rejection — the bar just shows zeros until the next
+    // poll succeeds.
+    return {
+      cpu: 0,
+      memUsed: 0,
+      memTotal: 0,
+      diskDeltaGb: 0,
+      ptyCount: 0,
+      ts: Date.now(),
+    }
+  }
 })
 
 // ─── App Lifecycle ──────────────────────────────────────────────────
@@ -1160,6 +1236,14 @@ if (!gotTheLock) {
       mainWindow?.webContents.send('teams:update', teams)
     })
 
+    // Forward every activity event to the renderer. The renderer subscribes
+    // via `team-activity:event` (single channel for all teams) and filters by
+    // teamId in the store — keeps preload simpler than fanning out
+    // per-team channels.
+    teamActivityTracker.on('event', (event: ActivityEvent) => {
+      mainWindow?.webContents.send('team-activity:event', event)
+    })
+
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow()
     })
@@ -1168,6 +1252,7 @@ if (!gotTheLock) {
   app.on('window-all-closed', () => {
     ptyManager.disposeAll()
     agentTeamWatcher.stop()
+    teamActivityTracker.stopAll().catch(() => {})
     crGraphManager.disposeAll()
     if (process.platform !== 'darwin') app.quit()
   })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,7 @@ const ALLOWED_CHANNELS = new Set([
   'action',
   'workspace-opened',
   'error-log:push',
+  'team-activity:event',
 ])
 
 const api = {
@@ -405,6 +406,73 @@ const api = {
     }> => ipcRenderer.invoke('teams:merge', teamId, opts),
   },
 
+  // ─── Team Activity ───────────────────────────────────────────────
+  //
+  // RunLiveView's right-rail activity feed reads the JSONL tail via list()
+  // and subscribes to live pushes via onEvent(). The single-channel layout
+  // (one event stream for all teams) was chosen over per-team channels so
+  // the preload allowlist stays small.
+  teamActivity: {
+    list: (
+      teamId: string,
+      limit?: number,
+    ): Promise<
+      Array<{
+        ts: number
+        teamId: string
+        agent: string
+        kind: 'edit' | 'commit' | 'state-change'
+        file?: string
+        added?: number
+        removed?: number
+        message?: string
+        files?: string[]
+        sha?: string
+        from?: string
+        to?: string
+        text?: string
+      }>
+    > => ipcRenderer.invoke('team-activity:list', teamId, limit),
+    onEvent: (
+      callback: (event: {
+        ts: number
+        teamId: string
+        agent: string
+        kind: 'edit' | 'commit' | 'state-change'
+        file?: string
+        added?: number
+        removed?: number
+        message?: string
+        files?: string[]
+        sha?: string
+        from?: string
+        to?: string
+        text?: string
+      }) => void,
+    ) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: {
+          ts: number
+          teamId: string
+          agent: string
+          kind: 'edit' | 'commit' | 'state-change'
+          file?: string
+          added?: number
+          removed?: number
+          message?: string
+          files?: string[]
+          sha?: string
+          from?: string
+          to?: string
+          text?: string
+        },
+      ) => callback(payload)
+      ipcRenderer.on('team-activity:event', handler)
+      return () => ipcRenderer.removeListener('team-activity:event', handler)
+    },
+  },
+
   // ─── code-review-graph ───────────────────────────────────────────
   crGraph: {
     isInstalled: (): Promise<{
@@ -549,6 +617,20 @@ const api = {
      */
     bundledToolsRoot: () =>
       ipcRenderer.invoke('system:bundledToolsRoot') as Promise<string | null>,
+    /**
+     * One-shot snapshot of CPU / memory / disk-delta / pty-count for the
+     * WorkspaceV2 ResourceBar. The main process caches for ~5s so this is
+     * cheap to call on a 5s polling interval. Always resolves — failure
+     * cases return zeros rather than rejecting.
+     */
+    resourceSnapshot: (): Promise<{
+      cpu: number
+      memUsed: number
+      memTotal: number
+      diskDeltaGb: number
+      ptyCount: number
+      ts: number
+    }> => ipcRenderer.invoke('resource:snapshot'),
   },
 
   // ─── Events ──────────────────────────────────────────────────────

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -162,4 +162,13 @@ export class PtyManager {
       this.dispose(id)
     }
   }
+
+  /**
+   * Number of currently-live PTY instances. Surfaced to the renderer via
+   * `system:resourceSnapshot` so the ResourceBar can show a real PTY count
+   * instead of a synthetic value.
+   */
+  activeCount(): number {
+    return this.instances.size
+  }
 }

--- a/electron/services/ResourceMonitor.ts
+++ b/electron/services/ResourceMonitor.ts
@@ -1,0 +1,199 @@
+/**
+ * ResourceMonitor — system-level snapshot used by the WorkspaceV2 ResourceBar.
+ *
+ * Collects four numbers, all best-effort:
+ *   - cpu        : aggregate %CPU summed across all processes (macOS: ps)
+ *   - memUsed    : GB of memory in use (macOS: vm_stat * pagesize)
+ *   - memTotal   : GB of installed memory (macOS: sysctl hw.memsize)
+ *   - diskDeltaGb: GB consumed by the workspace path since baseline (du)
+ *   - ptyCount   : live PTY instances tracked by PtyManager
+ *
+ * Snapshots are cached for `cacheMs` (default 5s) to keep the IPC cheap when
+ * multiple components subscribe. Every numeric is finite — failures degrade
+ * to 0 so the renderer never has to defend against NaN.
+ *
+ * Non-darwin platforms get zeros (we still return a well-formed snapshot).
+ */
+import os from 'os'
+import path from 'path'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+export interface ResourceSnapshot {
+  cpu: number
+  memUsed: number
+  memTotal: number
+  diskDeltaGb: number
+  ptyCount: number
+  /** Unix ms when the snapshot was assembled. */
+  ts: number
+}
+
+export interface ResourceMonitorOptions {
+  /** ms a snapshot stays cached before the next full poll. */
+  cacheMs?: number
+  /** PTY count provider — wired to PtyManager.activeCount() in main. */
+  getPtyCount: () => number
+  /** Workspace path used for `du -sk` measurement (optional). */
+  getWorkspacePath?: () => string | null
+}
+
+export class ResourceMonitor {
+  private cache: ResourceSnapshot | null = null
+  private inflight: Promise<ResourceSnapshot> | null = null
+  private cacheMs: number
+  private getPtyCount: () => number
+  private getWorkspacePath?: () => string | null
+  /**
+   * First measured "du" of the workspace path — diskDeltaGb is reported as
+   * `current - baseline` so the bar shows growth attributable to runs, not
+   * the absolute repo size which is noisy.
+   */
+  private duBaselineKb: number | null = null
+
+  constructor(opts: ResourceMonitorOptions) {
+    this.cacheMs = opts.cacheMs ?? 5000
+    this.getPtyCount = opts.getPtyCount
+    this.getWorkspacePath = opts.getWorkspacePath
+  }
+
+  async getSnapshot(): Promise<ResourceSnapshot> {
+    const now = Date.now()
+    if (this.cache && now - this.cache.ts < this.cacheMs) {
+      return this.cache
+    }
+    if (this.inflight) return this.inflight
+    this.inflight = this.collect()
+      .then((snap) => {
+        this.cache = snap
+        this.inflight = null
+        return snap
+      })
+      .catch((err) => {
+        this.inflight = null
+        throw err
+      })
+    return this.inflight
+  }
+
+  private async collect(): Promise<ResourceSnapshot> {
+    const [cpu, mem, diskDeltaGb] = await Promise.all([
+      this.cpuPercent(),
+      this.memSnapshot(),
+      this.workspaceDiskDeltaGb(),
+    ])
+    let ptyCount = 0
+    try {
+      const n = this.getPtyCount()
+      if (Number.isFinite(n)) ptyCount = n
+    } catch {
+      ptyCount = 0
+    }
+    return {
+      cpu: Number.isFinite(cpu) ? cpu : 0,
+      memUsed: Number.isFinite(mem.used) ? mem.used : 0,
+      memTotal: Number.isFinite(mem.total) ? mem.total : 0,
+      diskDeltaGb: Number.isFinite(diskDeltaGb) ? diskDeltaGb : 0,
+      ptyCount,
+      ts: Date.now(),
+    }
+  }
+
+  /**
+   * Aggregate %CPU across all user processes via `ps`. macOS-friendly. On
+   * non-darwin we read os.loadavg() / cpus().length as a coarse proxy so the
+   * bar still moves rather than sitting at 0.
+   */
+  private async cpuPercent(): Promise<number> {
+    if (os.platform() !== 'darwin') {
+      const [load1] = os.loadavg()
+      const n = os.cpus().length || 1
+      return Math.min(100, Math.max(0, (load1 / n) * 100))
+    }
+    try {
+      const { stdout } = await execFileAsync(
+        '/bin/sh',
+        ['-c', "ps -A -o %cpu | awk 'NR>1 {s+=$1} END {print s+0}'"],
+        { timeout: 4000 },
+      )
+      const v = Number(stdout.trim())
+      if (!Number.isFinite(v)) return 0
+      // ps reports per-core (so a 4-core box can hit 400%). Normalise to a
+      // 0..100 scale by dividing by core count — matches what users expect
+      // from Activity Monitor's "CPU usage" line.
+      const cores = os.cpus().length || 1
+      return Math.min(100, Math.max(0, v / cores))
+    } catch {
+      return 0
+    }
+  }
+
+  /** Returns { used, total } in GB. */
+  private async memSnapshot(): Promise<{ used: number; total: number }> {
+    const total = os.totalmem() / 1024 ** 3
+    if (os.platform() !== 'darwin') {
+      const used = (os.totalmem() - os.freemem()) / 1024 ** 3
+      return { used, total }
+    }
+    try {
+      // vm_stat reports pages; pagesize is in the header line.
+      const { stdout } = await execFileAsync('/usr/bin/vm_stat', [], { timeout: 3000 })
+      const lines = stdout.split('\n')
+      const header = lines[0] ?? ''
+      const pageSizeMatch = header.match(/page size of (\d+) bytes/)
+      const pageSize = pageSizeMatch ? Number(pageSizeMatch[1]) : 4096
+      const stats = new Map<string, number>()
+      for (const line of lines.slice(1)) {
+        const m = line.match(/^"?([^"]+?)"?:\s+(\d+)\.?\s*$/)
+        if (m) stats.set(m[1].trim(), Number(m[2]))
+      }
+      const wired = stats.get('Pages wired down') ?? 0
+      const active = stats.get('Pages active') ?? 0
+      const compressed = stats.get('Pages occupied by compressor') ?? 0
+      // App memory ≈ wired + active + compressed (matches Activity Monitor).
+      const usedBytes = (wired + active + compressed) * pageSize
+      return { used: usedBytes / 1024 ** 3, total }
+    } catch {
+      const used = (os.totalmem() - os.freemem()) / 1024 ** 3
+      return { used, total }
+    }
+  }
+
+  /**
+   * Disk growth (GB) of the active workspace path since first poll. Uses
+   * `du -sk` — fast on warm caches, capped with a generous timeout. When no
+   * workspace is set we return 0.
+   */
+  private async workspaceDiskDeltaGb(): Promise<number> {
+    if (!this.getWorkspacePath) return 0
+    let p: string | null
+    try {
+      p = this.getWorkspacePath()
+    } catch {
+      return 0
+    }
+    if (!p) return 0
+    try {
+      const safe = path.resolve(p)
+      const { stdout } = await execFileAsync('/usr/bin/du', ['-sk', safe], { timeout: 8000 })
+      const kb = Number(stdout.split(/\s+/)[0])
+      if (!Number.isFinite(kb)) return 0
+      if (this.duBaselineKb === null) {
+        this.duBaselineKb = kb
+        return 0
+      }
+      const deltaKb = Math.max(0, kb - this.duBaselineKb)
+      return deltaKb / 1024 / 1024 // KB → GB
+    } catch {
+      return 0
+    }
+  }
+
+  /** Reset the disk baseline — useful when the active workspace switches. */
+  resetDiskBaseline(): void {
+    this.duBaselineKb = null
+    this.cache = null
+  }
+}

--- a/electron/services/TeamActivityTracker.ts
+++ b/electron/services/TeamActivityTracker.ts
@@ -1,0 +1,471 @@
+/**
+ * TeamActivityTracker — converts on-disk member worktree changes into
+ * structured `ActivityEvent` records the renderer's RunLiveView feed renders
+ * in real time.
+ *
+ * Per team we watch:
+ *   1. Each member's `worktreePath` (chokidar) — fires `edit` events with
+ *      git-diff-derived line counts on file change/add. Synthetic shadow
+ *      directories are filtered (`.git`, `node_modules`, etc).
+ *   2. Each member's `worktreePath/.git/HEAD` (polling 1s) — when HEAD moves,
+ *      we resolve the new commit's message + file list and emit `commit`.
+ *   3. The team `config.json` (chokidar) — diffing the previous member states
+ *      yields `state-change` events.
+ *
+ * All events are mirrored into `~/.claude-forge/team-activity/<teamId>.jsonl`
+ * for crash-tolerant history. The renderer pulls the tail with `list()` and
+ * subscribes to live pushes via `subscribe()`.
+ *
+ * External tools (git) are gated — when missing we degrade to filename-only
+ * edits (no line counts) and skip commit polling. chokidar is required.
+ */
+import * as chokidar from 'chokidar'
+import path from 'path'
+import os from 'os'
+import fs from 'fs/promises'
+import { existsSync, mkdirSync, createWriteStream, type WriteStream } from 'fs'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { EventEmitter } from 'events'
+
+const execFileAsync = promisify(execFile)
+
+export type ActivityKind = 'edit' | 'commit' | 'state-change'
+
+export interface ActivityEvent {
+  /** Unix ms timestamp the event was observed. */
+  ts: number
+  /** Team this event belongs to. */
+  teamId: string
+  /** Member agentId / name responsible for the event. */
+  agent: string
+  kind: ActivityKind
+  /** Changed file path, relative to the worktree root. */
+  file?: string
+  /** Lines added (git diff numstat). */
+  added?: number
+  /** Lines removed (git diff numstat). */
+  removed?: number
+  /** Commit subject — first line of the commit message. */
+  message?: string
+  /** File paths changed in the commit. */
+  files?: string[]
+  /** Short HEAD sha for commit events. */
+  sha?: string
+  /** Member state transition (state-change events). */
+  from?: string
+  to?: string
+  /** Free-form text for unstructured events / fallbacks. */
+  text?: string
+}
+
+export interface MemberSpec {
+  agentId: string
+  name?: string
+  worktreePath?: string
+  state?: string
+}
+
+interface MemberWatcher {
+  agentId: string
+  worktreePath: string
+  /** Last seen HEAD sha — undefined until first poll. */
+  lastHead?: string
+  fsWatcher: chokidar.FSWatcher
+  /** Set of files we already emitted within the debounce window. */
+  recentlyEmitted: Map<string, number>
+}
+
+interface TeamWatcher {
+  teamId: string
+  members: Map<string, MemberWatcher>
+  configWatcher: chokidar.FSWatcher | null
+  configPath: string
+  lastMemberStates: Map<string, string>
+  headPollTimer: NodeJS.Timeout | null
+  jsonlStream: WriteStream | null
+  jsonlPath: string
+}
+
+const DEFAULT_LOG_DIR = path.join(os.homedir(), '.claude-forge', 'team-activity')
+
+/** chokidar ignore globs for member worktree watching. */
+const IGNORE_PATTERNS = [
+  /(^|[/\\])\..+/,     // dotfiles / dotdirs
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.git/**',
+  '**/coverage/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/__pycache__/**',
+]
+
+export class TeamActivityTracker extends EventEmitter {
+  private teams = new Map<string, TeamWatcher>()
+  private logDir: string
+  private gitAvailable: boolean | null = null
+
+  constructor(logDir: string = DEFAULT_LOG_DIR) {
+    super()
+    this.logDir = logDir
+    try {
+      mkdirSync(this.logDir, { recursive: true })
+    } catch {
+      // best-effort — emit() still works without persistence
+    }
+  }
+
+  /** Lazy git probe — cached since PATH is stable per process. */
+  private async hasGit(): Promise<boolean> {
+    if (this.gitAvailable !== null) return this.gitAvailable
+    try {
+      await execFileAsync('git', ['--version'], { timeout: 3000 })
+      this.gitAvailable = true
+    } catch {
+      this.gitAvailable = false
+    }
+    return this.gitAvailable
+  }
+
+  /**
+   * Start watching a team's members. Idempotent: calling start() again with
+   * the same teamId stops the previous watcher first.
+   */
+  async start(teamId: string, members: MemberSpec[], configPath?: string): Promise<void> {
+    if (!teamId) return
+    // Stop existing watcher if any.
+    await this.stop(teamId)
+
+    const memberMap = new Map<string, MemberWatcher>()
+    const lastStates = new Map<string, string>()
+    for (const m of members) {
+      lastStates.set(m.agentId, m.state ?? 'active')
+      if (!m.worktreePath) continue
+      try {
+        const exists = existsSync(m.worktreePath)
+        if (!exists) continue
+      } catch {
+        continue
+      }
+      const mw = this.spawnMemberWatcher(teamId, m)
+      if (mw) memberMap.set(m.agentId, mw)
+    }
+
+    let configWatcher: chokidar.FSWatcher | null = null
+    if (configPath && existsSync(configPath)) {
+      try {
+        configWatcher = chokidar.watch(configPath, {
+          persistent: true,
+          ignoreInitial: true,
+          awaitWriteFinish: { stabilityThreshold: 150, pollInterval: 50 },
+        })
+        configWatcher.on('change', () => {
+          this.handleConfigChange(teamId).catch(() => {
+            // ignore — best-effort
+          })
+        })
+      } catch {
+        configWatcher = null
+      }
+    }
+
+    let jsonlStream: WriteStream | null = null
+    const jsonlPath = path.join(this.logDir, `${teamId}.jsonl`)
+    try {
+      jsonlStream = createWriteStream(jsonlPath, { flags: 'a' })
+      jsonlStream.on('error', () => {
+        // disk full / permission — drop persistence but keep emitting
+        jsonlStream = null
+      })
+    } catch {
+      jsonlStream = null
+    }
+
+    const watcher: TeamWatcher = {
+      teamId,
+      members: memberMap,
+      configWatcher,
+      configPath: configPath ?? '',
+      lastMemberStates: lastStates,
+      headPollTimer: null,
+      jsonlStream,
+      jsonlPath,
+    }
+    this.teams.set(teamId, watcher)
+
+    // HEAD poll — single 1s timer per team scans all member worktrees.
+    if (await this.hasGit()) {
+      watcher.headPollTimer = setInterval(() => {
+        this.pollHeads(teamId).catch(() => {
+          // ignore — transient git failure
+        })
+      }, 1000)
+    }
+  }
+
+  private spawnMemberWatcher(teamId: string, member: MemberSpec): MemberWatcher | null {
+    if (!member.worktreePath) return null
+    let fsWatcher: chokidar.FSWatcher
+    try {
+      fsWatcher = chokidar.watch(member.worktreePath, {
+        persistent: true,
+        ignoreInitial: true,
+        ignored: IGNORE_PATTERNS,
+        depth: 8,
+        awaitWriteFinish: { stabilityThreshold: 250, pollInterval: 100 },
+      })
+    } catch {
+      return null
+    }
+
+    const mw: MemberWatcher = {
+      agentId: member.agentId,
+      worktreePath: member.worktreePath,
+      fsWatcher,
+      recentlyEmitted: new Map(),
+    }
+
+    const handle = (filePath: string) => {
+      // Coalesce repeated edits to the same file within 1.5s.
+      const now = Date.now()
+      const last = mw.recentlyEmitted.get(filePath) ?? 0
+      if (now - last < 1500) return
+      mw.recentlyEmitted.set(filePath, now)
+      // Lazy GC of the dedup map.
+      if (mw.recentlyEmitted.size > 256) {
+        for (const [k, v] of mw.recentlyEmitted) {
+          if (now - v > 60_000) mw.recentlyEmitted.delete(k)
+        }
+      }
+      this.handleFileChange(teamId, mw, filePath).catch(() => {
+        // ignore
+      })
+    }
+
+    fsWatcher.on('change', handle).on('add', handle)
+    fsWatcher.on('error', () => {
+      // Many transient errors are benign (EMFILE etc) — don't tear down the
+      // watcher, chokidar will recover.
+    })
+    return mw
+  }
+
+  private async handleFileChange(
+    teamId: string,
+    mw: MemberWatcher,
+    filePath: string,
+  ): Promise<void> {
+    const rel = path.relative(mw.worktreePath, filePath) || path.basename(filePath)
+    const event: ActivityEvent = {
+      ts: Date.now(),
+      teamId,
+      agent: mw.agentId,
+      kind: 'edit',
+      file: rel,
+    }
+
+    if (await this.hasGit()) {
+      try {
+        // --numstat against HEAD — captures uncommitted changes vs. last
+        // commit. Returns "<added>\t<removed>\t<file>" lines.
+        const { stdout } = await execFileAsync(
+          'git',
+          ['-C', mw.worktreePath, 'diff', '--numstat', '--', rel],
+          { timeout: 4000 },
+        )
+        const line = stdout.split('\n').find((l) => l.trim().length > 0)
+        if (line) {
+          const parts = line.split('\t')
+          const added = Number(parts[0])
+          const removed = Number(parts[1])
+          if (Number.isFinite(added)) event.added = added
+          if (Number.isFinite(removed)) event.removed = removed
+        }
+      } catch {
+        // ignore — emit edit without numbers
+      }
+    }
+    this.emitEvent(teamId, event)
+  }
+
+  private async pollHeads(teamId: string): Promise<void> {
+    const t = this.teams.get(teamId)
+    if (!t) return
+    for (const mw of t.members.values()) {
+      try {
+        const { stdout } = await execFileAsync(
+          'git',
+          ['-C', mw.worktreePath, 'rev-parse', 'HEAD'],
+          { timeout: 3000 },
+        )
+        const sha = stdout.trim()
+        if (!sha) continue
+        if (mw.lastHead === undefined) {
+          mw.lastHead = sha
+          continue
+        }
+        if (sha === mw.lastHead) continue
+
+        // HEAD moved — fetch the commit subject + file list.
+        let message = ''
+        try {
+          const { stdout: subj } = await execFileAsync(
+            'git',
+            ['-C', mw.worktreePath, 'log', '-1', '--pretty=%s', sha],
+            { timeout: 3000 },
+          )
+          message = subj.trim()
+        } catch {
+          // ignore
+        }
+        let files: string[] = []
+        try {
+          const { stdout: fl } = await execFileAsync(
+            'git',
+            ['-C', mw.worktreePath, 'show', '--name-only', '--pretty=', sha],
+            { timeout: 3000 },
+          )
+          files = fl.split('\n').map((s) => s.trim()).filter(Boolean)
+        } catch {
+          // ignore
+        }
+        const event: ActivityEvent = {
+          ts: Date.now(),
+          teamId,
+          agent: mw.agentId,
+          kind: 'commit',
+          message,
+          files,
+          sha: sha.slice(0, 7),
+        }
+        this.emitEvent(teamId, event)
+        mw.lastHead = sha
+      } catch {
+        // git failed — skip this round
+      }
+    }
+  }
+
+  private async handleConfigChange(teamId: string): Promise<void> {
+    const t = this.teams.get(teamId)
+    if (!t || !t.configPath) return
+    let raw: string
+    try {
+      raw = await fs.readFile(t.configPath, 'utf-8')
+    } catch {
+      return
+    }
+    let parsed: { members?: { agentId: string; state?: string }[] }
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return
+    }
+    const newStates = new Map<string, string>()
+    for (const m of parsed.members ?? []) {
+      newStates.set(m.agentId, m.state ?? 'active')
+    }
+    for (const [agentId, next] of newStates) {
+      const prev = t.lastMemberStates.get(agentId)
+      if (prev !== undefined && prev !== next) {
+        const event: ActivityEvent = {
+          ts: Date.now(),
+          teamId,
+          agent: agentId,
+          kind: 'state-change',
+          from: prev,
+          to: next,
+        }
+        this.emitEvent(teamId, event)
+      }
+    }
+    t.lastMemberStates = newStates
+  }
+
+  private emitEvent(teamId: string, event: ActivityEvent): void {
+    const t = this.teams.get(teamId)
+    if (!t) return
+    if (t.jsonlStream) {
+      try {
+        t.jsonlStream.write(JSON.stringify(event) + '\n')
+      } catch {
+        // ignore
+      }
+    }
+    this.emit('event', event)
+    this.emit(`event:${teamId}`, event)
+  }
+
+  /** Returns the most recent N events for a team from the JSONL log. */
+  async list(teamId: string, limit = 100): Promise<ActivityEvent[]> {
+    if (!teamId) return []
+    const file = path.join(this.logDir, `${teamId}.jsonl`)
+    let raw: string
+    try {
+      raw = await fs.readFile(file, 'utf-8')
+    } catch {
+      return []
+    }
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0)
+    const tail = lines.slice(-limit)
+    const out: ActivityEvent[] = []
+    for (const l of tail) {
+      try {
+        out.push(JSON.parse(l) as ActivityEvent)
+      } catch {
+        // ignore corrupt line
+      }
+    }
+    return out
+  }
+
+  /** Stop a single team's watchers + close the JSONL stream. */
+  async stop(teamId: string): Promise<void> {
+    const t = this.teams.get(teamId)
+    if (!t) return
+    if (t.headPollTimer) {
+      clearInterval(t.headPollTimer)
+      t.headPollTimer = null
+    }
+    for (const mw of t.members.values()) {
+      try {
+        await mw.fsWatcher.close()
+      } catch {
+        // ignore
+      }
+    }
+    t.members.clear()
+    if (t.configWatcher) {
+      try {
+        await t.configWatcher.close()
+      } catch {
+        // ignore
+      }
+      t.configWatcher = null
+    }
+    if (t.jsonlStream) {
+      try {
+        t.jsonlStream.end()
+      } catch {
+        // ignore
+      }
+      t.jsonlStream = null
+    }
+    this.teams.delete(teamId)
+  }
+
+  /** Stop every team — used on app shutdown. */
+  async stopAll(): Promise<void> {
+    const ids = Array.from(this.teams.keys())
+    for (const id of ids) {
+      await this.stop(id)
+    }
+  }
+
+  /** Snapshot of currently tracked team ids. */
+  trackedTeams(): string[] {
+    return Array.from(this.teams.keys())
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/components/v2/LiveTerminalGrid.tsx
+++ b/src/components/v2/LiveTerminalGrid.tsx
@@ -1,0 +1,584 @@
+// LiveTerminalGrid — real PTY-backed grid for RunLiveView.
+//
+// Each grid cell mounts (via portal) an `<XTerminal agent={...}>` instance bound
+// to the member's tmux pane. The xterm instance lives in a stable host element
+// keyed by `agentName`, so it survives layout transitions:
+//   normal grid (Nx M)  ↔  focus mode (1 expanded + thumbnails)  ↔  fullscreen
+// Without this portal pattern each layout reshape would tear down + respawn the
+// PTY (reattaching to tmux every time, losing scrollback, etc.).
+//
+// Fallback path: members without `tmuxPaneId` (shared worktree, tmux missing)
+// or in `queued` state render the design's "fake terminal lines" cycling — same
+// look the live view shipped with before real PTY landed.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Icon } from './icons'
+import { AgentBadge, Dot, STATE_COLOR, STATE_LABEL } from './primitives'
+import { AGENT_BY_ID } from './data'
+import { XTerminal } from './XTerminal'
+import type { TeamMember, TerminalLine } from './types'
+
+// ─── Slot registry (stable host per agentName) ─────────────────────
+
+type ElMap = Map<string, HTMLDivElement>
+
+interface SlotRegistry {
+  setSlot(key: string, el: HTMLDivElement | null): void
+  getOrCreateHost(key: string): HTMLDivElement
+  pruneHosts(activeKeys: ReadonlySet<string>): void
+  reattachAll(): void
+  subscribe(listener: () => void): () => void
+}
+
+function createSlotRegistry(): SlotRegistry {
+  const slots: ElMap = new Map()
+  const hosts: ElMap = new Map()
+  const listeners = new Set<() => void>()
+  const notify = () => listeners.forEach((l) => l())
+
+  const reattach = (key: string) => {
+    const slot = slots.get(key)
+    const host = hosts.get(key)
+    if (!slot || !host) return
+    if (host.parentElement !== slot) slot.appendChild(host)
+  }
+
+  return {
+    setSlot(key, el) {
+      if (el) {
+        slots.set(key, el)
+        reattach(key)
+        notify()
+      } else if (slots.has(key)) {
+        slots.delete(key)
+        notify()
+      }
+    },
+    getOrCreateHost(key) {
+      let host = hosts.get(key)
+      if (!host) {
+        host = document.createElement('div')
+        host.style.height = '100%'
+        host.style.width = '100%'
+        hosts.set(key, host)
+      }
+      return host
+    },
+    pruneHosts(activeKeys) {
+      for (const k of Array.from(hosts.keys())) {
+        if (!activeKeys.has(k)) {
+          hosts.get(k)?.remove()
+          hosts.delete(k)
+        }
+      }
+    },
+    reattachAll() {
+      for (const k of slots.keys()) reattach(k)
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}
+
+// ─── Cell slot (adopts the persistent host element) ────────────────
+
+interface CellSlotProps {
+  agentKey: string
+  registry: SlotRegistry
+}
+
+function CellSlot({ agentKey, registry }: CellSlotProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    registry.setSlot(agentKey, ref.current)
+    return () => registry.setSlot(agentKey, null)
+  }, [agentKey, registry])
+  return (
+    <div
+      ref={ref}
+      style={{
+        flex: 1,
+        minHeight: 0,
+        minWidth: 0,
+        display: 'flex',
+      }}
+    />
+  )
+}
+
+// ─── Pane shell (header + body container) ──────────────────────────
+
+interface PaneShellProps {
+  member: TeamMember
+  size: 'compact' | 'normal' | 'expanded'
+  onClick?: () => void
+  onClose?: () => void
+  onToggleFullscreen?: () => void
+  fullscreen?: boolean
+  children: React.ReactNode
+}
+
+function PaneShell({
+  member,
+  size,
+  onClick,
+  onClose,
+  onToggleFullscreen,
+  fullscreen,
+  children,
+}: PaneShellProps) {
+  const a = AGENT_BY_ID[member.agentId]
+  const stateC = STATE_COLOR[member.state]
+  const isActive = member.state === 'active'
+
+  const handleDoubleClick = (e: React.MouseEvent) => {
+    if (!onToggleFullscreen) return
+    e.stopPropagation()
+    onToggleFullscreen()
+  }
+
+  return (
+    <div
+      onClick={onClick}
+      onDoubleClick={handleDoubleClick}
+      style={{
+        height: '100%',
+        width: '100%',
+        borderRadius: 6,
+        background: '#0a0d12',
+        border: `1px solid ${
+          isActive
+            ? 'color-mix(in oklab, var(--success) 30%, var(--line-2))'
+            : 'var(--line-1)'
+        }`,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        cursor: onClick ? 'pointer' : 'default',
+        position: 'relative',
+        boxShadow: isActive
+          ? '0 0 0 1px color-mix(in oklab, var(--success) 18%, transparent), inset 0 0 32px rgba(74,222,128,0.04)'
+          : 'none',
+      }}
+    >
+      <div
+        className="ns"
+        style={{
+          height: 22,
+          flexShrink: 0,
+          background: 'var(--bg-2)',
+          borderBottom: '1px solid var(--line-1)',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 8px',
+          gap: 6,
+          fontSize: 10.5,
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--text-3)',
+        }}
+      >
+        <AgentBadge agentId={member.agentId} size={14} />
+        <span style={{ color: 'var(--text-2)' }}>{a?.name ?? member.agentId}</span>
+        <span>·</span>
+        <span
+          style={{
+            color: 'var(--text-3)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {member.pane}
+        </span>
+        <div style={{ flex: 1 }} />
+        <Dot color={stateC} pulse={isActive || member.state === 'blocked'} />
+        <span
+          style={{
+            color: stateC,
+            fontSize: 9,
+            fontWeight: 600,
+            letterSpacing: 0.3,
+          }}
+        >
+          {STATE_LABEL[member.state]}
+        </span>
+        {onToggleFullscreen && size !== 'compact' && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleFullscreen()
+            }}
+            title={fullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen (double-click)'}
+            style={{
+              width: 18,
+              height: 18,
+              marginLeft: 2,
+              borderRadius: 3,
+              background: 'transparent',
+              border: '1px solid transparent',
+              color: 'var(--text-3)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <Icon.Layers size={11} />
+          </button>
+        )}
+        {onClose && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onClose()
+            }}
+            title="Exit focus (Esc)"
+            style={{
+              width: 18,
+              height: 18,
+              marginLeft: 2,
+              borderRadius: 3,
+              background: 'transparent',
+              border: '1px solid transparent',
+              color: 'var(--text-3)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <Icon.X size={11} />
+          </button>
+        )}
+      </div>
+      <div style={{ flex: 1, minHeight: 0, position: 'relative', display: 'flex' }}>
+        {children}
+      </div>
+      {member.state === 'blocked' && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 22,
+            right: 8,
+            padding: '3px 7px',
+            background: 'color-mix(in oklab, var(--danger) 15%, var(--bg-2))',
+            border: '1px solid color-mix(in oklab, var(--danger) 35%, var(--line-2))',
+            borderRadius: 4,
+            fontSize: 10,
+            color: 'var(--danger)',
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 600,
+            zIndex: 2,
+            pointerEvents: 'none',
+          }}
+        >
+          ⚠ 결정 대기
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Fallback fake-terminal body (no PTY available / queued) ───────
+
+interface FakeBodyProps {
+  member: TeamMember
+  tick: number
+  size: 'compact' | 'normal' | 'expanded'
+  lines: TerminalLine[]
+  reason?: string
+}
+
+function FakeBody({ member, tick, size, lines, reason }: FakeBodyProps) {
+  const compact = size === 'compact'
+  const expanded = size === 'expanded'
+  const visibleCount = compact ? 4 : expanded ? 18 : 9
+  const offset = member.state === 'active' ? tick : 0
+  const slice: TerminalLine[] = []
+  for (let i = 0; i < visibleCount; i++) {
+    const idx = (offset + i) % lines.length
+    slice.push(lines[idx])
+  }
+  const isActive = member.state === 'active'
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: compact ? '6px 8px' : '8px 10px',
+        fontFamily: 'var(--font-mono)',
+        fontSize: compact ? 9.5 : expanded ? 12 : 10.5,
+        lineHeight: 1.5,
+        color: 'var(--text-2)',
+        overflow: 'hidden',
+        minHeight: 0,
+        position: 'relative',
+      }}
+    >
+      {slice.map((l, i) => (
+        <div
+          key={i}
+          style={{
+            color: l.c,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {l.t}
+          {i === slice.length - 1 && isActive && (
+            <span className="blink" style={{ color: 'var(--text-1)' }}>
+              ▍
+            </span>
+          )}
+        </div>
+      ))}
+      {reason && (
+        <div
+          style={{
+            position: 'absolute',
+            left: 8,
+            right: 8,
+            bottom: 6,
+            padding: '4px 8px',
+            background: 'color-mix(in oklab, var(--bg-3) 80%, transparent)',
+            border: '1px solid var(--line-2)',
+            borderRadius: 4,
+            fontSize: 10,
+            color: 'var(--text-3)',
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          {reason}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Main component ────────────────────────────────────────────────
+
+export interface LiveTerminalGridProps {
+  members: TeamMember[]
+  teamId: string
+  tick: number
+  selectedAgentId: string | null
+  onSelect: (id: string | null) => void
+  /** Fallback fake terminal lines keyed by agentId (used when tmuxPaneId is unset). */
+  terminalLines: Record<string, TerminalLine[]>
+}
+
+export function LiveTerminalGrid({
+  members,
+  teamId,
+  tick,
+  selectedAgentId,
+  onSelect,
+  terminalLines,
+}: LiveTerminalGridProps) {
+  // Stable registry across re-renders.
+  const registryRef = useRef<SlotRegistry | null>(null)
+  if (!registryRef.current) registryRef.current = createSlotRegistry()
+  const registry = registryRef.current
+
+  // Force re-render when slots change so portals reattach.
+  const [, force] = useState(0)
+  useEffect(() => registry.subscribe(() => force((n) => n + 1)), [registry])
+
+  // Fullscreen state — agentId, when set, takes over the entire grid.
+  const [fullscreenAgentId, setFullscreenAgentId] = useState<string | null>(null)
+
+  // ESC closes fullscreen (then focus mode, handled by parent via selectedAgentId).
+  useEffect(() => {
+    if (!fullscreenAgentId) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setFullscreenAgentId(null)
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [fullscreenAgentId])
+
+  // Members eligible for real PTY (have tmuxPaneId AND not in queued state).
+  const liveAgentKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const m of members) {
+      if (m.tmuxPaneId && m.state !== 'queued') {
+        keys.add(m.name ?? m.agentId)
+      }
+    }
+    return keys
+  }, [members])
+
+  // Prune hosts for agents that vanish (member removed) or lose tmuxPaneId.
+  useEffect(() => {
+    registry.pruneHosts(liveAgentKeys)
+    registry.reattachAll()
+  })
+
+  const layout = useMemo(() => {
+    const n = members.length
+    if (n <= 1) return { cols: 1, rows: 1 }
+    if (n === 2) return { cols: 2, rows: 1 }
+    if (n === 3) return { cols: 3, rows: 1 }
+    if (n === 4) return { cols: 2, rows: 2 }
+    if (n <= 6) return { cols: 3, rows: 2 }
+    return { cols: 4, rows: Math.ceil(n / 4) }
+  }, [members.length])
+
+  const renderBody = (member: TeamMember, size: 'compact' | 'normal' | 'expanded') => {
+    const agentKey = member.name ?? member.agentId
+    if (member.tmuxPaneId && member.state !== 'queued') {
+      return <CellSlot agentKey={agentKey} registry={registry} />
+    }
+    const reason = !member.tmuxPaneId
+      ? 'Terminal unavailable — shared worktree or tmux missing'
+      : member.state === 'queued'
+        ? 'Waiting…'
+        : undefined
+    const lines = terminalLines[member.agentId] ?? [
+      { c: 'var(--text-3)', t: '$ # waiting…' },
+      { c: 'var(--text-3)', t: '$ _' },
+    ]
+    return (
+      <FakeBody
+        member={member}
+        tick={tick}
+        size={size}
+        lines={lines}
+        reason={reason}
+      />
+    )
+  }
+
+  // ── Layout render ────────────────────────────────────────────────
+
+  let layoutNode: React.ReactNode
+
+  if (fullscreenAgentId) {
+    const fs = members.find((m) => m.agentId === fullscreenAgentId)
+    if (!fs) {
+      // Member vanished while fullscreen — drop back to grid.
+      setTimeout(() => setFullscreenAgentId(null), 0)
+    }
+    layoutNode = fs ? (
+      <div style={{ flex: 1, minHeight: 0, padding: 8 }}>
+        <PaneShell
+          member={fs}
+          size="expanded"
+          fullscreen
+          onToggleFullscreen={() => setFullscreenAgentId(null)}
+        >
+          {renderBody(fs, 'expanded')}
+        </PaneShell>
+      </div>
+    ) : null
+  } else if (selectedAgentId) {
+    const focused = members.find((m) => m.agentId === selectedAgentId)
+    const others = members.filter((m) => m.agentId !== selectedAgentId)
+    layoutNode = focused ? (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 8,
+          gap: 8,
+          minHeight: 0,
+        }}
+      >
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <PaneShell
+            member={focused}
+            size="expanded"
+            onClose={() => onSelect(null)}
+            onToggleFullscreen={() => setFullscreenAgentId(focused.agentId)}
+          >
+            {renderBody(focused, 'expanded')}
+          </PaneShell>
+        </div>
+        <div style={{ display: 'flex', gap: 8, height: 110, flexShrink: 0 }}>
+          {others.map((m) => (
+            <div key={m.agentId} style={{ flex: 1, minWidth: 0 }}>
+              <PaneShell
+                member={m}
+                size="compact"
+                onClick={() => onSelect(m.agentId)}
+              >
+                {renderBody(m, 'compact')}
+              </PaneShell>
+            </div>
+          ))}
+        </div>
+      </div>
+    ) : null
+  } else {
+    layoutNode = (
+      <div
+        style={{
+          flex: 1,
+          display: 'grid',
+          gridTemplateColumns: `repeat(${layout.cols}, 1fr)`,
+          gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
+          gap: 6,
+          padding: 8,
+          minHeight: 0,
+        }}
+      >
+        {members.map((m) => (
+          <PaneShell
+            key={m.agentId}
+            member={m}
+            size="normal"
+            onClick={() => onSelect(m.agentId)}
+            onToggleFullscreen={() => setFullscreenAgentId(m.agentId)}
+          >
+            {renderBody(m, 'normal')}
+          </PaneShell>
+        ))}
+      </div>
+    )
+  }
+
+  // ── Persistent xterm portals (one per live agent) ────────────────
+  // Rendered alongside the layout so each XTerminal component retains its
+  // mount across grid → focus → fullscreen transitions. The host is the
+  // adoption target; its current parent is whichever CellSlot last claimed it.
+  const portals = members
+    .filter((m) => m.tmuxPaneId && m.state !== 'queued')
+    .map((m) => {
+      const agentKey = m.name ?? m.agentId
+      const host = registry.getOrCreateHost(agentKey)
+      return createPortal(
+        <XTerminal
+          tabId={`team-${teamId}`}
+          paneId={`agent-${agentKey}`}
+          cwd=""
+          isActive
+          agent={{ teamId, agentName: agentKey }}
+        />,
+        host,
+        agentKey,
+      )
+    })
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+      }}
+    >
+      {layoutNode}
+      {portals}
+    </div>
+  )
+}

--- a/src/components/v2/ResourceBar.tsx
+++ b/src/components/v2/ResourceBar.tsx
@@ -2,7 +2,10 @@
  * ResourceBar — workspace footer strip showing live machine usage.
  *
  * Renders four metered fields: CPU · MEM · DISK · PTY.
- * Values self-tick every 1.5s when no real metrics are supplied.
+ * Pulls real metrics from main via `window.api.system.resourceSnapshot()`
+ * every 5s. When the IPC bridge is unavailable (older preload, storybook,
+ * etc.) the bar renders zeros so it's visibly inert rather than showing
+ * synthetic values.
  *
  * Source: /tmp/forge_design/forge/project/src/workspace_v2.jsx (ResourceBar).
  */
@@ -10,10 +13,9 @@ import { useEffect, useState } from 'react'
 import type { ResourceUsage } from './types'
 
 export interface ResourceBarProps {
-  /** Number of active runs — used to nudge synthetic CPU/PTY when no real
-   *  metrics are supplied. */
+  /** Number of active runs — surfaced in the footer hint. */
   runsActive?: number
-  /** Real machine metrics. When supplied, overrides synthetic values. */
+  /** Real machine metrics. When supplied, overrides the live snapshot. */
   usage?: Partial<ResourceUsage>
   /** Footer hint shown on the right. */
   hint?: string
@@ -25,41 +27,86 @@ interface MeterItem {
   pct: number
 }
 
+interface ResourceSnapshot extends ResourceUsage {
+  ts: number
+}
+
 export function ResourceBar({
   runsActive = 0,
   usage,
   hint = '무제한 정책 · 자원 표시는 정직성 위주',
 }: ResourceBarProps) {
-  const [tick, setTick] = useState(0)
+  const [snap, setSnap] = useState<ResourceSnapshot | null>(null)
 
   useEffect(() => {
-    if (usage) return // real metrics — no synthetic ticking needed
-    const id = setInterval(() => setTick((t) => t + 1), 1500)
-    return () => clearInterval(id)
+    if (usage) return // explicit override — skip polling entirely
+    let cancelled = false
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sysApi = (window as any)?.api?.system as
+      | { resourceSnapshot?: () => Promise<ResourceSnapshot> }
+      | undefined
+    if (typeof sysApi?.resourceSnapshot !== 'function') {
+      // No IPC — leave snap null so we render zeros.
+      return
+    }
+    const tick = async () => {
+      try {
+        const next = await sysApi.resourceSnapshot!()
+        if (!cancelled) setSnap(next)
+      } catch (err) {
+        // Defer to the next tick — single failures shouldn't blank the bar.
+        console.warn('[ResourceBar] snapshot failed:', err)
+      }
+    }
+    tick()
+    const id = setInterval(tick, 5000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
   }, [usage])
 
-  // Synthetic values seeded by tick + runsActive so the bar feels alive even
-  // when no IPC metrics provider is wired yet.
-  const synth = {
-    cpu: 28 + Math.round(Math.sin(tick / 3) * 6 + runsActive * 4),
-    memUsed: 6.4 + Math.sin(tick / 5) * 0.3,
-    memTotal: 32,
-    diskMb: 142,
-    ptys: 14 + runsActive * 2,
-  }
+  const cpu = usage?.cpu ?? snap?.cpu ?? 0
+  const memUsed = usage?.memUsed ?? snap?.memUsed ?? 0
+  const memTotal = usage?.memTotal ?? snap?.memTotal ?? 0
+  const memTotalSafe = memTotal > 0 ? memTotal : 1
+  const diskGb = usage?.diskDeltaGb ?? snap?.diskDeltaGb ?? 0
+  const ptys = usage?.ptyCount ?? snap?.ptyCount ?? 0
 
-  const cpu = usage?.cpu ?? synth.cpu
-  const memUsed = usage?.memUsed ?? synth.memUsed
-  const memTotal = usage?.memTotal ?? synth.memTotal
-  const diskMb = usage?.diskDeltaGb != null ? usage.diskDeltaGb * 1024 : synth.diskMb
-  const ptys = usage?.ptyCount ?? synth.ptys
+  const diskLabel =
+    diskGb >= 1
+      ? `${diskGb.toFixed(1)} GB worktree growth`
+      : `${Math.max(0, Math.round(diskGb * 1024))} MB worktree growth`
 
   const items: MeterItem[] = [
     { label: 'CPU',  value: `${Math.round(cpu)}%`,                        pct: cpu / 100 },
-    { label: 'MEM',  value: `${memUsed.toFixed(1)} / ${memTotal} GB`,     pct: memUsed / memTotal },
-    { label: 'DISK', value: `${Math.round(diskMb)} MB worktrees`,         pct: 0.18 },
+    {
+      label: 'MEM',
+      value: `${memUsed.toFixed(1)} / ${memTotal > 0 ? memTotal.toFixed(0) : '—'} GB`,
+      pct: memUsed / memTotalSafe,
+    },
+    { label: 'DISK', value: diskLabel,                                    pct: Math.min(0.5, diskGb / 50) },
     { label: 'PTY',  value: `${ptys} sessions`,                           pct: ptys / 64 },
   ]
+
+  // Threshold-aware bar colour. CPU/MEM use the spec'd 80%/85% warn lines.
+  function colourFor(label: string, pct: number): string {
+    if (label === 'CPU') {
+      if (pct > 0.9) return 'var(--danger)'
+      if (pct > 0.8) return 'var(--warning)'
+      return 'var(--success)'
+    }
+    if (label === 'MEM') {
+      if (pct > 0.95) return 'var(--danger)'
+      if (pct > 0.85) return 'var(--warning)'
+      return 'var(--success)'
+    }
+    if (pct > 0.85) return 'var(--danger)'
+    if (pct > 0.65) return 'var(--warning)'
+    return 'var(--success)'
+  }
+
+  const footer = runsActive > 0 ? `${hint} · ${runsActive} runs` : hint
 
   return (
     <div
@@ -86,11 +133,8 @@ export function ResourceBar({
           }}>
             <span style={{
               display: 'block', height: '100%',
-              width: `${Math.min(100, it.pct * 100)}%`,
-              background:
-                it.pct > 0.85 ? 'var(--danger)'
-                : it.pct > 0.65 ? 'var(--warning)'
-                : 'var(--success)',
+              width: `${Math.min(100, Math.max(0, it.pct * 100))}%`,
+              background: colourFor(it.label, it.pct),
             }} />
           </span>
           <span className="tabular" style={{ color: 'var(--text-2)' }}>
@@ -99,7 +143,7 @@ export function ResourceBar({
         </span>
       ))}
       <div style={{ flex: 1 }} />
-      <span style={{ color: 'var(--text-4)' }}>{hint}</span>
+      <span style={{ color: 'var(--text-4)' }}>{footer}</span>
     </div>
   )
 }

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -5,7 +5,7 @@
 // using mock terminal lines + a tick-driven activity feed. The real PTY wiring is
 // a future integration; for now it consumes seed data via props.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 // TODO: foundation import — provided by main session
 import { Icon } from './icons'
 import {
@@ -18,9 +18,14 @@ import {
   STATE_COLOR,
   STATE_LABEL,
 } from './primitives'
-import { AGENT_BY_ID, ACTIVITY, TERMINAL_LINES } from './data'
+import { AGENT_BY_ID, TERMINAL_LINES } from './data'
 import type { Team, TeamMember, ActivityItem, MemberState, TerminalLine } from './types'
 import { MergeConflictView, type ConflictItem } from './MergeConflictView'
+import { LiveTerminalGrid } from './LiveTerminalGrid'
+import {
+  useTeamActivityStore,
+  type ActivityEntry as RealActivityEntry,
+} from '@/stores/teamActivity'
 
 // ─── Optional team-control IPC (graceful when backend is unfinished) ─
 //
@@ -50,7 +55,12 @@ export interface RunLiveViewProps {
   team: Team
   onClose: () => void
   density?: 'compact' | 'normal' | 'spacious'
-  /** Optional override of the activity feed; defaults to seed `ACTIVITY`. */
+  /**
+   * Optional override of the activity feed. When omitted, the feed pulls
+   * real entries from the `teamActivity` zustand store (driven by main's
+   * TeamActivityTracker) and falls back to an empty-state placeholder if
+   * nothing has been observed yet.
+   */
   activity?: ActivityItem[]
   /** Optional override of pane terminal lines by agentId; defaults to seed `TERMINAL_LINES`. */
   terminalLines?: Record<string, TerminalLine[]>
@@ -59,7 +69,7 @@ export interface RunLiveViewProps {
 export function RunLiveView({
   team,
   onClose,
-  activity = ACTIVITY,
+  activity,
   terminalLines = TERMINAL_LINES,
 }: RunLiveViewProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
@@ -91,6 +101,43 @@ export function RunLiveView({
     const id = setInterval(() => setTick((t) => t + 1), 1200)
     return () => clearInterval(id)
   }, [paused])
+
+  // ── Real activity feed (TeamActivityTracker → store) ──────────────
+  //
+  // When the caller doesn't override `activity` we subscribe to live events
+  // for this team. The store ref-counts subscribers + tears down the IPC
+  // listener when the last consumer unmounts.
+  const subscribeActivity = useTeamActivityStore((s) => s.subscribe)
+  const unsubscribeActivity = useTeamActivityStore((s) => s.unsubscribe)
+  const teamEntries = useTeamActivityStore((s) => s.entries[team.id])
+  useEffect(() => {
+    if (activity) return // override active — don't double-fetch
+    let cancelled = false
+    subscribeActivity(team.id).catch(() => {
+      // hydrate failure is non-fatal — live stream still works
+    })
+    return () => {
+      cancelled = true
+      // Defer unsubscribe so back-to-back remounts don't thrash IPC. Effect
+      // cleanup runs synchronously, microtask is enough.
+      Promise.resolve().then(() => {
+        if (cancelled) unsubscribeActivity(team.id)
+      })
+    }
+  }, [team.id, activity, subscribeActivity, unsubscribeActivity])
+
+  /**
+   * Render-time mapping from the persistence shape to the v2 `ActivityItem`
+   * the feed renderer already understands. We always return a stable list:
+   *   - explicit `activity` prop wins (used by the design demo)
+   *   - else live store entries, mapped via realToActivityItem
+   *   - else an empty array → empty-state placeholder in <ActivityFeed/>
+   */
+  const feedItems = useMemo<ActivityItem[]>(() => {
+    if (activity) return activity
+    if (!teamEntries || teamEntries.length === 0) return []
+    return teamEntries.map(realToActivityItem)
+  }, [activity, teamEntries])
 
   // ── Action handlers (all IPC-optional) ──────────────────────────
   async function handlePauseAll() {
@@ -350,8 +397,9 @@ export function RunLiveView({
             background: '#06080b',
           }}
         >
-          <TmuxGrid
+          <LiveTerminalGrid
             members={team.members}
+            teamId={team.id}
             tick={tick}
             selectedAgentId={selectedAgentId}
             onSelect={setSelectedAgentId}
@@ -394,7 +442,7 @@ export function RunLiveView({
                 </button>
               }
             />
-            <ActivityFeed tick={tick} paused={paused} items={activity} />
+            <ActivityFeed tick={tick} paused={paused} items={feedItems} />
           </div>
         )}
       </div>
@@ -717,272 +765,6 @@ function CardIconBtn({ children, title, disabled, danger, dim, onClick }: CardIc
   )
 }
 
-// ─── tmux split grid ────────────────────────────────────────────────
-
-interface TmuxGridProps {
-  members: TeamMember[]
-  tick: number
-  selectedAgentId: string | null
-  onSelect: (id: string | null) => void
-  terminalLines: Record<string, TerminalLine[]>
-}
-
-function TmuxGrid({ members, tick, selectedAgentId, onSelect, terminalLines }: TmuxGridProps) {
-  const layout = useMemo(() => {
-    const n = members.length
-    if (n <= 1) return { cols: 1, rows: 1 }
-    if (n === 2) return { cols: 2, rows: 1 }
-    if (n === 3) return { cols: 3, rows: 1 }
-    if (n === 4) return { cols: 2, rows: 2 }
-    if (n <= 6) return { cols: 3, rows: 2 }
-    return { cols: 4, rows: Math.ceil(n / 4) }
-  }, [members.length])
-
-  if (selectedAgentId) {
-    const focused = members.find((m) => m.agentId === selectedAgentId)
-    const others = members.filter((m) => m.agentId !== selectedAgentId)
-    if (!focused) return null
-    return (
-      <div
-        style={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          padding: 8,
-          gap: 8,
-          minHeight: 0,
-        }}
-      >
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <TmuxPane
-            member={focused}
-            tick={tick}
-            expanded
-            onClose={() => onSelect(null)}
-            terminalLines={terminalLines}
-          />
-        </div>
-        <div style={{ display: 'flex', gap: 8, height: 110 }}>
-          {others.map((m) => (
-            <div key={m.agentId} style={{ flex: 1, minWidth: 0 }}>
-              <TmuxPane
-                member={m}
-                tick={tick}
-                compact
-                onClick={() => onSelect(m.agentId)}
-                terminalLines={terminalLines}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div
-      style={{
-        flex: 1,
-        display: 'grid',
-        gridTemplateColumns: `repeat(${layout.cols}, 1fr)`,
-        gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
-        gap: 6,
-        padding: 8,
-        minHeight: 0,
-      }}
-    >
-      {members.map((m) => (
-        <TmuxPane
-          key={m.agentId}
-          member={m}
-          tick={tick}
-          onClick={() => onSelect(m.agentId)}
-          terminalLines={terminalLines}
-        />
-      ))}
-    </div>
-  )
-}
-
-interface TmuxPaneProps {
-  member: TeamMember
-  tick: number
-  compact?: boolean
-  expanded?: boolean
-  onClick?: () => void
-  onClose?: () => void
-  terminalLines: Record<string, TerminalLine[]>
-}
-
-function TmuxPane({
-  member,
-  tick,
-  compact,
-  expanded,
-  onClick,
-  onClose,
-  terminalLines,
-}: TmuxPaneProps) {
-  const a = AGENT_BY_ID[member.agentId]
-  const lines: TerminalLine[] =
-    terminalLines[member.agentId] ?? [
-      { c: 'var(--text-3)', t: '$ # waiting…' },
-      { c: 'var(--text-3)', t: '$ _' },
-    ]
-  const visibleCount = compact ? 4 : expanded ? 18 : 9
-  const offset = member.state === 'active' ? tick : 0
-  const slice: TerminalLine[] = []
-  for (let i = 0; i < visibleCount; i++) {
-    const idx = (offset + i) % lines.length
-    slice.push(lines[idx])
-  }
-
-  const stateC = STATE_COLOR[member.state]
-  const isActive = member.state === 'active'
-
-  return (
-    <div
-      onClick={onClick}
-      style={{
-        borderRadius: 6,
-        background: '#0a0d12',
-        border: `1px solid ${
-          isActive
-            ? 'color-mix(in oklab, var(--success) 30%, var(--line-2))'
-            : 'var(--line-1)'
-        }`,
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        cursor: onClick ? 'pointer' : 'default',
-        position: 'relative',
-        boxShadow: isActive
-          ? '0 0 0 1px color-mix(in oklab, var(--success) 18%, transparent), inset 0 0 32px rgba(74,222,128,0.04)'
-          : 'none',
-      }}
-    >
-      {/* pane title */}
-      <div
-        className="ns"
-        style={{
-          height: 22,
-          flexShrink: 0,
-          background: 'var(--bg-2)',
-          borderBottom: '1px solid var(--line-1)',
-          display: 'flex',
-          alignItems: 'center',
-          padding: '0 8px',
-          gap: 6,
-          fontSize: 10.5,
-          fontFamily: 'var(--font-mono)',
-          color: 'var(--text-3)',
-        }}
-      >
-        <AgentBadge agentId={member.agentId} size={14} />
-        <span style={{ color: 'var(--text-2)' }}>{a?.name ?? member.agentId}</span>
-        <span>·</span>
-        <span
-          style={{
-            color: 'var(--text-3)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {member.pane}
-        </span>
-        <div style={{ flex: 1 }} />
-        <Dot color={stateC} pulse={isActive || member.state === 'blocked'} />
-        <span
-          style={{
-            color: stateC,
-            fontSize: 9,
-            fontWeight: 600,
-            letterSpacing: 0.3,
-          }}
-        >
-          {STATE_LABEL[member.state]}
-        </span>
-        {expanded && onClose && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onClose()
-            }}
-            style={{
-              width: 18,
-              height: 18,
-              marginLeft: 4,
-              borderRadius: 3,
-              background: 'transparent',
-              border: '1px solid transparent',
-              color: 'var(--text-3)',
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              cursor: 'pointer',
-            }}
-          >
-            <Icon.X size={11} />
-          </button>
-        )}
-      </div>
-      {/* body */}
-      <div
-        style={{
-          flex: 1,
-          padding: compact ? '6px 8px' : '8px 10px',
-          fontFamily: 'var(--font-mono)',
-          fontSize: compact ? 9.5 : expanded ? 12 : 10.5,
-          lineHeight: 1.5,
-          color: 'var(--text-2)',
-          overflow: 'hidden',
-          minHeight: 0,
-        }}
-      >
-        {slice.map((l, i) => (
-          <div
-            key={i}
-            style={{
-              color: l.c,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {l.t}
-            {i === slice.length - 1 && isActive && (
-              <span className="blink" style={{ color: 'var(--text-1)' }}>
-                ▍
-              </span>
-            )}
-          </div>
-        ))}
-      </div>
-      {/* blocked overlay */}
-      {member.state === 'blocked' && (
-        <div
-          style={{
-            position: 'absolute',
-            top: 22,
-            right: 8,
-            padding: '3px 7px',
-            background: 'color-mix(in oklab, var(--danger) 15%, var(--bg-2))',
-            border: '1px solid color-mix(in oklab, var(--danger) 35%, var(--line-2))',
-            borderRadius: 4,
-            fontSize: 10,
-            color: 'var(--danger)',
-            fontFamily: 'var(--font-mono)',
-            fontWeight: 600,
-          }}
-        >
-          ⚠ 결정 대기
-        </div>
-      )}
-    </div>
-  )
-}
-
 // ─── Activity feed (right column) ───────────────────────────────────
 
 interface ActivityFeedProps {
@@ -1012,8 +794,48 @@ const KIND_LABEL: Record<ActivityItem['kind'], string> = {
 }
 
 function ActivityFeed({ tick, paused, items }: ActivityFeedProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  // Auto-scroll-to-top when a new entry is prepended. We compare lengths +
+  // the head item identity (text+timestamp) to avoid scrolling on every
+  // re-render unrelated to insertion.
+  const prevHeadKeyRef = useRef<string>('')
+  useEffect(() => {
+    if (!items.length) return
+    const head = items[0]
+    const key = `${head.t}:${head.text}:${items.length}`
+    if (key !== prevHeadKeyRef.current) {
+      prevHeadKeyRef.current = key
+      const el = scrollRef.current
+      if (el) {
+        // requestAnimationFrame so the DOM has the new node before we move.
+        requestAnimationFrame(() => {
+          el.scrollTop = 0
+        })
+      }
+    }
+  }, [items])
+
+  if (items.length === 0) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '20px 16px',
+          textAlign: 'center',
+          color: 'var(--text-4)',
+          fontSize: 11.5,
+          lineHeight: 1.5,
+        }}
+      >
+        활동 없음 — 첫 변경을 기다리는 중
+      </div>
+    )
+  }
   return (
-    <div style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
+    <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
       {items.map((it, i) => {
         const a = AGENT_BY_ID[it.agent]
         const isNew = !paused && i === tick % 3 && i < 3
@@ -1021,7 +843,7 @@ function ActivityFeed({ tick, paused, items }: ActivityFeedProps) {
         const kindLabel = KIND_LABEL[it.kind]
         return (
           <div
-            key={i}
+            key={`${it.t}-${i}`}
             style={{
               display: 'flex',
               gap: 10,
@@ -1084,6 +906,58 @@ function ActivityFeed({ tick, paused, items }: ActivityFeedProps) {
       })}
     </div>
   )
+}
+
+// ─── Real activity → ActivityItem mapping ───────────────────────────
+//
+// TeamActivityTracker emits structured records; the v2 ActivityItem feed
+// expects { t, agent, kind, text }. We collapse the structured fields into
+// a one-line `text` per kind:
+//   edit   → "<file> +A -R"
+//   commit → "<sha> <subject> · N files"
+//   state  → "state: <from> → <to>"
+//
+// Kind is mapped onto the existing palette (edit/commit/decision/queued/done)
+// — state-change becomes 'decision' so it picks up the accent colour.
+
+function realToActivityItem(e: RealActivityEntry): ActivityItem {
+  const time = formatHHMMSS(e.ts)
+  if (e.kind === 'edit') {
+    const parts: string[] = [e.file ?? '(unknown)']
+    if (typeof e.added === 'number' || typeof e.removed === 'number') {
+      const a = typeof e.added === 'number' ? `+${e.added}` : ''
+      const r = typeof e.removed === 'number' ? `-${e.removed}` : ''
+      parts.push([a, r].filter(Boolean).join(' '))
+    }
+    return { t: time, agent: e.agent, kind: 'edit', text: parts.join(' ') }
+  }
+  if (e.kind === 'commit') {
+    const fileCount = e.files?.length ?? 0
+    const fileSuffix = fileCount > 0 ? ` · ${fileCount} files` : ''
+    const subj = e.message?.trim() || '(no message)'
+    const sha = e.sha ? `${e.sha} ` : ''
+    return {
+      t: time,
+      agent: e.agent,
+      kind: 'commit',
+      text: `${sha}${subj}${fileSuffix}`,
+    }
+  }
+  // state-change
+  return {
+    t: time,
+    agent: e.agent,
+    kind: 'decision',
+    text: `state: ${e.from ?? '?'} → ${e.to ?? '?'}`,
+  }
+}
+
+function formatHHMMSS(ms: number): string {
+  const d = new Date(ms)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return `${hh}:${mm}:${ss}`
 }
 
 // Re-exports for convenience

--- a/src/components/v2/WorkspaceV2.tsx
+++ b/src/components/v2/WorkspaceV2.tsx
@@ -286,26 +286,113 @@ function RunBackBar({ team, onClose }: RunBackBarProps) {
 
 export interface ResourceBarProps {
   runs: Team[]
+  /**
+   * Optional override of the live snapshot. When supplied, the bar skips IPC
+   * polling and renders these values directly — used by storybook / preview
+   * surfaces and by callers that already cache the snapshot upstream.
+   */
+  usage?: Partial<{
+    cpu: number
+    memUsed: number
+    memTotal: number
+    diskDeltaGb: number
+    ptyCount: number
+  }>
 }
 
-export function ResourceBar({ runs }: ResourceBarProps) {
-  const [tick, setTick] = useState(0)
+interface ResourceSnapshot {
+  cpu: number
+  memUsed: number
+  memTotal: number
+  diskDeltaGb: number
+  ptyCount: number
+  ts: number
+}
+
+export function ResourceBar({ runs, usage }: ResourceBarProps) {
+  // Live snapshot pulled from main every 5s. Initial state mirrors the
+  // "nothing measured yet" case so the bar renders immediately at zero
+  // instead of flashing fake values.
+  const [snap, setSnap] = useState<ResourceSnapshot | null>(null)
+
   useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 1500)
-    return () => clearInterval(id)
-  }, [])
-  // Fake-fluctuating values seeded by tick
-  const cpu = 28 + Math.round(Math.sin(tick / 3) * 6 + runs.length * 4)
-  const mem = 6.4 + Math.sin(tick / 5) * 0.3
-  const memMax = 32
-  const disk = 142
-  const ptys = 14 + runs.length * 2
+    if (usage) return // override path — skip polling entirely
+    let cancelled = false
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sysApi = (window as any)?.api?.system as
+      | { resourceSnapshot?: () => Promise<ResourceSnapshot> }
+      | undefined
+    if (typeof sysApi?.resourceSnapshot !== 'function') {
+      // IPC not wired (older preload) — leave the bar in its zero state so
+      // it's visibly inert rather than lying with synthetic values.
+      return
+    }
+    const tick = async () => {
+      try {
+        const next = await sysApi.resourceSnapshot!()
+        if (!cancelled) setSnap(next)
+      } catch (err) {
+        // swallow — the next interval will retry
+        console.warn('[ResourceBar] snapshot failed:', err)
+      }
+    }
+    tick()
+    const id = setInterval(tick, 5000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [usage])
+
+  // Pick fields with usage > snap > defaults precedence so test/preview
+  // overrides win without forcing the caller to supply every value.
+  const cpu = usage?.cpu ?? snap?.cpu ?? 0
+  const memUsed = usage?.memUsed ?? snap?.memUsed ?? 0
+  const memTotalRaw = usage?.memTotal ?? snap?.memTotal ?? 0
+  const memTotal = memTotalRaw > 0 ? memTotalRaw : 1 // avoid /0 in pct
+  const diskDeltaGb = usage?.diskDeltaGb ?? snap?.diskDeltaGb ?? 0
+  // ptyCount defaults to runs.length × 2 only if no real PTY count is known
+  // — it's better to show "0 sessions" than a synthetic number, but we do
+  // surface a hint so the bar isn't blank during the very first poll.
+  const ptyCount = usage?.ptyCount ?? snap?.ptyCount ?? 0
+
+  // Disk: show MB when small, GB when bigger.
+  const diskLabel =
+    diskDeltaGb >= 1
+      ? `${diskDeltaGb.toFixed(1)} GB worktree growth`
+      : `${Math.max(0, Math.round(diskDeltaGb * 1024))} MB worktree growth`
+
   const items = [
-    { label: 'CPU', value: `${cpu}%`, pct: cpu / 100 },
-    { label: 'MEM', value: `${mem.toFixed(1)} / ${memMax} GB`, pct: mem / memMax },
-    { label: 'DISK', value: `${disk} MB worktrees`, pct: 0.18 },
-    { label: 'PTY', value: `${ptys} sessions`, pct: ptys / 64 },
+    { label: 'CPU', value: `${Math.round(cpu)}%`, pct: cpu / 100 },
+    {
+      label: 'MEM',
+      value: `${memUsed.toFixed(1)} / ${memTotalRaw > 0 ? memTotalRaw.toFixed(0) : '—'} GB`,
+      pct: memUsed / memTotal,
+    },
+    { label: 'DISK', value: diskLabel, pct: Math.min(0.5, diskDeltaGb / 50) },
+    { label: 'PTY', value: `${ptyCount} sessions`, pct: ptyCount / 64 },
   ]
+
+  // Promote bar colour to warning/danger thresholds:
+  //   CPU > 80% → warning, CPU > 90% → danger
+  //   MEM > 85% → warning, MEM > 95% → danger
+  // Other meters use the linear gradient logic from the original design.
+  function colourFor(label: string, pct: number): string {
+    if (label === 'CPU') {
+      if (pct > 0.9) return 'var(--danger)'
+      if (pct > 0.8) return 'var(--warning)'
+      return 'var(--success)'
+    }
+    if (label === 'MEM') {
+      if (pct > 0.95) return 'var(--danger)'
+      if (pct > 0.85) return 'var(--warning)'
+      return 'var(--success)'
+    }
+    if (pct > 0.85) return 'var(--danger)'
+    if (pct > 0.65) return 'var(--warning)'
+    return 'var(--success)'
+  }
+
   return (
     <div
       className="ns mono"
@@ -344,13 +431,8 @@ export function ResourceBar({ runs }: ResourceBarProps) {
               style={{
                 display: 'block',
                 height: '100%',
-                width: `${Math.min(100, it.pct * 100)}%`,
-                background:
-                  it.pct > 0.85
-                    ? 'var(--danger)'
-                    : it.pct > 0.65
-                      ? 'var(--warning)'
-                      : 'var(--success)',
+                width: `${Math.min(100, Math.max(0, it.pct * 100))}%`,
+                background: colourFor(it.label, it.pct),
               }}
             />
           </span>
@@ -362,6 +444,7 @@ export function ResourceBar({ runs }: ResourceBarProps) {
       <div style={{ flex: 1 }} />
       <span style={{ color: 'var(--text-4)' }}>
         무제한 정책 · 자원 표시는 정직성 위주
+        {runs.length > 0 ? ` · ${runs.length} runs` : ''}
       </span>
     </div>
   )

--- a/src/stores/teamActivity.ts
+++ b/src/stores/teamActivity.ts
@@ -1,0 +1,137 @@
+/**
+ * teamActivity store — pulls historical events from
+ * `window.api.teamActivity.list(teamId)` and overlays live pushes from
+ * `onEvent`. Each team holds its own bounded ring (newest first, max 200)
+ * so RunLiveView's feed never grows unbounded over a long-running team.
+ *
+ * Subscription is reference-counted: if two views ask for the same team,
+ * we share a single onEvent handler. A subscriber is only torn down when
+ * the last consumer unsubscribes.
+ */
+import { create } from 'zustand'
+
+export type ActivityKind = 'edit' | 'commit' | 'state-change'
+
+export interface ActivityEntry {
+  ts: number
+  teamId: string
+  agent: string
+  kind: ActivityKind
+  file?: string
+  added?: number
+  removed?: number
+  message?: string
+  files?: string[]
+  sha?: string
+  from?: string
+  to?: string
+  text?: string
+}
+
+const MAX_PER_TEAM = 200
+
+interface TeamActivityState {
+  /** entries[teamId] is sorted newest-first. */
+  entries: Record<string, ActivityEntry[]>
+  /** Per-team subscriber refcount (so multiple consumers share one IPC handler). */
+  subscriberCounts: Record<string, number>
+  /** The single global IPC unsubscribe — set once on first subscribe(). */
+  globalOff: (() => void) | null
+
+  subscribe: (teamId: string) => Promise<void>
+  unsubscribe: (teamId: string) => void
+  /** Internal: ingest a single event. Exported on the store so tests can poke it. */
+  ingest: (event: ActivityEntry) => void
+  /** Drop all entries for a team — used when teams are removed. */
+  clear: (teamId: string) => void
+}
+
+function pushBounded(list: ActivityEntry[], event: ActivityEntry): ActivityEntry[] {
+  const next = [event, ...list]
+  if (next.length > MAX_PER_TEAM) next.length = MAX_PER_TEAM
+  return next
+}
+
+export const useTeamActivityStore = create<TeamActivityState>((set, get) => ({
+  entries: {},
+  subscriberCounts: {},
+  globalOff: null,
+
+  ingest: (event: ActivityEntry) => {
+    if (!event || !event.teamId) return
+    set((s) => {
+      const cur = s.entries[event.teamId] ?? []
+      return {
+        entries: {
+          ...s.entries,
+          [event.teamId]: pushBounded(cur, event),
+        },
+      }
+    })
+  },
+
+  subscribe: async (teamId: string) => {
+    if (!teamId) return
+    const api = window.api?.teamActivity
+    // Bump the per-team refcount and lazily attach the global onEvent
+    // listener exactly once.
+    const counts = get().subscriberCounts
+    set({
+      subscriberCounts: { ...counts, [teamId]: (counts[teamId] ?? 0) + 1 },
+    })
+    if (!get().globalOff && typeof api?.onEvent === 'function') {
+      const off = api.onEvent((event) => {
+        // Filter inside the store so a single channel can fan out to N teams.
+        get().ingest(event as ActivityEntry)
+      })
+      set({ globalOff: off })
+    }
+
+    // Hydrate the team's history if we don't already have it. Failures here
+    // are non-fatal — the live stream will populate over time.
+    if (!get().entries[teamId] && typeof api?.list === 'function') {
+      try {
+        const past = await api.list(teamId, MAX_PER_TEAM)
+        const sorted = (past as ActivityEntry[])
+          .slice()
+          .sort((a, b) => b.ts - a.ts)
+          .slice(0, MAX_PER_TEAM)
+        set((s) => ({
+          entries: { ...s.entries, [teamId]: sorted },
+        }))
+      } catch (err) {
+        console.warn('[teamActivity] list failed:', err)
+        set((s) => ({
+          entries: { ...s.entries, [teamId]: s.entries[teamId] ?? [] },
+        }))
+      }
+    }
+  },
+
+  unsubscribe: (teamId: string) => {
+    if (!teamId) return
+    const counts = get().subscriberCounts
+    const cur = counts[teamId] ?? 0
+    const next = Math.max(0, cur - 1)
+    const updated = { ...counts, [teamId]: next }
+    if (next === 0) delete updated[teamId]
+    set({ subscriberCounts: updated })
+
+    // Tear down the global listener only when no team has any subscriber.
+    const stillActive = Object.values(updated).some((n) => n > 0)
+    if (!stillActive) {
+      const off = get().globalOff
+      if (off) off()
+      set({ globalOff: null })
+    }
+  },
+
+  clear: (teamId: string) => {
+    if (!teamId) return
+    set((s) => {
+      const next = { ...s.entries }
+      delete next[teamId]
+      return { entries: next }
+    })
+  },
+}))


### PR DESCRIPTION
## 요약
RunLiveView 의 마지막 mock 영역 3종을 실 데이터로 교체.

- **tmux split grid** → 실제 멤버 tmux PTY 라이브 attach (LiveTerminalGrid + portal 라이프타임)
- **Activity feed** → chokidar + git HEAD polling + jsonl 영속화
- **ResourceBar** → ps + vm_stat + du + activeCount 5s polling, 임계 색상

자세한 변경: CHANGELOG.md [0.5.3]