### PR TITLE
fix: 0.5.5 — 죽은 UI 전수 wire (35+ onClick) + React #310 + SEED 가짜 팀 제거

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,6 +225,50 @@ export default function App() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
 
+  // ── Dashboard quick action bus ──────────────────────────────────
+  // DashboardPanel emits CustomEvent('forge:*') to request app-level actions
+  // since the panel itself doesn't own the wizard / sidebar / dialog state.
+  useEffect(() => {
+    const handleNewRun = () => {
+      setWizardPrefill(undefined)
+      setWizardOpen(true)
+    }
+    const handleOpenFolder = (e: Event) => {
+      const detail = (e as CustomEvent<{ path: string }>).detail
+      if (detail?.path) void openWorkspace(detail.path)
+    }
+    const handleNavLibrary = (e: Event) => {
+      setView('library')
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (detail?.tab) {
+        // Library tab is owned by Library component — broadcast a follow-up
+        // event it can pick up after mount.
+        setTimeout(() => {
+          window.dispatchEvent(new CustomEvent('forge:library-tab', { detail: { tab: detail.tab } }))
+        }, 50)
+      }
+    }
+    const handleNavSettings = (e: Event) => {
+      setView('settings')
+      const detail = (e as CustomEvent<{ section?: string; card?: string }>).detail
+      if (detail) {
+        setTimeout(() => {
+          window.dispatchEvent(new CustomEvent('forge:settings-target', { detail }))
+        }, 50)
+      }
+    }
+    window.addEventListener('forge:new-run', handleNewRun)
+    window.addEventListener('forge:open-folder', handleOpenFolder)
+    window.addEventListener('forge:nav-library', handleNavLibrary)
+    window.addEventListener('forge:nav-settings', handleNavSettings)
+    return () => {
+      window.removeEventListener('forge:new-run', handleNewRun)
+      window.removeEventListener('forge:open-folder', handleOpenFolder)
+      window.removeEventListener('forge:nav-library', handleNavLibrary)
+      window.removeEventListener('forge:nav-settings', handleNavSettings)
+    }
+  }, [openWorkspace])
+
   // ── Run + palette wiring ────────────────────────────────────────
   const onSwitchWorkspace = (id: string) => {
     const ws = workspaces.find((w) => w.id === id)
@@ -454,15 +498,14 @@ export default function App() {
     bundledHarnessVersion &&
     installedHarnessVersion !== bundledHarnessVersion
 
-  // Real teams from the watcher, scoped to the active workspace. When empty,
-  // we keep the seed list so the design demo still has something to render.
+  // Real teams from the watcher, scoped to the active workspace.
+  // No seed fallback — empty workspace gets an empty Teams section, not fake
+  // \"회원가입 피처팀\" cards. Lying to the user is worse than an empty list.
   const realTeams = useAgentTeamStore((s) => s.teams)
   const runs = useMemo<V2Team[]>(() => {
-    const wsTeams = realTeams.filter(
-      (t) => !t.workspaceId || t.workspaceId === activeWorkspace?.id,
-    )
-    if (wsTeams.length === 0) return SEED_TEAMS
-    return wsTeams.map(toV2Team)
+    return realTeams
+      .filter((t) => !t.workspaceId || t.workspaceId === activeWorkspace?.id)
+      .map(toV2Team)
   }, [realTeams, activeWorkspace])
 
   // Map current view → main content

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,8 +229,16 @@ export default function App() {
   // DashboardPanel emits CustomEvent('forge:*') to request app-level actions
   // since the panel itself doesn't own the wizard / sidebar / dialog state.
   useEffect(() => {
-    const handleNewRun = () => {
-      setWizardPrefill(undefined)
+    const handleNewRun = (e: Event) => {
+      const detail = (e as CustomEvent<{ prefillMembers?: string[] }>).detail
+      // Library "Add to run" passes a single-member prefill — preserve it so
+      // the wizard opens with that agent already selected. Dashboard's plain
+      // "새 팀 만들기" still emits with no detail, so we fall back to undefined.
+      setWizardPrefill(
+        detail?.prefillMembers && detail.prefillMembers.length > 0
+          ? detail.prefillMembers
+          : undefined,
+      )
       setWizardOpen(true)
     }
     const handleOpenFolder = (e: Event) => {
@@ -584,14 +592,130 @@ export default function App() {
         items={DEFAULT_PALETTE_ITEMS}
         onAction={(action) => {
           setPaletteOpen(false)
-          // Map common palette actions to existing handlers.
-          if (action === 'new-run') onNewRun()
-          else if (action === 'new-workspace') setNewWorkspaceDialog(true)
-          else if (action === 'open-settings') setView('settings')
-          else if (action === 'view-workspace') setView('workspace')
-          else if (action === 'view-git') setView('git')
-          else if (action === 'view-dashboard') setView('dashboard')
-          else if (action === 'view-library') setView('library')
+          // ── Navigation
+          if (action === 'go-workspace' || action === 'view-workspace') {
+            setView('workspace')
+          } else if (action === 'go-git' || action === 'view-git') {
+            setView('git')
+          } else if (action === 'go-dashboard' || action === 'view-dashboard') {
+            setView('dashboard')
+          } else if (action === 'go-teams') {
+            setView('workspace')
+          } else if (action === 'go-library' || action === 'view-library') {
+            setView('library')
+          } else if (action === 'go-settings' || action === 'open-settings') {
+            setView('settings')
+          }
+          // ── Library deep-links
+          else if (action === 'lib-compositions') {
+            setView('library')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:library-tab', { detail: { tab: 'compositions' } }),
+              )
+            }, 50)
+          } else if (action === 'lib-agents' || action === 'add-agent') {
+            setView('library')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:library-tab', { detail: { tab: 'agents' } }),
+              )
+              if (action === 'add-agent') {
+                setTimeout(() => {
+                  window.dispatchEvent(
+                    new CustomEvent('forge:library-new', { detail: { tab: 'agents' } }),
+                  )
+                }, 50)
+              }
+            }, 50)
+          } else if (action === 'lib-skills' || action === 'add-skill') {
+            setView('library')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:library-tab', { detail: { tab: 'skills' } }),
+              )
+              if (action === 'add-skill') {
+                setTimeout(() => {
+                  window.dispatchEvent(
+                    new CustomEvent('forge:library-new', { detail: { tab: 'skills' } }),
+                  )
+                }, 50)
+              }
+            }, 50)
+          } else if (action === 'lib-commands') {
+            setView('library')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:library-tab', { detail: { tab: 'commands' } }),
+              )
+            }, 50)
+          } else if (action === 'lib-hooks') {
+            setView('library')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:library-tab', { detail: { tab: 'hooks' } }),
+              )
+            }, 50)
+          }
+          // ── Run actions
+          else if (action === 'create-team' || action === 'new-run') {
+            onNewRun()
+          } else if (action === 'new-workspace') {
+            setNewWorkspaceDialog(true)
+          } else if (action === 'push') {
+            // Open Git view; user reviews changes before pushing.
+            setView('git')
+          } else if (action === 'diff') {
+            setView('git')
+          } else if (action === 'harness-update') {
+            if (harnessUpdateAvailable) {
+              setUpdatePreviewOpen(true)
+            } else {
+              setToast({ name: '하네스가 이미 최신 버전입니다', count: 0 })
+              setTimeout(() => setToast(null), 3000)
+            }
+          } else if (
+            action === 'slash-clear' ||
+            action === 'slash-compact' ||
+            action === 'slash-cost'
+          ) {
+            // Slash commands are executed inside an active terminal — surface a
+            // breadcrumb toast so the user knows to type it themselves once
+            // we don't yet auto-route to a terminal.
+            setToast({
+              name: `${action.replace('slash-', '/')} — 활성 터미널에 직접 입력하세요`,
+              count: 0,
+            })
+            setTimeout(() => setToast(null), 4000)
+          }
+          // ── Settings deep-links
+          else if (action === 'model') {
+            setView('settings')
+            setTimeout(() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:settings-target', {
+                  detail: { section: 'agents' },
+                }),
+              )
+            }, 50)
+          } else if (action === 'theme-toggle') {
+            setToast({
+              name: '테마 토글은 v0.6.0 — 현재 dark only',
+              count: 0,
+            })
+            setTimeout(() => setToast(null), 3000)
+          } else if (action === 'keys') {
+            // Re-open onboarding step 4 (shortcut tour).
+            void window.api?.system?.openExternal(
+              'https://github.com/anthropics/forge-studio#shortcuts',
+            )
+          }
+          // ── Recent (best-effort no-op for now — surfaces existing nav)
+          else if (action === 'open-active') {
+            setView('workspace')
+          } else if (action === 'recent-last-run') {
+            setView('workspace')
+          }
         }}
       />
 

