### PR TITLE
fix(teams): v0.5.5 — Codex 라운드2 hotfix (H1+H2+M1+M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.5.5] — 2026-05-08
+
+### Fixed — Codex adversarial review 라운드2 결함 4개
+
+#### H1. workspaceDirty 가 자기 자신 때문에 항상 true (merge 영구 실패)
+`AgentTeamWatcher.create()` 가 `<workspace>/.claude/teams/<teamId>/`,
+worktree 디렉터리를 만든다. 그런데 `merge()` 의 dirty-tree gate 는
+`git status --porcelain` 비어있어야 통과 — `.claude` 가 추적 대상인
+워크스페이스에선 팀 생성 즉시 dirty. Merge 버튼은 자기 자신이 만든
+파일 때문에 영구히 `workspace has uncommitted changes` 로 실패.
+
+수정: `workspaceDirty()` 가 porcelain 출력을 라인 단위로 파싱 후
+Forge 소유 경로 (`.claude/teams/**`, `.claude/worktrees/**`) 만
+필터링. 사용자 WIP 는 그대로 감지. `isForgeOwnedPath()` 헬퍼 추가.
+
+#### H2. Activity tracker 가 부팅·워크스페이스 전환 후 inert
+`teamActivityTracker.start()` 는 `teams:create` 핸들러에서만 호출.
+앱 재시작 시 `agentTeamWatcher.start()` 가 기존 팀 목록을 cache 에
+복원 + `teams:update` 발신하지만 activity tracker 는 안 켜짐 →
+RunLiveView 가 JSONL tail 만 보여주고 라이브 edit/commit/state-change
+이벤트는 영영 도착 안 함. \"실시간 피드\" 라벨이 거짓말.
+
+수정: `agentTeamWatcher.on('teams', ...)` 안에서
+`reconcileActivityTrackers()` 호출. live id Set 과 active tracker Set
+diff 해서 빠진 팀 start, 사라진 팀 stop. `agentTeamWatcher.configPathFor()`
+public 메서드 추가 — tracker 가 tail 할 config.json 경로 조회용.
+재시작/워크스페이스 swap 후에도 라이브 피드 유지.
+
+#### M1. Pause/Resume 백엔드 상태가 v2 어댑터에서 무시됨
+`pause()` 는 `team.status='paused'` 작성, `pauseMember()` 는
+`member.state='idle'` 작성. 그런데 `toV2Team()` 어댑터는 inbox 파생
+`m.status` (AgentStatus) 만 `statusToMemberState()` 통과시킴 → paused
+멤버가 inbox 활동 흔적 없으면 그대로 'active' 렌더링. RunLiveView 의
+Resume 조건은 그 v2 status 에 의존 → 사용자가 Pause 반복 클릭하지만
+실제 프로세스 상태는 이미 변경된 상태 (불일치).
+
+수정:
+- `MemberState` 에 `'paused'` 추가 (`primitives.tsx`, `types.ts`)
+- `STATE_COLOR/STATE_LABEL` paused 컬러 추가 (`var(--warn)` + `PAUSED`)
+- `src/types/index.ts` TeamMember 에 `state?: 'active' | 'idle'` 노출
+- `toV2Team()` precedence 명시: team.status='paused' → 모든 멤버 paused;
+  member.state='idle' (lifecycle pause) → paused; 그 외 inbox-derived
+- 팀 status 집계: paused (team) > blocked > active > paused (members) > idle > done
+- `RunLiveView` 의 `state === 'idle' || 'queued'` hack → `state === 'paused'`
+
+#### M2. Agent 터미널 버튼이 PTY 만들고 버림 (누수)
+`AgentCard` 의 터미널 아이콘이 `window.api.teams.openAgentTerminal()`
+호출 후 `flash('success', 'attached')` 만 띄움. 반환된 PTY id 는 즉시
+discard — `pty.onData` 구독 없음, 터미널 store 등록 없음, dispose 없음.
+사용자는 'attached' 만 보고 실제 터미널은 안 열림. tmux attach PTY 는
+앱 종료까지 alive (dangling).
+
+수정: `LiveTerminalGrid` 가 이미 모든 멤버에 라이브 attach 중 →
+중복 PTY 만들 필요 없음. 버튼이 `forge:agent-fullscreen` CustomEvent
+dispatch → grid 가 fullscreen mode toggle. `LiveTerminalGrid` 에 이벤트
+listener 추가 (member 존재 검증 + agentName/agentId 매칭). 누수 0.
+
 ## [0.5.4] — 2026-05-08
 
 ### Fixed — Codex adversarial review 결함 4개 (0.5.3 hotfix)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,6 +39,48 @@ const agentTeamWatcher = new AgentTeamWatcher()
 const fsManager = new FsManager()
 const hookProfiler = new HookProfiler()
 const teamActivityTracker = new TeamActivityTracker()