--- a/src/components/v2/Library.tsx
+++ b/src/components/v2/Library.tsx
@@ -11,7 +11,7 @@
  * Source: design handoff at /tmp/forge_design/forge/project/src/library.jsx
  */
 
-import { useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
 // TODO: foundation import — adjust if foundation barrels things differently.
 import { Btn, Pill, AvatarStack } from './primitives'
 import { Icon } from './icons'
@@ -58,6 +58,21 @@ interface TabSpec {
 
 export function Library({ workspace, onApplyComposition }: LibraryProps) {
   const [tab, setTab] = useState<TabId>('compositions')
+
+  // ── Listen for forge:library-tab events (from Dashboard quick actions /
+  // command palette) → switch tab so external nav lands on the right list.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (!detail?.tab) return
+      const valid: TabId[] = ['compositions', 'agents', 'skills', 'commands', 'hooks', 'presets']
+      if ((valid as string[]).includes(detail.tab)) {
+        setTab(detail.tab as TabId)
+      }
+    }
+    window.addEventListener('forge:library-tab', handler)
+    return () => window.removeEventListener('forge:library-tab', handler)
+  }, [])
   // Counts reflect real scanner data when present; seed otherwise.
   const realComps = useLibraryStore((s) => s.compositions)
   const realAgents = useLibraryStore((s) => s.agents)
@@ -111,10 +126,42 @@ export function Library({ workspace, onApplyComposition }: LibraryProps) {
             </div>
           </div>
           <div style={{ flex: 1 }} />
-          <Btn variant="ghost" icon={<Icon.Search size={13} />}>
+          <Btn
+            variant="ghost"
+            icon={<Icon.Search size={13} />}
+            onClick={() => {
+              // Cross-tab search lives in the Command Palette (⌘K) where the
+              // user can fuzzy-match agent / skill / command names regardless
+              // of the active tab. Each tab also has its own in-context search
+              // for finer filtering.
+              window.dispatchEvent(new KeyboardEvent('keydown', {
+                key: 'k',
+                metaKey: true,
+                bubbles: true,
+              }))
+            }}
+            title="Command Palette 열기 (⌘K) — 라이브러리 전체 검색"
+          >
             Search library
           </Btn>
-          <Btn variant="primary" icon={<Icon.Plus size={13} />}>
+          <Btn
+            variant="primary"
+            icon={<Icon.Plus size={13} />}
+            onClick={() => {
+              // Each tab owns its own create flow (uses LibraryRowMenu's
+              // editors). The fastest non-duplicating approach is to
+              // dispatch a custom event that the active tab listens for.
+              window.dispatchEvent(
+                new CustomEvent('forge:library-new', { detail: { tab } }),
+              )
+            }}
+            title={
+              tab === 'compositions'
+                ? 'compositions 생성은 v0.6.0 — 지금은 Wizard에서 팀을 만든 뒤 저장하세요'
+                : `새 ${tab.slice(0, -1)} 만들기`
+            }
+            disabled={tab === 'compositions' || tab === 'presets'}
+          >
             New {tab === 'compositions' ? 'composition' : tab.slice(0, -1)}
           </Btn>
         </div>

--- a/src/components/v2/LibraryTabsAgents.tsx
+++ b/src/components/v2/LibraryTabsAgents.tsx
@@ -10,7 +10,7 @@
  * fields that won't be in real agent files.
  */
 
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Btn, Pill, Dot } from './primitives'
 import { Icon } from './icons'
 import {
@@ -53,6 +53,17 @@ export function AgentsTab() {
   const [editing, setEditing] = useState<EditingState | null>(null)
   const [deleting, setDeleting] = useState<{ name: string } | null>(null)
   const [toast, setToast] = useState<{ message: string } | null>(null)
+
+  // Library-level "New" button dispatches forge:library-new — each tab listens
+  // for its own kind so the editor opens without duplicating the modal.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (detail?.tab === 'agents' && workspacePath) setEditing({})
+    }
+    window.addEventListener('forge:library-new', handler)
+    return () => window.removeEventListener('forge:library-new', handler)
+  }, [workspacePath])
 
   const filtered = items.filter((a) => {
     if (filter !== 'all' && a.owner !== filter) return false
@@ -322,7 +333,21 @@ function AgentDetail({ agent, canEdit, onEdit }: AgentDetailProps) {
             Edit
           </Btn>
         )}
-        <Btn variant="primary" icon={<Icon.Plus size={11} />}>
+        <Btn
+          variant="primary"
+          icon={<Icon.Plus size={11} />}
+          onClick={() => {
+            // "Add to run" wires to the team-create wizard — prefill this
+            // single agent so the user can finalize team metadata. The
+            // global forge:new-run listener in App.tsx receives the prefill.
+            window.dispatchEvent(
+              new CustomEvent('forge:new-run', {
+                detail: { prefillMembers: [agent.id] },
+              }),
+            )
+          }}
+          title="이 agent로 새 팀 위저드 열기"
+        >
           Add to run
         </Btn>
       </div>

--- a/src/components/v2/LibraryTabsCommands.tsx
+++ b/src/components/v2/LibraryTabsCommands.tsx
@@ -6,7 +6,7 @@
  * "+ 새 커맨드" to open CommandEditor in create mode.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Btn } from './primitives'
 import { Icon } from './icons'
 import { COMMANDS_LIB, type LibCommand } from './LibraryData'
@@ -36,6 +36,16 @@ export function CommandsTab() {
   const [editing, setEditing] = useState<EditingState | null>(null)
   const [deleting, setDeleting] = useState<{ name: string } | null>(null)
   const [toast, setToast] = useState<{ message: string } | null>(null)
+
+  // Library-level "New" button → forge:library-new with tab='commands'.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (detail?.tab === 'commands' && workspacePath) setEditing({})
+    }
+    window.addEventListener('forge:library-new', handler)
+    return () => window.removeEventListener('forge:library-new', handler)
+  }, [workspacePath])
 
   const builtin = items.filter((c) => c.builtin)
   const custom = items.filter((c) => !c.builtin)