+
+/**
+ * Track which team JSONL streams we've already wired up so the watcher's
+ * `teams` event can trigger start/stop without restarting healthy trackers
+ * every time the cache emits.
+ */
+const activityTrackerTeams = new Set<string>()
+
+/**
+ * Reconcile the activity tracker against the watcher's authoritative team
+ * list. Called on every `teams` emission (boot, workspace switch, create,
+ * remove). Without this, only teams created in the current process get a
+ * tracker — restored teams from disk show stale JSONL with no live edits.
+ */
+async function reconcileActivityTrackers(teams: { id: string; members: { agentId: string; name: string; worktreePath?: string; state?: 'active' | 'idle' }[] }[]): Promise<void> {
+  const liveIds = new Set(teams.map((t) => t.id))
+
+  for (const teamId of activityTrackerTeams) {
+    if (!liveIds.has(teamId)) {
+      await teamActivityTracker.stop(teamId).catch(() => {})
+      activityTrackerTeams.delete(teamId)
+    }
+  }
+
+  for (const team of teams) {
+    if (activityTrackerTeams.has(team.id)) continue
+    const configPath = agentTeamWatcher.configPathFor(team.id)
+    if (!configPath) continue
+    const memberSpecs: MemberSpec[] = team.members.map((m) => ({
+      agentId: m.agentId,
+      name: m.name,
+      worktreePath: m.worktreePath,
+      state: m.state,
+    }))
+    try {
+      await teamActivityTracker.start(team.id, memberSpecs, configPath)
+      activityTrackerTeams.add(team.id)
+    } catch (err) {
+      console.warn(`[teamActivityTracker] start failed for ${team.id} (non-fatal):`, err)
+    }
+  }
+}
 /**
  * ResourceMonitor reads the active workspace path lazily so a swap doesn't
  * leave us measuring a stale folder. Disk baseline is reset whenever the
@@ -1063,12 +1105,14 @@ ipcMain.handle(
   ) => {
     const result = await agentTeamWatcher.create(opts)
     // Spin up the activity tracker for the brand-new team. The watcher's
-    // create() already wrote config.json + worktrees, so we read the live
-    // member list back out instead of recomputing.
+    // create() already wrote config.json + worktrees + emitted 'teams',
+    // which triggered reconcileActivityTrackers — so this is normally a no-op.
+    // We keep the explicit start as a synchronous guarantee that the tracker
+    // is alive before the IPC returns (reconcile is fire-and-forget).
     try {
       const teams = agentTeamWatcher.list()
       const team = teams.find((t) => t.id === result.teamId)
-      if (team) {
+      if (team && !activityTrackerTeams.has(team.id)) {
         const memberSpecs: MemberSpec[] = team.members.map((m) => ({
           agentId: m.agentId,
           name: m.name,
@@ -1076,6 +1120,7 @@ ipcMain.handle(
           state: m.state,
         }))
         await teamActivityTracker.start(result.teamId, memberSpecs, result.configPath)
+        activityTrackerTeams.add(result.teamId)
       }
     } catch (err) {
       console.warn('[teamActivityTracker] start failed (non-fatal):', err)
@@ -1086,8 +1131,10 @@ ipcMain.handle(
 
 ipcMain.handle('teams:remove', async (_event, teamId: string) => {
   // Tear down activity tracking before the watcher rm's the team config so
-  // the JSONL stream flushes its tail line cleanly.
+  // the JSONL stream flushes its tail line cleanly. The watcher's remove()
+  // emits 'teams' afterward, which lets reconcile handle any leftovers.
   await teamActivityTracker.stop(teamId).catch(() => {})
+  activityTrackerTeams.delete(teamId)
   await agentTeamWatcher.remove(teamId)
 })
 
@@ -1234,6 +1281,9 @@ if (!gotTheLock) {
     })
     agentTeamWatcher.on('teams', (teams) => {
       mainWindow?.webContents.send('teams:update', teams)
+      reconcileActivityTrackers(teams).catch((err) => {
+        console.warn('[teamActivityTracker] reconcile failed (non-fatal):', err)
+      })
     })
 
     // Forward every activity event to the renderer. The renderer subscribes

--- a/electron/services/AgentTeamWatcher.ts
+++ b/electron/services/AgentTeamWatcher.ts
@@ -353,6 +353,18 @@ export class AgentTeamWatcher extends EventEmitter {
     return Array.from(this.cache.values()).sort((a, b) => b.createdAt - a.createdAt)
   }
 
+  /**
+   * Return the on-disk config.json path for a team, or null if the team is
+   * unknown or the watcher has no active workspace. Used by main.ts to
+   * reconcile activity trackers against the live team list on boot/workspace
+   * switch — the activity tracker tails this file for state changes.
+   */
+  configPathFor(teamId: string): string | null {
+    if (!this.workspacePath) return null
+    if (!this.cache.has(teamId)) return null
+    return path.join(this.workspacePath, '.claude/teams', teamId, 'config.json')
+  }
+
   // ── External tool gating ─────────────────────────────────────────────
 
   /** Return true when `git` resolves on PATH and is invokable. */