--- a/src/components/v2/LibraryTabsHooks.tsx
+++ b/src/components/v2/LibraryTabsHooks.tsx
@@ -87,6 +87,16 @@ export function HooksTab() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspacePath])
 
+  // Library-level "New" button → forge:library-new with tab='hooks'.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (detail?.tab === 'hooks' && workspacePath) setEditing({})
+    }
+    window.addEventListener('forge:library-new', handler)
+    return () => window.removeEventListener('forge:library-new', handler)
+  }, [workspacePath])
+
   const open = useMemo(() => hooks.find((h) => h.id === openId) ?? null, [hooks, openId])
 
   async function handleSaved() {

--- a/src/components/v2/LibraryTabsSkills.tsx
+++ b/src/components/v2/LibraryTabsSkills.tsx
@@ -6,7 +6,7 @@
  * carries a "⋯" menu (편집 / 복제 / 삭제) when the skill exists on disk.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Btn, Pill, AvatarStack } from './primitives'
 import { Icon } from './icons'
 import { SKILLS_LIB } from './LibraryData'
@@ -37,6 +37,16 @@ export function SkillsTab() {
   const [editing, setEditing] = useState<EditingState | null>(null)
   const [deleting, setDeleting] = useState<{ name: string } | null>(null)
   const [toast, setToast] = useState<{ message: string } | null>(null)
+
+  // Library-level "New" button → forge:library-new with tab='skills'.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: string }>).detail
+      if (detail?.tab === 'skills' && workspacePath) setEditing({})
+    }
+    window.addEventListener('forge:library-new', handler)
+    return () => window.removeEventListener('forge:library-new', handler)
+  }, [workspacePath])
 
   const filtered = items.filter(
     (s) => !q || (s.name + ' ' + s.desc).toLowerCase().includes(q.toLowerCase()),

--- a/src/components/v2/LiveTerminalGrid.tsx
+++ b/src/components/v2/LiveTerminalGrid.tsx
@@ -417,10 +417,14 @@ export function LiveTerminalGrid({
   }, [members])
 
   // Prune hosts for agents that vanish (member removed) or lose tmuxPaneId.
+  // Deps narrow to the actual triggers — without these, the effect runs every
+  // render and reattachAll() can fire during reconciliation, which together
+  // with the registry's force-render subscribe creates a render loop that
+  // surfaces as React error #310.
   useEffect(() => {
     registry.pruneHosts(liveAgentKeys)
     registry.reattachAll()
-  })
+  }, [liveAgentKeys, registry])
 
   const layout = useMemo(() => {
     const n = members.length
@@ -461,12 +465,18 @@ export function LiveTerminalGrid({
 
   let layoutNode: React.ReactNode
 
+  // If the fullscreen target vanishes (member removed while in fullscreen),
+  // exit fullscreen on the next render cycle. This effect-based recovery
+  // replaces a previous setTimeout-during-render that triggered React #310.
+  useEffect(() => {
+    if (!fullscreenAgentId) return
+    if (!members.some((m) => m.agentId === fullscreenAgentId)) {
+      setFullscreenAgentId(null)
+    }
+  }, [fullscreenAgentId, members])
+
   if (fullscreenAgentId) {
     const fs = members.find((m) => m.agentId === fullscreenAgentId)
-    if (!fs) {
-      // Member vanished while fullscreen — drop back to grid.
-      setTimeout(() => setFullscreenAgentId(null), 0)
-    }
     layoutNode = fs ? (
       <div style={{ flex: 1, minHeight: 0, padding: 8 }}>
         <PaneShell

--- a/src/components/v2/SettingsFull.tsx
+++ b/src/components/v2/SettingsFull.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { Btn, Pill, Dot, AvatarStack } from './primitives'
 import { Icon } from './icons'
 import type { WorkspaceSummary } from './types'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { CodeGraphViz } from './CodeGraphViz'
 import { HarnessLintPanel } from './HarnessLintPanel'
 import { SessionPreview } from './SessionPreview'
@@ -60,6 +61,39 @@ export function SettingsFull({ workspaces, workspace }: SettingsFullProps) {
     { id: 'account',      label: t('settings.account'),      icon: Icon.Lock },
     { id: 'error-log',    label: t('settings.errorLog'),     icon: Icon.Activity },
   ]
+
+  // ── Listen for forge:settings-target events (from Dashboard quick actions
+  // and TopBar bell) → switch the section so deep-link nav lands on the right
+  // card. The optional `card` payload is rebroadcast so child components can
+  // scroll into view.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ section?: string; card?: string }>).detail
+      if (!detail?.section) return
+      const valid: SectionId[] = ['general', 'harness', 'agents', 'integrations', 'account', 'error-log']
+      if ((valid as string[]).includes(detail.section)) {
+        setSection(detail.section as SectionId)
+        if (detail.card) {
+          // Defer so the child cards have mounted under the new section.
+          setTimeout(() => {
+            const el = document.querySelector(
+              `[data-settings-card="${detail.card}"]`,
+            ) as HTMLElement | null
+            if (el) {
+              el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              el.style.transition = 'box-shadow 240ms'
+              el.style.boxShadow = '0 0 0 2px var(--accent)'
+              window.setTimeout(() => {
+                el.style.boxShadow = ''
+              }, 1400)
+            }
+          }, 60)
+        }
+      }
+    }
+    window.addEventListener('forge:settings-target', handler)
+    return () => window.removeEventListener('forge:settings-target', handler)
+  }, [])
 
   return (
     <div
@@ -163,8 +197,16 @@ interface SettingsCardProps {
 }
 
 function SettingsCard({ title, right, children }: SettingsCardProps) {
+  // Slugify the title so deep-link targeting (forge:settings-target with
+  // `card`) can scroll the matching SettingsCard into view. Lowercase, ASCII,
+  // hyphenated — keeps the data-attribute predictable.
+  const cardKey = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
   return (
     <div
+      data-settings-card={cardKey}
       style={{
         background: 'var(--bg-2)',
         border: '1px solid var(--line-1)',
@@ -297,13 +339,20 @@ interface SettingsGeneralProps {
 export function SettingsGeneral({ workspaces }: SettingsGeneralProps) {
   const [autoFocus, setAutoFocus] = useState(true)
   const [confirmDestructive, setConfirmDestructive] = useState(true)
+  const setNewWorkspaceDialog = useWorkspaceStore((s) => s.setNewWorkspaceDialog)
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace)
+  const allWorkspaces = useWorkspaceStore((s) => s.workspaces)
   return (
     <>
       <SectionHeader title={t('settings.general')} sub={t('settings.generalSub')} />
       <SettingsCard
         title={t('settings.workspaces')}
         right={
-          <Btn variant="ghost" icon={<Icon.Plus size={11} />}>
+          <Btn
+            variant="ghost"
+            icon={<Icon.Plus size={11} />}
+            onClick={() => setNewWorkspaceDialog(true)}
+          >
             {t('settings.addWorkspace')}
           </Btn>
         }
@@ -333,7 +382,20 @@ export function SettingsGeneral({ workspaces }: SettingsGeneralProps) {
               </div>
             </div>
             {w.current && <Pill color="var(--accent)">{t('settings.current')}</Pill>}
-            <Btn variant="ghost" icon={<Icon.Cog size={11} />}>
+            <Btn
+              variant="ghost"
+              icon={<Icon.Cog size={11} />}
+              onClick={() => {
+                // "Configure" on the workspaces row → set this workspace as
+                // active so the rest of Settings (Harness / Agents / etc.)
+                // operates against it. The path stored in the summary is the
+                // canonical lookup key.
+                const ws = allWorkspaces.find((x) => x.id === w.id)
+                if (ws) void setActiveWorkspace(ws)
+              }}
+              title={w.current ? '이미 활성 워크스페이스입니다' : '이 워크스페이스로 전환'}
+              disabled={!!w.current}
+            >
               {t('common.configure')}
             </Btn>
           </div>
@@ -478,6 +540,10 @@ export function SettingsHarness({ workspace }: SettingsHarnessProps = {}) {
   const [autoUpdate, setAutoUpdate] = useState(true)
   const [telemetry, setTelemetry] = useState(false)
   const [betaChannel, setBetaChannel] = useState(false)
+  // Repo policy toggles — kept in renderer state until a backend policy
+  // surface exists (today they're documented intent, not enforced rules).
+  const [blockForcePush, setBlockForcePush] = useState(true)
+  const [requireReviewer, setRequireReviewer] = useState(true)
   return (
     <>
       <SectionHeader title={t('settings.harness')} sub={t('settings.harnessSub')} />
@@ -536,13 +602,13 @@ export function SettingsHarness({ workspace }: SettingsHarnessProps = {}) {
       <SettingsCard title="Repository policies">
         <Row
           label="Block force pushes"
-          sub="모든 agent가 --force 푸시 차단"
-          right={<Toggle value={true} onChange={() => {}} />}
+          sub="모든 agent가 --force 푸시 차단 (실제 강제는 v0.6.0 — 현재는 의도 기록)"
+          right={<Toggle value={blockForcePush} onChange={setBlockForcePush} />}
         />
         <Row
           label="Require reviewer"
-          sub="머지 게이트에 reviewer agent 의무 통과"
-          right={<Toggle value={true} onChange={() => {}} />}
+          sub="머지 게이트에 reviewer agent 의무 통과 (실제 강제는 v0.6.0 — 현재는 의도 기록)"
+          right={<Toggle value={requireReviewer} onChange={setRequireReviewer} />}
         />
         <Row
           label="Branch prefix"
@@ -578,7 +644,14 @@ export function SettingsAgents() {
       <SettingsCard
         title="Pool defaults"
         right={
-          <Btn variant="ghost" onClick={() => {}}>
+          <Btn
+            variant="ghost"
+            onClick={() => {
+              window.dispatchEvent(
+                new CustomEvent('forge:nav-library', { detail: { tab: 'agents' } }),
+              )
+            }}
+          >
             Library에서 편집
           </Btn>
         }
@@ -707,7 +780,19 @@ export function SettingsIntegrations() {
       <SettingsCard
         title="Connections"
         right={
-          <Btn variant="ghost" icon={<Icon.Plus size={11} />}>
+          <Btn
+            variant="ghost"
+            icon={<Icon.Plus size={11} />}
+            onClick={() => {
+              // No backend integration registry yet — point users at the
+              // GitHub README so they can request the integration they need
+              // and stay aware that the list is curated, not configurable.
+              void window.api?.system?.openExternal(
+                'https://github.com/anthropics/forge-studio#integrations',
+              )
+            }}
+            title="새 통합 요청 — GitHub 이슈로 이동 (자체 추가는 v0.7.0)"
+          >
             Add
           </Btn>
         }
@@ -782,9 +867,39 @@ export function SettingsIntegrations() {
               )}
             </div>
             {it.connected ? (
-              <Btn variant="ghost">Configure</Btn>
+              <Btn
+                variant="ghost"
+                onClick={() => {
+                  // Per-integration config UI is v0.6.0+. Until then point at
+                  // the integration's own settings page where the user manages
+                  // tokens / org connections.
+                  const urls: Record<string, string> = {
+                    github: 'https://github.com/settings/tokens',
+                    linear: 'https://linear.app/settings/api',
+                    sentry: 'https://sentry.io/settings/account/api/auth-tokens/',
+                  }
+                  const url = urls[it.id] ?? `https://${it.id}.com`
+                  void window.api?.system?.openExternal(url)
+                }}
+                title={`${it.name} 외부 설정 페이지 열기 (in-app 설정은 v0.6.0)`}
+              >
+                Configure
+              </Btn>
             ) : (
-              <Btn variant="primary" icon={<Icon.Plus size={11} />}>
+              <Btn
+                variant="primary"
+                icon={<Icon.Plus size={11} />}
+                onClick={() => {
+                  const urls: Record<string, string> = {
+                    slack: 'https://api.slack.com/apps',
+                    figma: 'https://www.figma.com/developers/api',
+                    vercel: 'https://vercel.com/account/tokens',
+                  }
+                  const url = urls[it.id] ?? `https://${it.id}.com`
+                  void window.api?.system?.openExternal(url)
+                }}
+                title={`${it.name} 토큰 발급 페이지 — 발급 후 .env에 추가하세요 (in-app 연결은 v0.6.0)`}
+              >
                 Connect
               </Btn>
             )}
@@ -795,7 +910,21 @@ export function SettingsIntegrations() {
       <SettingsCard
         title="MCP servers"
         right={
-          <Btn variant="ghost" icon={<Icon.Plus size={11} />}>
+          <Btn
+            variant="ghost"
+            icon={<Icon.Plus size={11} />}
+            onClick={() => {
+              // The real authoring UI lives under Settings → Harness → MCP
+              // servers (full McpServerEditor). Re-route there instead of
+              // shipping a duplicate dialog from this read-only summary.
+              window.dispatchEvent(
+                new CustomEvent('forge:settings-target', {
+                  detail: { section: 'harness', card: 'mcp-servers' },
+                }),
+              )
+            }}
+            title="Harness 섹션의 전체 MCP 편집기로 이동"
+          >
             Add server
           </Btn>
         }
@@ -837,7 +966,18 @@ export function SettingsIntegrations() {
             <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
               {s.tools} tools
             </span>
-            <Btn variant="ghost" icon={<Icon.More size={11} />}>
+            <Btn
+              variant="ghost"
+              icon={<Icon.More size={11} />}
+              onClick={() => {
+                window.dispatchEvent(
+                  new CustomEvent('forge:settings-target', {
+                    detail: { section: 'harness', card: 'mcp-servers' },
+                  }),
+                )
+              }}
+              title="Harness 섹션의 MCP 편집기로 이동 (편집·삭제)"
+            >
               {' '}
             </Btn>
           </div>
@@ -916,7 +1056,20 @@ export function SettingsAccount() {
       <SettingsCard
         title="API keys"
         right={
-          <Btn variant="ghost" icon={<Icon.Plus size={11} />}>
+          <Btn
+            variant="ghost"
+            icon={<Icon.Plus size={11} />}
+            onClick={() => {
+              // Forge doesn't yet host its own API key issuance — direct the
+              // user to the Anthropic console where the upstream key is
+              // created. Local CI keys will be issued in v0.6.0 once the
+              // backend service is online.
+              void window.api?.system?.openExternal(
+                'https://console.anthropic.com/settings/keys',
+              )
+            }}
+            title="Anthropic 콘솔에서 API 키 발급 (Forge CI 키는 v0.6.0)"
+          >
             Generate
           </Btn>
         }

--- a/src/components/v2/TopBar.tsx
+++ b/src/components/v2/TopBar.tsx
@@ -319,19 +319,44 @@ export function TopBar({
       <div className="app-no-drag" style={{
         display: 'flex', alignItems: 'center', gap: 8, paddingRight: 10,
       }}>
-        <button style={{
-          height: 24, padding: '0 8px', borderRadius: 5,
-          background: 'transparent', border: '1px solid var(--line-2)',
-          display: 'flex', alignItems: 'center', gap: 6,
-          color: 'var(--text-2)', fontSize: 11.5, cursor: 'pointer',
-        }}>
+        <button
+          title="모델 선택은 v0.6.0에서 활성화됩니다 — 현재는 sonnet-4.5 고정"
+          onClick={() => {
+            // Model picker UI ships in v0.6.0 — for now route the user to
+            // Settings → Agents → "Models per role" where the per-role model
+            // dropdowns already render (read-only).
+            window.dispatchEvent(
+              new CustomEvent('forge:nav-settings', {
+                detail: { section: 'agents' },
+              }),
+            )
+          }}
+          style={{
+            height: 24, padding: '0 8px', borderRadius: 5,
+            background: 'transparent', border: '1px solid var(--line-2)',
+            display: 'flex', alignItems: 'center', gap: 6,
+            color: 'var(--text-2)', fontSize: 11.5, cursor: 'pointer',
+          }}
+        >
           <Icon.Sparkle size={12} style={{ color: 'var(--accent)' }} />
           <span className="mono" style={{ fontSize: 11 }}>{model}</span>
           <Pill style={{ background: 'transparent', border: '1px solid var(--line-2)' }}>
             {modelEffort}
           </Pill>
         </button>
-        <button title="Notifications" style={{ ...iconBtn, position: 'relative' }}>
+        <button
+          title="알림 — Error Log 열기"
+          onClick={() => {
+            // Bell currently routes to the Error Log section of settings; once
+            // a real notifications inbox lands it'll open a dropdown instead.
+            window.dispatchEvent(
+              new CustomEvent('forge:nav-settings', {
+                detail: { section: 'error-log' },
+              }),
+            )
+          }}
+          style={{ ...iconBtn, position: 'relative', cursor: 'pointer' }}
+        >
           <Icon.Bell size={14} />
           {hasNotifications && (
             <span style={{

--- a/src/components/v2/WorkspaceV2.tsx
+++ b/src/components/v2/WorkspaceV2.tsx
@@ -190,6 +190,17 @@ function WorkspaceHeaderV2({ workspace, harnessUpdate }: WorkspaceHeaderV2Props)
       <div style={{ flex: 1 }} />
       {harnessUpdate ? (
         <button
+          onClick={() => {
+            // Forward to Settings → Harness so the user sees the lint card +
+            // diff preview (and the existing Apply flow). Mirrors the
+            // dashboard quick-action wiring.
+            window.dispatchEvent(
+              new CustomEvent('forge:nav-settings', {
+                detail: { section: 'harness' },
+              }),
+            )
+          }}
+          title="Settings → Harness 에서 업데이트 다이프 / 적용"
           style={{
             height: 22,
             padding: '0 8px',

--- a/src/components/v2/wired/DashboardPanelWired.tsx
+++ b/src/components/v2/wired/DashboardPanelWired.tsx
@@ -247,7 +247,7 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
       t: 'MCP 추가',
       k: '',
       action: () => {
-        window.dispatchEvent(new CustomEvent('forge:nav-settings', { detail: { section: 'harness', card: 'mcp' } }))
+        window.dispatchEvent(new CustomEvent('forge:nav-settings', { detail: { section: 'harness', card: 'mcp-servers' } }))
       },
     },
     {

--- a/src/components/v2/wired/DashboardPanelWired.tsx
+++ b/src/components/v2/wired/DashboardPanelWired.tsx
@@ -25,6 +25,8 @@ interface QuickAction {
   i: React.ReactNode
   t: string
   k: string
+  action?: () => void | Promise<void>
+  disabled?: boolean
 }
 
 export interface DashboardPanelWiredProps {
@@ -97,7 +99,13 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
     activeWorkspace,
     scanHarness,
     scanMcp,
+    updateHarness,
   } = useWorkspaceStore()
+
+  const harnessUpdateAvailable =
+    !!installedHarnessVersion &&
+    !!bundledHarnessVersion &&
+    installedHarnessVersion !== bundledHarnessVersion
 
   // Make sure data is fresh whenever this panel mounts (e.g. via sidebar nav).
   useEffect(() => {
@@ -206,19 +214,66 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
     },
   ]
 
+  const wsPath = activeWorkspace?.path
   const actions: QuickAction[] = [
-    { i: <Icon.Plus size={13} />, t: '새 팀 만들기', k: '⌘N' },
-    { i: <Icon.Bolt size={13} />, t: '하네스 업데이트', k: '⌘⇧U' },
-    { i: <Icon.Sparkle size={13} />, t: 'skill 추가', k: '⌘⇧S' },
-    { i: <Icon.Cube size={13} />, t: 'MCP 추가', k: '⌘⇧M' },
-    { i: <Icon.Code size={13} />, t: 'command 작성', k: '⌘⇧C' },
-    { i: <Icon.Folder size={13} />, t: '워크스페이스 추가', k: '⌘O' },
+    {
+      i: <Icon.Plus size={13} />,
+      t: '새 팀 만들기',
+      k: '⌘N',
+      action: () => {
+        window.dispatchEvent(new CustomEvent('forge:new-run'))
+      },
+    },
+    {
+      i: <Icon.Bolt size={13} />,
+      t: '하네스 업데이트',
+      k: '',
+      disabled: !harnessUpdateAvailable,
+      action: () => {
+        if (!wsPath) return
+        void updateHarness()
+      },
+    },
+    {
+      i: <Icon.Sparkle size={13} />,
+      t: 'skill 추가',
+      k: '',
+      action: () => {
+        window.dispatchEvent(new CustomEvent('forge:nav-library', { detail: { tab: 'skills' } }))
+      },
+    },
+    {
+      i: <Icon.Cube size={13} />,
+      t: 'MCP 추가',
+      k: '',
+      action: () => {
+        window.dispatchEvent(new CustomEvent('forge:nav-settings', { detail: { section: 'harness', card: 'mcp' } }))
+      },
+    },
+    {
+      i: <Icon.Code size={13} />,
+      t: 'command 작성',
+      k: '',
+      action: () => {
+        window.dispatchEvent(new CustomEvent('forge:nav-library', { detail: { tab: 'commands' } }))
+      },
+    },
+    {
+      i: <Icon.Folder size={13} />,
+      t: '워크스페이스 열기',
+      k: '',
+      action: async () => {
+        const result = await window.api.system
+          .showOpenDialog({ properties: ['openDirectory', 'createDirectory'], title: '기존 폴더 열기' })
+          .catch(() => null)
+        if (result && !result.canceled && result.filePaths[0]) {
+          window.dispatchEvent(new CustomEvent('forge:open-folder', { detail: { path: result.filePaths[0] } }))
+        }
+      },
+    },
   ]
 
-  const harnessUpdateAvailable =
-    installedHarnessVersion &&
-    bundledHarnessVersion &&
-    installedHarnessVersion !== bundledHarnessVersion
+
 
   return (
     <div
@@ -523,6 +578,8 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
             {actions.map((a, i) => (
               <button
                 key={i}
+                onClick={a.disabled ? undefined : () => void a.action?.()}
+                disabled={a.disabled}
                 style={{
                   width: '100%',
                   display: 'flex',
@@ -532,20 +589,21 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
                   borderRadius: 5,
                   background: 'transparent',
                   border: '1px solid transparent',
-                  color: 'var(--text-2)',
+                  color: a.disabled ? 'var(--text-4)' : 'var(--text-2)',
                   fontSize: 12.5,
-                  cursor: 'pointer',
+                  cursor: a.disabled ? 'not-allowed' : 'pointer',
+                  opacity: a.disabled ? 0.5 : 1,
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--bg-3)'
+                  if (!a.disabled) e.currentTarget.style.background = 'var(--bg-3)'
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.background = 'transparent'
                 }}
               >
-                <span style={{ color: 'var(--accent)' }}>{a.i}</span>
+                <span style={{ color: a.disabled ? 'var(--text-3)' : 'var(--accent)' }}>{a.i}</span>
                 <span style={{ flex: 1, textAlign: 'left' }}>{a.t}</span>
-                <Kbd>{a.k}</Kbd>
+                {a.k && <Kbd>{a.k}</Kbd>}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## 요약
사용자가 0.5.4 검증 중 "대부분 UI 만 존재 + 동작 0" 발견. 전 v2 UI audit 후 35+ 죽은 액션을 모두 wire 하거나 명확히 'v0.6.0 예정' disabled.

## 주요 fix
- React error #310 — LiveTerminalGrid 의 deps 없는 useEffect + 렌더 중 setTimeout
- SEED_TEAMS fallback 제거 — '회원가입 피처팀' / '리팩토링 팀' 가짜 카드 안 보임
- Dashboard Quick actions 6개 onClick wire
- TopBar bell/model · Settings 9개 액션 + 2 toggle · Library 'New X' / Search · LibraryTabs 4개 'forge:library-new' listener · WorkspaceV2 orange Update 버튼 · CommandPalette 26개 액션 풀 핸들링

자세한 변경: 커밋 메시지