@@ -909,6 +921,11 @@ export class AgentTeamWatcher extends EventEmitter {
    * `git status --porcelain` returns one line per untracked/modified path.
    * Empty stdout = clean tree. Used to gate merge entry/exit so we never
    * report success while the index has staged-but-uncommitted changes.
+   *
+   * Forge-owned runtime paths (`.claude/teams/**`, worktree directories the
+   * watcher itself creates) are filtered out — otherwise the merge gate would
+   * deterministically fail in workspaces where `.claude` is tracked, because
+   * `create()` itself dirties the same tree that `merge()` requires clean.
    */
   private async workspaceDirty(wsPath: string): Promise<boolean> {
     try {
@@ -917,11 +934,30 @@ export class AgentTeamWatcher extends EventEmitter {
         ['-C', wsPath, 'status', '--porcelain'],
         { timeout: 5000, env: tmuxEnv() }
       )
-      return stdout.trim().length > 0
+      const lines = stdout.split('\n').map((l) => l.trimEnd()).filter(Boolean)
+      const userDirty = lines.filter((line) => {
+        // Porcelain v1 format: XY<space>path  (renames have ` -> ` separator)
+        const rest = line.slice(3)
+        const arrow = rest.indexOf(' -> ')
+        const filePath = (arrow >= 0 ? rest.slice(arrow + 4) : rest).replace(/^"(.*)"$/, '$1')
+        return !this.isForgeOwnedPath(filePath)
+      })
+      return userDirty.length > 0
     } catch {
       // If status itself fails we can't trust the tree — treat as dirty.
       return true
     }
+  }
+
+  /** Paths the watcher itself writes inside a workspace. */
+  private isForgeOwnedPath(rel: string): boolean {
+    const normalized = rel.replace(/\\/g, '/')
+    return (
+      normalized === '.claude/teams' ||
+      normalized.startsWith('.claude/teams/') ||
+      normalized === '.claude/worktrees' ||
+      normalized.startsWith('.claude/worktrees/')
+    )
   }
 
   private async collectConflicts(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import type { Workspace as WorkspaceModel, Team as StoreTeam, AgentStatus } from
 
 /** Map an inbox AgentStatus → the v2 MemberState used by RunLiveView etc. */
 function statusToMemberState(status: AgentStatus): MemberState {
+  if (status === 'paused') return 'paused'
   if (status === 'idle') return 'idle'
   if (status === 'shutdown') return 'done'
   return 'active'
@@ -33,28 +34,60 @@ function statusToMemberState(status: AgentStatus): MemberState {
 /**
  * Adapt the watcher-emitted Team (config.json + inbox-derived status) onto the
  * richer v2 Team shape consumed by WorkspaceV2 / TeamsRunSection / RunLiveView.
- * UI-only fields (progress, tokens, durationMin) get sensible placeholders;
- * we'll wire them to real telemetry once it exists.
+ *
+ * State precedence (most → least authoritative):
+ *   1. team.status === 'paused'              → every member becomes 'paused'
+ *   2. member.state (lifecycle, set by pause/resume backend) === 'idle'
+ *      → 'paused'  (the watcher's RawMember.state field semantically means
+ *        "explicitly paused" after pauseMember(); distinct from inbox idle)
+ *   3. inbox-derived AgentStatus              → fallback via statusToMemberState
+ *
+ * Without precedence #1 + #2, Pause backend changes are invisible to the UI:
+ * the inbox stays at the pre-pause activity, RunLiveView keeps showing
+ * 'active', and the Pause button never flips to Resume.
  */
 function toV2Team(team: StoreTeam): V2Team {
-  const members = team.members.map((m) => ({
-    agentId: m.agentId,
-    task: m.task ?? m.lastSummary ?? '',
-    state: statusToMemberState(m.status),
-    tokens: 0,
-    files: 0,
-    pane: m.name?.slice(0, 4).toUpperCase() ?? 'PANE',
-    name: m.name,
-    tmuxPaneId: m.tmuxPaneId,
-  }))
-  // Aggregate run status: blocked > active > idle > done.
-  const runStatus: V2Team['status'] = members.some((m) => m.state === 'blocked')
-    ? 'blocked'
-    : members.some((m) => m.state === 'active')
-      ? 'active'
-      : members.every((m) => m.state === 'done')
-        ? 'done'
-        : 'idle'
+  const teamPaused = team.status === 'paused'
+  const members = team.members.map((m) => {
+    let state: MemberState
+    if (teamPaused) {
+      state = 'paused'
+    } else if (m.state === 'idle') {
+      state = 'paused'
+    } else if (m.state === 'active') {
+      // Backend says active but inbox might still be reporting idle/shutdown —
+      // trust inbox for blocked/done/idle differentiation but never over-claim
+      // 'paused' once the lifecycle has been resumed.
+      state = statusToMemberState(m.status)
+      if (state === 'paused') state = 'active'
+    } else {
+      state = statusToMemberState(m.status)
+    }
+    return {
+      agentId: m.agentId,
+      task: m.task ?? m.lastSummary ?? '',
+      state,
+      tokens: 0,
+      files: 0,
+      pane: m.name?.slice(0, 4).toUpperCase() ?? 'PANE',
+      name: m.name,
+      tmuxPaneId: m.tmuxPaneId,
+    }
+  })
+  // Aggregate run status: paused (team) > blocked > active > paused (members)
+  // > idle > done. Team-level pause beats individual member states; otherwise
+  // pause is reported only when EVERY non-done member is paused.
+  const runStatus: V2Team['status'] = teamPaused
+    ? 'paused'
+    : members.some((m) => m.state === 'blocked')
+      ? 'blocked'
+      : members.some((m) => m.state === 'active')
+        ? 'active'
+        : members.every((m) => m.state === 'done')
+          ? 'done'
+          : members.length > 0 && members.every((m) => m.state === 'paused' || m.state === 'done')
+            ? 'paused'
+            : 'idle'
   return {
     id: team.id,
     name: team.name,

--- a/src/components/v2/LiveTerminalGrid.tsx
+++ b/src/components/v2/LiveTerminalGrid.tsx
@@ -405,6 +405,25 @@ export function LiveTerminalGrid({
     return () => window.removeEventListener('keydown', onKey, true)
   }, [fullscreenAgentId])
 
+  // External request to fullscreen a specific agent (e.g. AgentCard's
+  // terminal icon in the sidebar). The grid already owns the live PTY attach,
+  // so we toggle our own fullscreen state instead of spawning a duplicate.
+  useEffect(() => {
+    const onAgentFullscreen = (e: Event) => {
+      const detail = (e as CustomEvent<{ agentName?: string; agentId?: string }>).detail
+      if (!detail) return
+      const target = detail.agentName ?? detail.agentId
+      if (!target) return
+      // Only toggle when the agent has a live pane registered — otherwise we'd
+      // open an empty fullscreen with no terminal to show.
+      const liveTarget = members.find((m) => (m.name ?? m.agentId) === target)
+      if (!liveTarget) return
+      setFullscreenAgentId((cur) => (cur === target ? null : target))
+    }
+    window.addEventListener('forge:agent-fullscreen', onAgentFullscreen)
+    return () => window.removeEventListener('forge:agent-fullscreen', onAgentFullscreen)
+  }, [members])
+
   // Members eligible for real PTY (have tmuxPaneId AND not in queued state).
   const liveAgentKeys = useMemo(() => {
     const keys = new Set<string>()

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -174,7 +174,7 @@ export function RunLiveView({
   async function handlePauseMember(member: TeamMember) {
     const api = getTeamsControlApi()
     const agentName = member.name ?? member.agentId
-    const isPaused = member.state === 'idle' || member.state === 'queued'
+    const isPaused = member.state === 'paused'
     const fn = isPaused ? api?.resumeMember : api?.pauseMember
     const verb = isPaused ? 'Resume' : 'Pause'
     if (typeof fn !== 'function') {
@@ -226,7 +226,6 @@ export function RunLiveView({
   }
 
   function handleOpenAgentTerminal(member: TeamMember) {
-    const api = window.api?.teams
     if (!member.tmuxPaneId) {
       flash(
         'warn',
@@ -234,19 +233,17 @@ export function RunLiveView({
       )
       return
     }
-    if (typeof api?.openAgentTerminal !== 'function') {
-      console.warn('[RunLiveView] window.api.teams.openAgentTerminal() unavailable')
-      flash('error', '터미널 IPC 사용 불가')
-      return
-    }
+    // The LiveTerminalGrid already owns the live PTY attach for every
+    // member. Spawning another via openAgentTerminal() would leak a
+    // detached PTY that nothing reads from. Instead, ask the grid to
+    // fullscreen this agent's existing pane.
     const agentName = member.name ?? member.agentId
-    api
-      .openAgentTerminal({ teamId: team.id, agentName, cols: 80, rows: 24 })
-      .then(() => flash('success', `${agentName} 터미널에 attach`))
-      .catch((err) => {
-        console.error('[RunLiveView] openAgentTerminal failed:', err)
-        flash('error', '터미널 attach 실패 — see console')
-      })
+    setSelectedAgentId(member.agentId)
+    window.dispatchEvent(
+      new CustomEvent('forge:agent-fullscreen', {
+        detail: { agentId: member.agentId, agentName },
+      }),
+    )
   }
 
   return (
@@ -559,7 +556,7 @@ function AgentCard({
   const stateC = STATE_COLOR[member.state]
   if (!a) return null
   const blocked = member.state === 'blocked'
-  const isPaused = member.state === 'idle' || member.state === 'queued'
+  const isPaused = member.state === 'paused'
   return (
     <div
       onClick={onClick}

--- a/src/components/v2/primitives.tsx
+++ b/src/components/v2/primitives.tsx
@@ -149,7 +149,7 @@ export function Dot({ color, pulse, size = 6, style }: DotProps) {
 }
 
 // ─── StateDot ────────────────────────────────────────────────────────
-export type AgentState = 'active' | 'done' | 'blocked' | 'queued' | 'idle'
+export type AgentState = 'active' | 'done' | 'blocked' | 'queued' | 'idle' | 'paused'
 
 export const STATE_COLOR: Record<AgentState, string> = {
   active:  'var(--success)',
@@ -157,6 +157,7 @@ export const STATE_COLOR: Record<AgentState, string> = {
   blocked: 'var(--danger)',
   queued:  'var(--text-3)',
   idle:    'var(--text-3)',
+  paused:  'var(--warn)',
 }
 export const STATE_LABEL: Record<AgentState, string> = {
   active:  'ACTIVE',
@@ -164,6 +165,7 @@ export const STATE_LABEL: Record<AgentState, string> = {
   blocked: 'BLOCKED',
   queued:  'QUEUED',
   idle:    'IDLE',
+  paused:  'PAUSED',
 }
 
 export interface StateDotProps {

--- a/src/components/v2/types.ts
+++ b/src/components/v2/types.ts
@@ -4,7 +4,7 @@
  */
 
 export type RunState = 'active' | 'paused' | 'idle' | 'blocked' | 'done' | 'queued'
-export type MemberState = 'active' | 'done' | 'blocked' | 'queued' | 'idle'
+export type MemberState = 'active' | 'done' | 'blocked' | 'queued' | 'idle' | 'paused'
 
 export interface Agent {
   id: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -179,6 +179,13 @@ export interface TeamMember {
   /** Per-member worktree path (when isolated worktrees are provisioned). */
   worktreePath?: string
   branch?: string
+  /**
+   * Member-level lifecycle state, set by pauseMember/resumeMember on the
+   * backend. `'idle'` here means "explicitly paused" (semantically distinct
+   * from the inbox-derived idle status). The renderer surfaces this as a
+   * 'paused' member state so Pause/Resume controls stay correct.
+   */
+  state?: 'active' | 'idle'
 }
 
 export interface Team {


### PR DESCRIPTION
## Summary

Codex adversarial review 라운드2 결함 4개 수정. 모두 \"기능이 진짜로 동작하는가\" 관점:

- **H1** `workspaceDirty()` 가 자기 자신 (`.claude/teams/**`) 때문에 항상 true → merge 영구 실패. Forge 소유 경로 필터.
- **H2** Activity tracker 가 `teams:create` 핸들러에서만 start → 재시작 후 기존 팀 라이브 피드 inert. `reconcileActivityTrackers()` 추가.
- **M1** Pause/Resume 백엔드 상태가 inbox 파생 status 에 가려져 v2 UI 에 안 보임. `MemberState` 에 `paused` 추가 + lifecycle 우선 매핑.
- **M2** AgentCard 터미널 버튼이 PTY 만들고 즉시 discard (누수). `LiveTerminalGrid` 가 이미 attach 중이므로 fullscreen 이벤트로 라우팅.

상세는 CHANGELOG 0.5.5 섹션.

## Test plan

- [x] `npm run typecheck` 통과
- [ ] 팀 생성 → 즉시 merge 시도 → \"workspace dirty\" 안 뜨고 정상 진행
- [ ] 앱 재시작 → 기존 팀 RunLiveView 진입 → 라이브 edit 이벤트 도착 확인
- [ ] 멤버 Pause 클릭 → 카드 PAUSED 배지 + 버튼이 Resume 으로 토글
- [ ] AgentCard 터미널 아이콘 클릭 → 그리드가 해당 agent fullscreen, 별도 PTY 생성 없음

🤖 Codex 라운드2 검수 통과