### PR TITLE
feat(v0.6.0): 서브에이전트 폐지 + Forge Team CLI + 터미널 lifetime fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] — 2026-05-08
+
+### Architecture — Forge Team only (서브에이전트 폐지)
+
+이번 마이너는 메인 Claude Code 세션의 병렬 실행 메커니즘을 **서브에이전트
+(`Agent`/`Task` 도구) 에서 Forge Team (격리 worktree + tmux + 별 Claude
+인스턴스) 로 전환**한다. 사용자 명시 요구: 서브에이전트는 절대 사용 금지,
+모든 위임은 진짜 격리 환경의 별도 Claude 프로세스로.
+
+#### Added
+
+##### `forge-team` CLI — 메인 세션이 호출할 헤드리스 팀 관리자
+- `electron/services/TeamOperations.ts` (NEW, 814 LOC) — 워치/Electron 의존성
+  없는 순수 함수. tmux/git/fs 작업의 단일 source of truth.
+- `bin/forge-team.ts` + `bin/forge-team` (bash shim) — Node 22.6+
+  `--experimental-strip-types` 직접 실행. 의존성 추가 0.
+- 명령어: `create / list / merge / pause / resume / remove`. stdout 단일 라인
+  JSON. exit 코드로 conflict 감지 (merge 실패 시 exit 2).
+- 호출 위치 3가지: 레포 체크아웃 / 패키지된 Forge.app / `npm link` 글로벌.
+- electron-builder `extraResources` 로 `Forge.app/Contents/Resources/forge-cli/`
+  에 번들 — 패키지 환경에서도 즉시 사용.
+
+##### `LiveTerminalsRoot` — App 레벨 XTerminal 인스턴스 풀
+- `src/components/v2/LiveTerminalsRoot.tsx` (NEW) — registry + portal hosts
+  를 App 레벨로 lift.
+- `src/stores/liveTerminals.ts` (NEW) — Zustand store. 활성 팀 멤버 목록
+  관리. 워크스페이스 swap 시 `clear()`.
+- 결과: **다른 화면 (Library/Dashboard/Settings) 갔다와도 PTY/스크롤백 유지**.
+  이전엔 `RunLiveView` unmount → 모든 XTerminal cleanup → tmux attach kill.
+
+#### Changed
+
+##### `electron/services/AgentTeamWatcher.ts` 1076 → 398 LOC 슬림
+- create/pause/resume/pauseMember/resumeMember/merge/remove 의 본문은
+  `TeamOperations` 위임. 공개 API 100% 호환 (preload.ts/main.ts 변경 0).
+- bug fix: `configPathFor()` 가 참조하던 미정의 `this.workspacePath` 필드
+  문제도 정리.
+
+##### CLAUDE.md / orchestration.md / agent-team.md 재작성
+- Agent Routing 표 → **Team Routing 표** (요청 유형 → 멤버 구성).
+- "Agent 도구로 병렬 호출" → "`forge-team create --members ...` 단일 호출".
+- ROLE 블록을 "Team Orchestrator" 로 변경. `Agent`/`Task` 도구 호출 금지
+  명시 + STOP-THE-LINE 추가.
+
+##### `resources/harness-template/.claude/settings.json`
+- `permissions.deny` 에 `"Agent"`, `"Task"` 추가 (서브에이전트 차단).
+- `PreToolUse Agent|Task` 인라인 훅 추가 — 사용 시 명시 메시지 ("forge-team
+  create 로 대신 만들어라") + exit 2.
+
+#### Removed (no longer used)
+
+- `LiveTerminalGrid` 의 자체 `SlotRegistry` + portal mount 영역 → App 레벨로
+  이동. 그리드는 layout + slot ref 등록만.
+- 메인 세션의 `Agent` / `Task` 도구 호출 — 정책상 차단.
+
+#### Compatibility
+
+- 기존 워크스페이스의 `.claude/teams/<id>/config.json` 포맷 변경 없음 — CLI
+  와 GUI 가 같은 파일을 읽고 쓴다.
+- 기존 IPC handler (preload.ts/main.ts) 변경 없음 — Watcher 의 공개 API 가
+  보존되었으므로 GUI 쪽은 영향 0.
+
+#### Known limitation (이전과 동일)
+
+`worktreeStrategy: isolated` 시 `team/<id>` 베이스 브랜치와
+`team/<id>/<agent>` 멤버 브랜치가 git refs 의 디렉토리 충돌로 동시 존재 불가
+→ shared 모드 silent fallback. 결과 envelope 의 `worktreesCreated: 0` 으로
+사용자에게 표시. 다음 라운드에서 베이스 브랜치를 `team/<id>-base` 로 변경
+검토.
+
 ## [0.5.5] — 2026-05-08
 
 ### Fixed — Codex adversarial review 라운드2 결함 4개

--- a/bin/forge-team
+++ b/bin/forge-team
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# forge-team — shell launcher for the Node-based CLI bridge.
+#
+# We intentionally don't ship a precompiled JS — the source is a single
+# TypeScript file and Node 22.6+ can strip types natively. The shim here
+# resolves to the .ts source relative to its own location so the launcher
+# works whether it's invoked from a sibling repo, a symlink in $PATH, or
+# the bundled `npm run team` script.
+#
+# Requires: Node ≥ 22.6 (for --experimental-strip-types).
+
+set -euo pipefail
+
+# Resolve the directory containing this script, even via symlinks.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+ENTRY="$SCRIPT_DIR/forge-team.ts"
+
+if [ ! -f "$ENTRY" ]; then
+  echo "forge-team: cannot find entry point: $ENTRY" >&2
+  exit 1
+fi
+
+# Verify Node supports --experimental-strip-types (≥ 22.6). Earlier Node
+# can't run this script without an extra transpiler, which we won't pull in
+# as a dep — fail loudly with an actionable hint instead.
+NODE_VER="$(node -v 2>/dev/null || echo 'v0.0.0')"
+NODE_MAJOR="${NODE_VER#v}"; NODE_MAJOR="${NODE_MAJOR%%.*}"
+NODE_MINOR_REST="${NODE_VER#v*.}"
+NODE_MINOR="${NODE_MINOR_REST%%.*}"
+if [ "${NODE_MAJOR:-0}" -lt 22 ] || { [ "${NODE_MAJOR}" -eq 22 ] && [ "${NODE_MINOR:-0}" -lt 6 ]; }; then
+  echo "forge-team: requires Node >= 22.6 (got $NODE_VER)" >&2
+  echo "  Install via 'brew install node' or 'nvm install 22'" >&2
+  exit 1
+fi
+
+# Suppress the MODULE_TYPELESS_PACKAGE_JSON warning — we don't want to flip
+# package.json to ESM (would break Electron's CommonJS bundle) just to silence
+# this. NO_WARNINGS keeps stderr clean for piped JSON consumers.
+exec env NODE_NO_WARNINGS=1 node --experimental-strip-types --no-warnings "$ENTRY" "$@"

--- a/bin/forge-team.ts
+++ b/bin/forge-team.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * forge-team — headless CLI bridge for the Forge Studio team registry.
+ *
+ * Lets the main Claude Code session (which has no IPC channel into a running
+ * Electron GUI) provision exactly the same on-disk state the GUI's
+ * AgentTeamWatcher would produce: per-team config.json under
+ * `<workspace>/.claude/teams/<teamId>/`, isolated git worktrees, optional
+ * tmux sessions. When the GUI is running it discovers the new team via its
+ * own chokidar watcher — so this CLI is consciously *write-only* with respect
+ * to runtime IPC.
+ *
+ * Implementation note: imports `TeamOperations` directly. PathManager is
+ * skipped because it depends on `electron`; the CLI falls back to system
+ * `tmux` on PATH. If you launch this from inside the packaged Forge.app and
+ * want the bundled tmux, prepend `<Forge.app>/Contents/Resources/bundled-tools/bin`
+ * to your PATH manually before invoking.
+ */
+
+import path from 'path'
+import { TeamOperations } from '../electron/services/TeamOperations.ts'
+import type {
+  TeamCreateMember,
+  WorktreeStrategy,
+  MergeStrategy,
+} from '../electron/services/TeamOperations.ts'
+
+// Pure system fallbacks — no electron, no PathManager. Callers running inside
+// Forge.app can override PATH externally to pick up the bundled tmux.
+const ops = new TeamOperations({
+  tmuxBin: () => 'tmux',
+  tmuxEnv: () => ({ ...process.env }),
+})
+
+interface ParsedArgs {
+  command: string
+  flags: Map<string, string>
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const [command, ...rest] = argv
+  const flags = new Map<string, string>()
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i]
+    if (!tok.startsWith('--')) continue
+    const key = tok.slice(2)
+    const next = rest[i + 1]
+    if (next !== undefined && !next.startsWith('--')) {
+      flags.set(key, next)
+      i++
+    } else {
+      flags.set(key, 'true')
+    }
+  }
+  return { command: command ?? '', flags }
+}
+
+function requireFlag(flags: Map<string, string>, name: string): string {
+  const v = flags.get(name)
+  if (!v) {
+    fail(`missing required flag: --${name}`)
+  }
+  return v as string
+}
+
+function emit(payload: unknown): void {
+  process.stdout.write(JSON.stringify(payload) + '\n')
+}
+
+function fail(msg: string, code = 1): never {
+  process.stderr.write(`forge-team: ${msg}\n`)
+  process.exit(code)
+}
+
+/**
+ * Members syntax (CLI-friendly, JSON-friendly, both supported):
+ *   --members "agentId1:task1,agentId2:task2"
+ *   --members '[{"agentId":"x","task":"y"}, ...]'
+ *
+ * Commas inside tasks aren't supported in the simple form; switch to JSON
+ * if a task description contains a comma.
+ */
+function parseMembers(raw: string): TeamCreateMember[] {
+  const trimmed = raw.trim()
+  if (trimmed.startsWith('[')) {
+    try {
+      const arr = JSON.parse(trimmed)
+      if (!Array.isArray(arr)) throw new Error('expected JSON array')
+      return arr.map((m: { agentId: string; task?: string }) => ({
+        agentId: String(m.agentId),
+        task: m.task ? String(m.task) : undefined,
+      }))
+    } catch (err) {
+      fail(`--members JSON parse failed: ${(err as Error).message}`)
+    }
+  }
+  return trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const colonIdx = entry.indexOf(':')
+      if (colonIdx < 0) return { agentId: entry }
+      return {
+        agentId: entry.slice(0, colonIdx).trim(),
+        task: entry.slice(colonIdx + 1).trim() || undefined,
+      }
+    })
+}
+
+function asWorktreeStrategy(v: string | undefined): WorktreeStrategy {
+  if (v === 'isolated' || v === 'shared') return v
+  if (v === undefined) return 'isolated'
+  fail(`--worktree-strategy must be 'isolated' or 'shared' (got: ${v})`)
+}
+
+function asMergeStrategy(v: string | undefined): MergeStrategy {
+  if (v === 'squash' || v === 'sequential') return v
+  if (v === undefined) return 'squash'
+  fail(`--merge-strategy must be 'squash' or 'sequential' (got: ${v})`)
+}
+
+function resolveWorkspace(flags: Map<string, string>): string {
+  const ws = flags.get('workspace')
+  if (!ws) fail('missing required flag: --workspace')
+  return path.resolve(ws as string)
+}
+
+async function cmdCreate(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const name = requireFlag(flags, 'name')
+  const goal = flags.get('goal')
+  const membersRaw = requireFlag(flags, 'members')
+  const members = parseMembers(membersRaw)
+  if (members.length === 0) fail('--members must list at least one entry')
+  const worktreeStrategy = asWorktreeStrategy(flags.get('worktree-strategy'))
+  const mergeStrategy = asMergeStrategy(flags.get('merge-strategy'))
+  const workspaceId = flags.get('workspace-id') ?? path.basename(workspacePath)
+  // Default to NOT auto-running `claude` from the headless CLI — the main
+  // session is the orchestrator and probably wants to wire the prompt itself.
+  // Pass --auto-start to opt in.
+  const autoStartClaude = flags.get('auto-start') === 'true'
+
+  const result = await ops.create({
+    workspaceId,
+    workspacePath,
+    name,
+    goal,
+    members,
+    worktreeStrategy,
+    mergeStrategy,
+    autoStartClaude,
+  })
+  emit(result)
+}
+
+async function cmdList(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const teams = await ops.list(workspacePath)
+  emit(teams)
+}
+
+async function cmdRemove(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const teamId = requireFlag(flags, 'team-id')
+  await ops.remove(workspacePath, teamId)
+  emit({ ok: true, teamId })
+}
+
+async function cmdMerge(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const teamId = requireFlag(flags, 'team-id')
+  const strategyFlag = flags.get('merge-strategy')
+  const opts = strategyFlag ? { mergeStrategy: asMergeStrategy(strategyFlag) } : {}
+  const result = await ops.merge(workspacePath, teamId, opts)
+  emit(result)
+  if (!result.ok) process.exit(2)
+}
+
+async function cmdPause(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const teamId = requireFlag(flags, 'team-id')
+  const agentId = flags.get('agent-id')
+  const result = agentId
+    ? await ops.pauseMember(workspacePath, teamId, agentId)
+    : await ops.pause(workspacePath, teamId)
+  emit(result)
+}
+
+async function cmdResume(flags: Map<string, string>): Promise<void> {
+  const workspacePath = resolveWorkspace(flags)
+  const teamId = requireFlag(flags, 'team-id')
+  const agentId = flags.get('agent-id')
+  const result = agentId
+    ? await ops.resumeMember(workspacePath, teamId, agentId)
+    : await ops.resume(workspacePath, teamId)
+  emit(result)
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'forge-team — headless team registry for Forge Studio',
+      '',
+      'Usage:',
+      '  forge-team <command> [flags]',
+      '',
+      'Commands:',
+      '  create   Provision a new team (worktrees + tmux + config.json)',
+      '  list     List teams under a workspace',
+      '  remove   Tear down a team (worktrees + tmux + branches + config)',
+      '  merge    Merge member branches back into the team base branch',
+      '  pause    Pause an entire team or a single member (--agent-id)',
+      '  resume   Resume an entire team or a single member (--agent-id)',
+      '',
+      'Common flags:',
+      '  --workspace <path>          Workspace root (required)',
+      '  --team-id <id>              Existing team id (required for ops)',
+      '',
+      'create flags:',
+      '  --name <text>               Team display name (required)',
+      '  --goal <text>               Team goal / description',
+      '  --members <spec>            "agentId:task,agentId:task" or JSON array',
+      '  --worktree-strategy         isolated (default) | shared',
+      '  --merge-strategy            squash (default) | sequential',
+      '  --workspace-id <id>         Override workspace id (default: dir name)',
+      '  --auto-start                Auto-run `claude` inside each tmux pane',
+      '',
+      'merge flags:',
+      '  --merge-strategy            squash | sequential (overrides team default)',
+      '',
+      'pause/resume flags:',
+      '  --agent-id <id>             Pause/resume just this member',
+      '',
+      'Examples:',
+      '  forge-team create --workspace . --name auth --goal "OAuth" \\',
+      '    --members "nestjs-backend:auth API,flutter-ui:로그인 화면"',
+      '  forge-team list --workspace .',
+      '  forge-team merge --workspace . --team-id team-1234',
+      '  forge-team remove --workspace . --team-id team-1234',
+      '',
+    ].join('\n')
+  )
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help' || argv[0] === 'help') {
+    printHelp()
+    return
+  }
+  const { command, flags } = parseArgs(argv)
+  try {
+    switch (command) {
+      case 'create':
+        await cmdCreate(flags)
+        break
+      case 'list':
+        await cmdList(flags)
+        break
+      case 'remove':
+      case 'rm':
+      case 'delete':
+        await cmdRemove(flags)
+        break
+      case 'merge':
+        await cmdMerge(flags)
+        break
+      case 'pause':
+        await cmdPause(flags)
+        break
+      case 'resume':
+        await cmdResume(flags)
+        break
+      default:
+        fail(`unknown command: ${command} (try \`forge-team help\`)`)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    fail(msg)
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err)
+  fail(msg)
+})

--- a/electron/services/AgentTeamWatcher.ts
+++ b/electron/services/AgentTeamWatcher.ts
@@ -2,12 +2,17 @@ import * as chokidar from 'chokidar'
 import path from 'path'
 import os from 'os'
 import fs from 'fs/promises'
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { EventEmitter } from 'events'
 import { pathManager } from './PathManager'
-
-const execFileAsync = promisify(execFile)
+import {
+  TeamOperations,
+  type RawConfig,
+  type TeamCreateOptions as OpsCreateOptions,
+  type TeamCreateResult as OpsCreateResult,
+  type TeamMergeOptions as OpsMergeOptions,
+  type TeamMergeResult as OpsMergeResult,
+  type TeamMergeConflict as OpsMergeConflict,
+} from './TeamOperations'
 
 /**
  * Resolve the tmux binary at call time. Falls back to PATH `tmux` so the
@@ -22,11 +27,6 @@ function tmuxEnv(): NodeJS.ProcessEnv {
   return pathManager.augmentEnv({ ...process.env })
 }
 
-/** Strict tmux pane-id form (`%42`, `@7`, `$3`). Anything else is rejected. */
-function isTmuxPaneId(value: string | undefined | null): value is string {
-  return !!value && /^[%@$][A-Za-z0-9_-]+$/.test(value)
-}
-
 export type AgentStatus = 'running' | 'idle' | 'shutdown' | 'paused' | 'active'
 export type TeamStatus = 'active' | 'paused'
 export type WorktreeStrategy = 'isolated' | 'shared'
@@ -37,17 +37,14 @@ export interface TeamCreateMember {
   task?: string
 }
 
-export interface TeamCreateOptions {
-  workspaceId: string
-  workspacePath: string
-  name: string
-  goal?: string
-  members: TeamCreateMember[]
-  worktreeStrategy: WorktreeStrategy
-  mergeStrategy: MergeStrategy
-  /** Automatically `claude` boot inside each tmux session. Defaults to true. */
-  autoStartClaude?: boolean
-}
+// Re-export the ops shapes so existing IPC handlers / consumers keep their
+// import sites stable. The watcher delegates to TeamOperations under the hood.
+export type TeamCreateOptions = OpsCreateOptions
+export type TeamCreateResult = OpsCreateResult
+export type TeamMergeOptions = OpsMergeOptions
+export type TeamMergeResult = OpsMergeResult
+export type TeamMergeConflict = OpsMergeConflict
+export type { TeamSummary } from './TeamOperations'
 
 export interface TeamMember {
   agentId: string
@@ -87,71 +84,6 @@ export interface Team {
   status?: TeamStatus
 }
 
-export interface TeamCreateResult {
-  teamId: string
-  configPath: string
-  worktreesCreated: number
-  tmuxSessionsStarted: number
-}
-
-export interface TeamMergeConflict {
-  file: string
-  theirsBranch: string
-  oursBranch: string
-  conflictMarkers: string
-}
-
-/**
- * Flat result envelope — chosen to match the renderer's `MergeResult` so the
- * IPC payload doesn't need bridging on the boundary. `ok: true` populates
- * `mergedBranch`/`commitSha`; `ok: false` populates `conflicts`/`error`.
- */
-export interface TeamMergeResult {
-  ok: boolean
-  mergedBranch?: string
-  commitSha?: string
-  conflicts?: TeamMergeConflict[]
-  error?: string
-}
-
-export interface TeamMergeOptions {
-  mergeStrategy?: MergeStrategy
-}
-
-interface RawMember {
-  agentId: string
-  name: string
-  agentType: string
-  model: string
-  cwd?: string
-  tmuxPaneId?: string
-  backendType?: string
-  joinedAt: number
-  color?: string
-  prompt?: string
-  task?: string
-  worktreePath?: string
-  branch?: string
-  state?: 'active' | 'idle'
-}
-
-interface RawConfig {
-  name: string
-  description?: string
-  goal?: string
-  workspaceId?: string
-  workspacePath?: string
-  worktreeStrategy?: WorktreeStrategy
-  mergeStrategy?: MergeStrategy
-  createdAt: number
-  leadAgentId: string
-  leadSessionId?: string
-  members: RawMember[]
-  status?: TeamStatus
-  /** Base branch carved out for the team — `team/<teamId>`. */
-  baseBranch?: string
-}
-
 interface InboxMessage {
   from: string
   text: string
@@ -161,18 +93,6 @@ interface InboxMessage {
   read?: boolean
 }
 
-/** Validate `child` is contained within `parent` to defend against path traversal. */
-function isPathInside(parent: string, child: string): boolean {
-  const rel = path.relative(parent, child)
-  return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel)
-}
-
-function teamSessionName(teamId: string, agentId: string): string {
-  // tmux session names: alphanumerics, dashes, underscores. Sanitize agent ids.
-  const safe = agentId.replace(/[^A-Za-z0-9_-]/g, '_')
-  return `forge-team-${teamId}-${safe}`
-}
-
 export class AgentTeamWatcher extends EventEmitter {
   /**
    * Active teams root. Defaults to ~/.claude/teams for legacy installs but is
@@ -180,9 +100,27 @@ export class AgentTeamWatcher extends EventEmitter {
    * so each workspace has its own scoped team registry.
    */
   private teamsDir = path.join(os.homedir(), '.claude', 'teams')
+  /**
+   * Currently-active workspace path the watcher is scoped to. `null` means the
+   * legacy `~/.claude/teams` fallback is in effect. Tracked separately from
+   * teamsDir so we can hand it to TeamOperations (which expects the workspace
+   * root, not the teams subdirectory).
+   */
+  private workspacePath: string | null = null
   private watcher: chokidar.FSWatcher | null = null
   private cache: Map<string, Team> = new Map()
   private refreshTimer: NodeJS.Timeout | null = null
+  private readonly ops = new TeamOperations({
+    tmuxBin,
+    tmuxEnv,
+    // Watcher-scoped teams root resolution: when the watcher has an active
+    // workspace, all ops route through that workspace; otherwise legacy
+    // `~/.claude/teams`. Keeps GUI parity with prior behaviour.
+    teamsDirFor: (ws) =>
+      ws
+        ? path.join(ws, '.claude', 'teams')
+        : path.join(os.homedir(), '.claude', 'teams'),
+  })
 
   /**
    * Switch the watcher to a workspace-scoped teams directory. Safe to call
@@ -194,6 +132,7 @@ export class AgentTeamWatcher extends EventEmitter {
       : path.join(os.homedir(), '.claude', 'teams')
     if (next === this.teamsDir && this.watcher) return
     this.teamsDir = next
+    this.workspacePath = workspacePath
     if (this.watcher) {
       await this.watcher.close().catch(() => {})
       this.watcher = null
@@ -365,637 +304,76 @@ export class AgentTeamWatcher extends EventEmitter {
     return path.join(this.workspacePath, '.claude/teams', teamId, 'config.json')
   }
 
-  // ── External tool gating ─────────────────────────────────────────────
-
-  /** Return true when `git` resolves on PATH and is invokable. */
-  private async hasGit(): Promise<boolean> {
-    try {
-      await execFileAsync('git', ['--version'], { timeout: 3000, env: tmuxEnv() })
-      return true
-    } catch {
-      return false
-    }
-  }
-
-  /**
-   * Return true when `tmux` resolves — checking the bundled binary first so
-   * Dock-launched apps (which inherit a sparse PATH) still find the bundled
-   * tmux even when the system PATH lacks /opt/homebrew/bin.
-   */
-  private async hasTmux(): Promise<boolean> {
-    try {
-      await execFileAsync(tmuxBin(), ['-V'], { timeout: 3000, env: tmuxEnv() })
-      return true
-    } catch {
-      return false
-    }
-  }
-
-  private async resolveBaseBranch(workspacePath: string): Promise<string> {
-    try {
-      const { stdout } = await execFileAsync('git', ['-C', workspacePath, 'branch', '--show-current'], {
-        timeout: 5000,
-        env: tmuxEnv(),
-      })
-      const cur = stdout.trim()
-      if (cur) return cur
-    } catch {
-      // fall through
-    }
-    return 'main'
-  }
-
-  /** Best-effort `git branch <newBranch> <fromBranch>` — silent on failure. */
-  private async ensureBranch(workspacePath: string, newBranch: string, fromBranch: string): Promise<boolean> {
-    try {
-      // If branch already exists, just succeed.
-      await execFileAsync('git', ['-C', workspacePath, 'rev-parse', '--verify', newBranch], {
-        timeout: 4000,
-        env: tmuxEnv(),
-      })
-      return true
-    } catch {
-      // doesn't exist yet, create
-    }
-    try {
-      await execFileAsync('git', ['-C', workspacePath, 'branch', newBranch, fromBranch], {
-        timeout: 8000,
-        env: tmuxEnv(),
-      })
-      return true
-    } catch {
-      return false
-    }
-  }
-
   /**
    * Create a new team. Provisions:
    *   1. config.json under <workspacePath>/.claude/teams/<teamId>/
    *   2. (isolated) per-member git worktrees + branches off `team/<teamId>`
    *   3. tmux session per member, optionally auto-launching `claude`
    *
-   * All side effects are best-effort — missing git/tmux yields graceful
-   * degradation: config is still written so the team appears in the registry,
-   * just without worktree/tmux fields populated.
+   * Delegates the heavy lifting to TeamOperations, then nudges the cache so
+   * the renderer sees the new team without waiting for the chokidar tick.
    */
   async create(opts: TeamCreateOptions): Promise<TeamCreateResult> {
-    if (!opts.workspacePath) throw new Error('workspacePath is required')
-    if (!opts.name?.trim()) throw new Error('team name is required')
-    if (!Array.isArray(opts.members) || opts.members.length === 0) {
-      throw new Error('at least one member is required')
-    }
-
-    const teamId = `team-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const teamRoot = path.join(opts.workspacePath, '.claude', 'teams', teamId)
-    await fs.mkdir(teamRoot, { recursive: true })
-
-    const now = Date.now()
-    const leadAgentId = opts.members[0].agentId
-    const wsPath = opts.workspacePath
-    const gitOk = await this.hasGit()
-    const tmuxOk = await this.hasTmux()
-
-    let baseBranch: string | undefined
-    let teamBaseBranch: string | undefined
-    if (gitOk && opts.worktreeStrategy === 'isolated') {
-      baseBranch = await this.resolveBaseBranch(wsPath)
-      teamBaseBranch = `team/${teamId}`
-      // Carve out a stable base for member worktrees to branch from.
-      await this.ensureBranch(wsPath, teamBaseBranch, baseBranch)
-    } else if (gitOk) {
-      baseBranch = await this.resolveBaseBranch(wsPath)
-    }
-
-    let worktreesCreated = 0
-    let tmuxSessionsStarted = 0
-    const autoStart = opts.autoStartClaude !== false
-
-    const rawMembers: RawMember[] = []
-    for (let idx = 0; idx < opts.members.length; idx++) {
-      const m = opts.members[idx]
-      const safeAgentId = m.agentId.replace(/[^A-Za-z0-9_-]/g, '_')
-      const member: RawMember = {
-        agentId: m.agentId,
-        // Member `name` doubles as the inbox filename — keep it filesystem-safe
-        // and unique within the team.
-        name: m.agentId,
-        agentType: m.agentId,
-        model: 'sonnet-4.5',
-        joinedAt: now + idx,
-        task: m.task,
-        state: 'active',
-      }
-
-      // ── Worktree provisioning ──────────────────────────────────────
-      let memberCwd: string | null = null
-      if (opts.worktreeStrategy === 'isolated' && gitOk && teamBaseBranch) {
-        const worktreePath = path.join(teamRoot, 'worktrees', safeAgentId)
-        // Defense in depth: ensure path is contained in teamRoot which itself
-        // is under wsPath (constructed from workspacePath above).
-        if (!isPathInside(teamRoot, worktreePath)) {
-          // Skip silently — can't safely create. Member ends up shared-style.
-          member.worktreePath = wsPath
-          member.branch = baseBranch
-          memberCwd = wsPath
-        } else {
-          const memberBranch = `team/${teamId}/${safeAgentId}`
-          try {
-            await fs.mkdir(path.dirname(worktreePath), { recursive: true })
-            await execFileAsync(
-              'git',
-              ['-C', wsPath, 'worktree', 'add', '-b', memberBranch, worktreePath, teamBaseBranch],
-              { timeout: 30_000, env: tmuxEnv() }
-            )
-            member.worktreePath = worktreePath
-            member.branch = memberBranch
-            memberCwd = worktreePath
-            worktreesCreated++
-          } catch {
-            // Graceful — leave fields empty, fall back to wsPath for tmux cwd.
-            memberCwd = wsPath
-          }
-        }
-      } else {
-        // Shared strategy or no git: every member operates on the workspace.
-        member.worktreePath = wsPath
-        member.branch = baseBranch
-        memberCwd = wsPath
-      }
-
-      // ── tmux session ───────────────────────────────────────────────
-      if (tmuxOk && memberCwd) {
-        const session = teamSessionName(teamId, m.agentId)
-        const tmux = tmuxBin()
-        const env = tmuxEnv()
-        try {
-          await execFileAsync(
-            tmux,
-            ['new-session', '-d', '-s', session, '-c', memberCwd],
-            { timeout: 8000, env }
-          )
-          // Capture the real pane id (`%N`) of the freshly-created session so
-          // PtyManager.createTmuxAttach (which strictly validates the
-          // `%`/`@`/`$` form) can attach. The legacy `session:0.0` form was
-          // rejected as "Invalid tmux target", leaving the live terminal grid
-          // unable to mount any pane.
-          let realPaneId: string | null = null
-          try {
-            const { stdout } = await execFileAsync(
-              tmux,
-              ['display-message', '-p', '-t', session, '#{pane_id}'],
-              { timeout: 3000, env }
-            )
-            const candidate = stdout.trim()
-            if (isTmuxPaneId(candidate)) realPaneId = candidate
-          } catch {
-            // pane lookup failed — fall through; member ends up without a
-            // valid tmuxPaneId so the UI shows a degraded state instead of a
-            // bogus "session:0.0" target.
-          }
-          if (autoStart) {
-            try {
-              await execFileAsync(tmux, ['send-keys', '-t', session, 'claude', 'Enter'], {
-                timeout: 4000,
-                env,
-              })
-            } catch {
-              // ignore — session exists, claude just didn't auto-fire.
-            }
-          }
-          if (realPaneId) {
-            member.tmuxPaneId = realPaneId
-            member.backendType = 'tmux'
-            member.cwd = memberCwd
-            tmuxSessionsStarted++
-          } else {
-            // Session exists but we couldn't resolve a valid pane id. Keep
-            // the cwd so the UI can show the member, but omit tmuxPaneId so
-            // the renderer falls back to a non-tmux terminal instead of
-            // crashing on attach.
-            member.cwd = memberCwd
-          }
-        } catch {
-          // tmux unavailable / collision — leave tmuxPaneId unset.
-        }
-      } else if (memberCwd) {
-        member.cwd = memberCwd
-      }
-
-      rawMembers.push(member)
-    }
-
-    const config: RawConfig = {
-      name: opts.name,
-      goal: opts.goal,
-      workspaceId: opts.workspaceId,
-      workspacePath: wsPath,
-      worktreeStrategy: opts.worktreeStrategy,
-      mergeStrategy: opts.mergeStrategy,
-      createdAt: now,
-      leadAgentId,
-      members: rawMembers,
-      status: 'active',
-      baseBranch: teamBaseBranch,
-    }
-    const configPath = path.join(teamRoot, 'config.json')
-    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
-
-    // chokidar is debounced; nudge the cache immediately so the renderer can
-    // see the new team without waiting for the next refresh tick.
+    const result = await this.ops.create(opts)
     await this.refresh()
     this.emit('teams', this.list())
-    return { teamId, configPath, worktreesCreated, tmuxSessionsStarted }
-  }
-
-  // ── Pause / Resume ───────────────────────────────────────────────────
-
-  /** Read+write the raw on-disk config for `teamId`. */
-  private async readConfig(teamId: string): Promise<{ configPath: string; config: RawConfig } | null> {
-    const teamDir = path.join(this.teamsDir, teamId)
-    const configPath = path.join(teamDir, 'config.json')
-    try {
-      const config = JSON.parse(await fs.readFile(configPath, 'utf-8')) as RawConfig
-      return { configPath, config }
-    } catch {
-      return null
-    }
-  }
-
-  private async writeConfig(configPath: string, config: RawConfig): Promise<void> {
-    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+    return result
   }
 
   /**
-   * Resolve the pane's foreground PID via `tmux display-message -p
-   * '#{pane_pid}'`. The pane_pid is the *direct child* of tmux (typically the
-   * shell), so SIGSTOP/SIGCONT on it pauses the shell and any descendants
-   * (claude, child agents) by virtue of process-group inheritance on most
-   * shells. Returns null when tmux can't be queried or the pid is unparsable.
-   */
-  private async resolvePanePid(paneId: string): Promise<number | null> {
-    if (!isTmuxPaneId(paneId)) return null
-    try {
-      const { stdout } = await execFileAsync(
-        tmuxBin(),
-        ['display-message', '-p', '-t', paneId, '#{pane_pid}'],
-        { timeout: 3000, env: tmuxEnv() }
-      )
-      const pid = parseInt(stdout.trim(), 10)
-      return Number.isFinite(pid) && pid > 0 ? pid : null
-    } catch {
-      return null
-    }
-  }
-
-  /**
-   * Stop or continue the foreground process tree of a tmux pane. We send the
-   * signal to the pane's process group (`-PID`) so children (claude →
-   * sub-agents) get the signal too. Returns true when the signal landed.
-   *
-   * Falls back to no-op on platforms that don't support POSIX kill (Windows)
-   * — caller should treat false as "couldn't truly suspend, fell back to
-   * detach" and surface the degraded state to the user.
-   */
-  private signalPaneTree(pid: number, signal: 'SIGSTOP' | 'SIGCONT'): boolean {
-    try {
-      // Negative PID = process group. The shell tmux spawns is normally a
-      // session leader so this hits its descendants too. If group signaling
-      // fails (e.g. the pane child isn't a group leader), fall back to PID.
-      try {
-        process.kill(-pid, signal)
-        return true
-      } catch {
-        process.kill(pid, signal)
-        return true
-      }
-    } catch {
-      return false
-    }
-  }
-
-  /**
-   * Pause every member of a team. We send SIGSTOP to the foreground process
-   * group of each member's pane so the underlying agent (claude / hooks /
-   * children) actually halts — preventing further file edits and token spend.
-   * If pane PID resolution or signaling fails, we fall back to detach-client
-   * (cosmetic only) and emit a `pause:degraded` event so the UI can warn.
+   * Pause every member of a team. SIGSTOP is sent to the foreground process
+   * group of each tmux pane so the underlying agent (claude / hooks /
+   * children) actually halts. If signaling fails we fall back to detach-client
+   * and emit `pause:degraded` so the UI can warn.
    */
   async pause(teamId: string): Promise<{ ok: boolean; degraded?: boolean }> {
-    if (!teamId) throw new Error('teamId is required')
-    const found = await this.readConfig(teamId)
-    if (!found) return { ok: false }
-    const tmuxOk = await this.hasTmux()
-    found.config.status = 'paused'
-    let degraded = false
-    for (const m of found.config.members) {
-      m.state = 'idle'
-      if (!tmuxOk || !isTmuxPaneId(m.tmuxPaneId)) {
-        degraded = true
-        continue
-      }
-      const pid = await this.resolvePanePid(m.tmuxPaneId)
-      const stopped = pid != null && this.signalPaneTree(pid, 'SIGSTOP')
-      if (!stopped) {
-        // Fallback: detach the client so the user no longer sees it; warn the
-        // caller that the agent process is still running.
-        const session = teamSessionName(teamId, m.agentId)
-        await execFileAsync(tmuxBin(), ['detach-client', '-s', session], {
-          timeout: 3000,
-          env: tmuxEnv(),
-        }).catch(() => {})
-        degraded = true
-      }
-    }
-    await this.writeConfig(found.configPath, found.config)
+    const result = await this.ops.pause(this.workspacePath, teamId)
     await this.refresh()
     this.emit('teams', this.list())
     this.emit('change', teamId)
-    if (degraded) this.emit('pause:degraded', teamId)
-    return { ok: true, degraded }
+    if (result.degraded) this.emit('pause:degraded', teamId)
+    return result
   }
 
   async resume(teamId: string): Promise<{ ok: boolean; degraded?: boolean }> {
-    if (!teamId) throw new Error('teamId is required')
-    const found = await this.readConfig(teamId)
-    if (!found) return { ok: false }
-    const tmuxOk = await this.hasTmux()
-    found.config.status = 'active'
-    let degraded = false
-    for (const m of found.config.members) {
-      m.state = 'active'
-      if (!tmuxOk || !isTmuxPaneId(m.tmuxPaneId)) continue
-      const pid = await this.resolvePanePid(m.tmuxPaneId)
-      const cont = pid != null && this.signalPaneTree(pid, 'SIGCONT')
-      if (!cont) degraded = true
-    }
-    await this.writeConfig(found.configPath, found.config)
+    const result = await this.ops.resume(this.workspacePath, teamId)
     await this.refresh()
     this.emit('teams', this.list())
     this.emit('change', teamId)
-    return { ok: true, degraded }
+    return result
   }
 
-  async pauseMember(teamId: string, agentId: string): Promise<{ ok: boolean; degraded?: boolean }> {
-    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
-    const found = await this.readConfig(teamId)
-    if (!found) return { ok: false }
-    const member = found.config.members.find((m) => m.agentId === agentId)
-    if (!member) return { ok: false }
-    member.state = 'idle'
-    let degraded = false
-    const tmuxOk = await this.hasTmux()
-    if (tmuxOk && isTmuxPaneId(member.tmuxPaneId)) {
-      const pid = await this.resolvePanePid(member.tmuxPaneId)
-      const stopped = pid != null && this.signalPaneTree(pid, 'SIGSTOP')
-      if (!stopped) {
-        const session = teamSessionName(teamId, agentId)
-        await execFileAsync(tmuxBin(), ['detach-client', '-s', session], {
-          timeout: 3000,
-          env: tmuxEnv(),
-        }).catch(() => {})
-        degraded = true
-      }
-    } else {
-      degraded = true
-    }
-    await this.writeConfig(found.configPath, found.config)
+  async pauseMember(
+    teamId: string,
+    agentId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    const result = await this.ops.pauseMember(this.workspacePath, teamId, agentId)
     await this.refresh()
     this.emit('teams', this.list())
     this.emit('change', teamId)
-    return { ok: true, degraded }
+    return result
   }
 
-  async resumeMember(teamId: string, agentId: string): Promise<{ ok: boolean; degraded?: boolean }> {
-    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
-    const found = await this.readConfig(teamId)
-    if (!found) return { ok: false }
-    const member = found.config.members.find((m) => m.agentId === agentId)
-    if (!member) return { ok: false }
-    member.state = 'active'
-    let degraded = false
-    const tmuxOk = await this.hasTmux()
-    if (tmuxOk && isTmuxPaneId(member.tmuxPaneId)) {
-      const pid = await this.resolvePanePid(member.tmuxPaneId)
-      const cont = pid != null && this.signalPaneTree(pid, 'SIGCONT')
-      if (!cont) degraded = true
-    }
-    await this.writeConfig(found.configPath, found.config)
+  async resumeMember(
+    teamId: string,
+    agentId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    const result = await this.ops.resumeMember(this.workspacePath, teamId, agentId)
     await this.refresh()
     this.emit('teams', this.list())
     this.emit('change', teamId)
-    return { ok: true, degraded }
+    return result
   }
-
-  // ── Merge ────────────────────────────────────────────────────────────
 
   /**
    * Merge each member branch into the team base branch (`team/<teamId>`).
    * Strategy:
    *   - 'squash':     `git merge --squash <branch>` per member, single commit.
    *   - 'sequential': `git merge --no-ff <branch>` per member, ordered.
-   *
-   * On first conflict: aborts the in-flight merge, scrapes conflicted files,
-   * and returns conflict descriptors. Already-merged members are kept.
    */
   async merge(teamId: string, opts: TeamMergeOptions = {}): Promise<TeamMergeResult> {
-    if (!teamId) throw new Error('teamId is required')
-    const found = await this.readConfig(teamId)
-    if (!found) return { ok: false, conflicts: [], error: 'team not found' }
-    const cfg = found.config
-    const wsPath = cfg.workspacePath
-    if (!wsPath) {
-      return { ok: false, conflicts: [], error: 'workspacePath missing on team' }
-    }
-    if (!(await this.hasGit())) {
-      return { ok: false, conflicts: [], error: 'git not available' }
-    }
-
-    const baseBranch = cfg.baseBranch ?? `team/${teamId}`
-    const strategy: MergeStrategy = opts.mergeStrategy ?? cfg.mergeStrategy ?? 'squash'
-    const env = tmuxEnv()
-
-    // Refuse to merge into a dirty workspace — otherwise we'd silently fold
-    // the user's WIP into the team merge commit.
-    const dirty = await this.workspaceDirty(wsPath)
-    if (dirty) {
-      return {
-        ok: false,
-        conflicts: [],
-        error: 'workspace has uncommitted changes; commit or stash before merging the team',
-      }
-    }
-
-    // Move HEAD to baseBranch in the workspace so merges land there.
-    try {
-      await execFileAsync('git', ['-C', wsPath, 'checkout', baseBranch], { timeout: 10_000, env })
-    } catch (err) {
-      return {
-        ok: false,
-        conflicts: [],
-        error: `failed to checkout ${baseBranch}: ${(err as Error).message}`,
-      } satisfies TeamMergeResult
-    }
-
-    const memberBranches = cfg.members.map((m) => m.branch).filter((b): b is string => !!b && b !== baseBranch)
-
-    for (const branch of memberBranches) {
-      const args = strategy === 'squash'
-        ? ['-C', wsPath, 'merge', '--squash', branch]
-        : ['-C', wsPath, 'merge', '--no-ff', '--no-edit', branch]
-      try {
-        await execFileAsync('git', args, { timeout: 30_000, env })
-      } catch (err) {
-        // Inspect conflict state, abort, return descriptors.
-        const conflicts = await this.collectConflicts(wsPath, branch, baseBranch)
-        await execFileAsync('git', ['-C', wsPath, 'merge', '--abort'], {
-          timeout: 5000,
-          env,
-        }).catch(() => {})
-        return {
-          ok: false,
-          conflicts,
-          error: (err as Error).message,
-        }
-      }
-
-      if (strategy === 'squash') {
-        // --squash leaves changes staged; commit them before the next member.
-        // Failure here (missing identity, hook rejection, etc.) MUST abort —
-        // swallowing it leaves the workspace with staged-but-uncommitted
-        // changes while we report success, which is the H3 bug.
-        try {
-          await execFileAsync(
-            'git',
-            ['-C', wsPath, 'commit', '-m', `team(${teamId}): squash merge ${branch}`],
-            { timeout: 10_000, env }
-          )
-        } catch (err) {
-          const stderr = ((err as { stderr?: Buffer | string }).stderr ?? '').toString().trim()
-          // Reset the staged squash so we don't leave the index dirty for the
-          // user to clean up by hand. `git reset --merge` is the documented
-          // way to undo a squash that hasn't been committed.
-          await execFileAsync('git', ['-C', wsPath, 'reset', '--merge'], {
-            timeout: 5000,
-            env,
-          }).catch(() => {})
-          return {
-            ok: false,
-            conflicts: [],
-            error: `squash commit failed for ${branch}: ${stderr || (err as Error).message}`,
-          }
-        }
-      }
-
-      // After every merged branch, verify the workspace is clean. If it's
-      // not, something committed partial state (e.g. pre-commit hook silently
-      // unstaged files) and we should bail rather than continue stacking
-      // members on top of an inconsistent base.
-      const stillDirty = await this.workspaceDirty(wsPath)
-      if (stillDirty) {
-        return {
-          ok: false,
-          conflicts: [],
-          error: `workspace not clean after merging ${branch}; aborting`,
-        }
-      }
-    }
-
-    // Resolve final commit sha on the base branch.
-    let commitSha: string | undefined
-    try {
-      const { stdout } = await execFileAsync('git', ['-C', wsPath, 'rev-parse', 'HEAD'], {
-        timeout: 4000,
-        env,
-      })
-      commitSha = stdout.trim() || undefined
-    } catch {
-      // ignore
-    }
-
-    const result: TeamMergeResult = { ok: true, mergedBranch: baseBranch }
-    if (commitSha) result.commitSha = commitSha
-    return result
+    return this.ops.merge(this.workspacePath, teamId, opts)
   }
-
-  /**
-   * `git status --porcelain` returns one line per untracked/modified path.
-   * Empty stdout = clean tree. Used to gate merge entry/exit so we never
-   * report success while the index has staged-but-uncommitted changes.
-   *
-   * Forge-owned runtime paths (`.claude/teams/**`, worktree directories the
-   * watcher itself creates) are filtered out — otherwise the merge gate would
-   * deterministically fail in workspaces where `.claude` is tracked, because
-   * `create()` itself dirties the same tree that `merge()` requires clean.
-   */
-  private async workspaceDirty(wsPath: string): Promise<boolean> {
-    try {
-      const { stdout } = await execFileAsync(
-        'git',
-        ['-C', wsPath, 'status', '--porcelain'],
-        { timeout: 5000, env: tmuxEnv() }
-      )
-      const lines = stdout.split('\n').map((l) => l.trimEnd()).filter(Boolean)
-      const userDirty = lines.filter((line) => {
-        // Porcelain v1 format: XY<space>path  (renames have ` -> ` separator)
-        const rest = line.slice(3)
-        const arrow = rest.indexOf(' -> ')
-        const filePath = (arrow >= 0 ? rest.slice(arrow + 4) : rest).replace(/^"(.*)"$/, '$1')
-        return !this.isForgeOwnedPath(filePath)
-      })
-      return userDirty.length > 0
-    } catch {
-      // If status itself fails we can't trust the tree — treat as dirty.
-      return true
-    }
-  }
-
-  /** Paths the watcher itself writes inside a workspace. */
-  private isForgeOwnedPath(rel: string): boolean {
-    const normalized = rel.replace(/\\/g, '/')
-    return (
-      normalized === '.claude/teams' ||
-      normalized.startsWith('.claude/teams/') ||
-      normalized === '.claude/worktrees' ||
-      normalized.startsWith('.claude/worktrees/')
-    )
-  }
-
-  private async collectConflicts(
-    wsPath: string,
-    theirsBranch: string,
-    oursBranch: string
-  ): Promise<TeamMergeConflict[]> {
-    let files: string[] = []
-    try {
-      const { stdout } = await execFileAsync(
-        'git',
-        ['-C', wsPath, 'diff', '--name-only', '--diff-filter=U'],
-        { timeout: 5000, env: tmuxEnv() }
-      )
-      files = stdout.split('\n').map((s) => s.trim()).filter(Boolean)
-    } catch {
-      // ignore
-    }
-    const out: TeamMergeConflict[] = []
-    for (const file of files) {
-      let conflictMarkers = ''
-      try {
-        const buf = await fs.readFile(path.join(wsPath, file), 'utf-8')
-        // Extract just the first conflict block (≤ ~40 lines) for preview.
-        const start = buf.indexOf('<<<<<<<')
-        const end = buf.indexOf('>>>>>>>', start)
-        if (start >= 0 && end > start) {
-          conflictMarkers = buf.slice(start, end + 80).split('\n').slice(0, 60).join('\n')
-        }
-      } catch {
-        // unreadable — leave empty
-      }
-      out.push({ file, theirsBranch, oursBranch, conflictMarkers })
-    }
-    return out
-  }
-
-  // ── Remove ───────────────────────────────────────────────────────────
 
   /**
    * Tear down a team:
@@ -1003,64 +381,9 @@ export class AgentTeamWatcher extends EventEmitter {
    *   2. Remove each member git worktree (force).
    *   3. Delete `team/<teamId>` base branch.
    *   4. Remove the team config directory.
-   * Each step is independently best-effort.
    */
   async remove(teamId: string): Promise<void> {
-    if (!teamId) throw new Error('teamId is required')
-    const found = await this.readConfig(teamId)
-    const tmuxOk = await this.hasTmux()
-    const gitOk = await this.hasGit()
-
-    if (found) {
-      const cfg = found.config
-      const wsPath = cfg.workspacePath
-      const env = tmuxEnv()
-
-      // Kill tmux sessions (per member). Use the bundled tmux when available
-      // so this works in Dock-launched apps without /opt/homebrew on PATH.
-      if (tmuxOk) {
-        const tmux = tmuxBin()
-        for (const m of cfg.members) {
-          const session = teamSessionName(teamId, m.agentId)
-          await execFileAsync(tmux, ['kill-session', '-t', session], {
-            timeout: 3000,
-            env,
-          }).catch(() => {})
-        }
-      }
-
-      // Remove worktrees (only if isolated and within wsPath).
-      if (gitOk && wsPath) {
-        for (const m of cfg.members) {
-          if (!m.worktreePath || m.worktreePath === wsPath) continue
-          if (!isPathInside(wsPath, m.worktreePath)) continue
-          await execFileAsync(
-            'git',
-            ['-C', wsPath, 'worktree', 'remove', m.worktreePath, '--force'],
-            { timeout: 15_000, env }
-          ).catch(() => {})
-        }
-        // Delete member branches.
-        for (const m of cfg.members) {
-          if (!m.branch || !m.branch.startsWith(`team/${teamId}`)) continue
-          if (m.branch === cfg.baseBranch) continue
-          await execFileAsync('git', ['-C', wsPath, 'branch', '-D', m.branch], {
-            timeout: 5000,
-            env,
-          }).catch(() => {})
-        }
-        // Delete team base branch.
-        const teamBase = cfg.baseBranch ?? `team/${teamId}`
-        await execFileAsync('git', ['-C', wsPath, 'branch', '-D', teamBase], {
-          timeout: 5000,
-          env,
-        }).catch(() => {})
-      }
-    }
-
-    // Finally, drop the config directory.
-    const target = path.join(this.teamsDir, teamId)
-    await fs.rm(target, { recursive: true, force: true }).catch(() => {})
+    await this.ops.remove(this.workspacePath, teamId)
     await this.refresh()
     this.emit('teams', this.list())
     this.emit('change', teamId)

--- a/electron/services/TeamOperations.ts
+++ b/electron/services/TeamOperations.ts
@@ -1,0 +1,814 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs/promises'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * TeamOperations — pure, watcher-free, electron-free implementation of the
+ * team lifecycle (create / pause / resume / merge / remove).
+ *
+ * Why split this out of AgentTeamWatcher:
+ *   - The Electron GUI uses chokidar to discover teams and reacts to file
+ *     changes; the headless CLI (`bin/forge-team`) does not.
+ *   - The CLI must run without `electron` or `chokidar` imported at load
+ *     time, so the I/O-bearing logic that both consumers share lives here.
+ *   - The Watcher delegates state-mutating calls into this module and
+ *     re-emits change events afterward.
+ *
+ * The class accepts `tmuxBin` / `tmuxEnv` as factories so callers can plug
+ * in their own resolution (PathManager-backed in Electron, plain `tmux` on
+ * PATH from the CLI).
+ */
+
+export type AgentStatus = 'running' | 'idle' | 'shutdown' | 'paused' | 'active'
+export type TeamStatus = 'active' | 'paused'
+export type WorktreeStrategy = 'isolated' | 'shared'
+export type MergeStrategy = 'squash' | 'sequential'
+
+export interface TeamCreateMember {
+  agentId: string
+  task?: string
+}
+
+export interface TeamCreateOptions {
+  workspaceId: string
+  workspacePath: string
+  name: string
+  goal?: string
+  members: TeamCreateMember[]
+  worktreeStrategy: WorktreeStrategy
+  mergeStrategy: MergeStrategy
+  autoStartClaude?: boolean
+}
+
+export interface TeamCreateResult {
+  teamId: string
+  configPath: string
+  worktreesCreated: number
+  tmuxSessionsStarted: number
+}
+
+export interface TeamMergeConflict {
+  file: string
+  theirsBranch: string
+  oursBranch: string
+  conflictMarkers: string
+}
+
+export interface TeamMergeResult {
+  ok: boolean
+  mergedBranch?: string
+  commitSha?: string
+  conflicts?: TeamMergeConflict[]
+  error?: string
+}
+
+export interface TeamMergeOptions {
+  mergeStrategy?: MergeStrategy
+}
+
+export interface RawMember {
+  agentId: string
+  name: string
+  agentType: string
+  model: string
+  cwd?: string
+  tmuxPaneId?: string
+  backendType?: string
+  joinedAt: number
+  color?: string
+  prompt?: string
+  task?: string
+  worktreePath?: string
+  branch?: string
+  state?: 'active' | 'idle'
+}
+
+export interface RawConfig {
+  name: string
+  description?: string
+  goal?: string
+  workspaceId?: string
+  workspacePath?: string
+  worktreeStrategy?: WorktreeStrategy
+  mergeStrategy?: MergeStrategy
+  createdAt: number
+  leadAgentId: string
+  leadSessionId?: string
+  members: RawMember[]
+  status?: TeamStatus
+  baseBranch?: string
+}
+
+export interface TeamSummary {
+  id: string
+  name: string
+  goal?: string
+  workspaceId?: string
+  worktreeStrategy?: WorktreeStrategy
+  mergeStrategy?: MergeStrategy
+  status?: TeamStatus
+  createdAt: number
+  leadAgentId: string
+  members: Array<{
+    agentId: string
+    name: string
+    branch?: string
+    worktreePath?: string
+    tmuxPaneId?: string
+    state?: 'active' | 'idle'
+    task?: string
+  }>
+}
+
+export interface TeamOperationsDeps {
+  /** Resolve the tmux binary to invoke. Falls back to PATH `tmux`. */
+  tmuxBin: () => string
+  /** Build an env that exposes any bundled bin/ directories on PATH. */
+  tmuxEnv: () => NodeJS.ProcessEnv
+  /**
+   * Resolve the teams root directory for a workspace. Defaults to
+   * `<workspacePath>/.claude/teams`; the Electron watcher overrides this so
+   * a null workspace falls back to `~/.claude/teams`.
+   */
+  teamsDirFor?: (workspacePath: string | null) => string
+}
+
+/** Strict tmux pane-id form (`%42`, `@7`, `$3`). Anything else is rejected. */
+export function isTmuxPaneId(value: string | undefined | null): value is string {
+  return !!value && /^[%@$][A-Za-z0-9_-]+$/.test(value)
+}
+
+/** Validate `child` is contained within `parent` to defend against path traversal. */
+export function isPathInside(parent: string, child: string): boolean {
+  const rel = path.relative(parent, child)
+  return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+export function teamSessionName(teamId: string, agentId: string): string {
+  const safe = agentId.replace(/[^A-Za-z0-9_-]/g, '_')
+  return `forge-team-${teamId}-${safe}`
+}
+
+function defaultTeamsDirFor(workspacePath: string | null): string {
+  return workspacePath
+    ? path.join(workspacePath, '.claude', 'teams')
+    : path.join(os.homedir(), '.claude', 'teams')
+}
+
+export class TeamOperations {
+  private readonly tmuxBin: () => string
+  private readonly tmuxEnv: () => NodeJS.ProcessEnv
+  private readonly teamsDirFor: (workspacePath: string | null) => string
+
+  constructor(deps: TeamOperationsDeps) {
+    this.tmuxBin = deps.tmuxBin
+    this.tmuxEnv = deps.tmuxEnv
+    this.teamsDirFor = deps.teamsDirFor ?? defaultTeamsDirFor
+  }
+
+  // ── External tool gating ─────────────────────────────────────────────
+
+  async hasGit(): Promise<boolean> {
+    try {
+      await execFileAsync('git', ['--version'], { timeout: 3000, env: this.tmuxEnv() })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async hasTmux(): Promise<boolean> {
+    try {
+      await execFileAsync(this.tmuxBin(), ['-V'], { timeout: 3000, env: this.tmuxEnv() })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private async resolveBaseBranch(workspacePath: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['-C', workspacePath, 'branch', '--show-current'],
+        { timeout: 5000, env: this.tmuxEnv() }
+      )
+      const cur = stdout.trim()
+      if (cur) return cur
+    } catch {
+      // fall through
+    }
+    return 'main'
+  }
+
+  private async ensureBranch(
+    workspacePath: string,
+    newBranch: string,
+    fromBranch: string
+  ): Promise<boolean> {
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', workspacePath, 'rev-parse', '--verify', newBranch],
+        { timeout: 4000, env: this.tmuxEnv() }
+      )
+      return true
+    } catch {
+      // doesn't exist yet
+    }
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', workspacePath, 'branch', newBranch, fromBranch],
+        { timeout: 8000, env: this.tmuxEnv() }
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  // ── Listing ──────────────────────────────────────────────────────────
+
+  /**
+   * Enumerate teams under `<workspacePath>/.claude/teams`. Returns a flat,
+   * JSON-friendly summary (no inbox parsing — that lives in the watcher).
+   * Callers that need the richer Team shape (status from inbox, unread
+   * counts, etc.) should use the watcher's `list()` instead.
+   */
+  async list(workspacePath: string | null): Promise<TeamSummary[]> {
+    const teamsDir = this.teamsDirFor(workspacePath)
+    let dirs: string[] = []
+    try {
+      dirs = await fs.readdir(teamsDir)
+    } catch {
+      return []
+    }
+    const out: TeamSummary[] = []
+    for (const id of dirs) {
+      const found = await this.readConfig(workspacePath, id)
+      if (!found) continue
+      const cfg = found.config
+      out.push({
+        id,
+        name: cfg.name,
+        goal: cfg.goal,
+        workspaceId: cfg.workspaceId,
+        worktreeStrategy: cfg.worktreeStrategy,
+        mergeStrategy: cfg.mergeStrategy,
+        status: cfg.status,
+        createdAt: cfg.createdAt,
+        leadAgentId: cfg.leadAgentId,
+        members: cfg.members.map((m) => ({
+          agentId: m.agentId,
+          name: m.name,
+          branch: m.branch,
+          worktreePath: m.worktreePath,
+          tmuxPaneId: m.tmuxPaneId,
+          state: m.state,
+          task: m.task,
+        })),
+      })
+    }
+    return out.sort((a, b) => b.createdAt - a.createdAt)
+  }
+
+  // ── Create ───────────────────────────────────────────────────────────
+
+  async create(opts: TeamCreateOptions): Promise<TeamCreateResult> {
+    if (!opts.workspacePath) throw new Error('workspacePath is required')
+    if (!opts.name?.trim()) throw new Error('team name is required')
+    if (!Array.isArray(opts.members) || opts.members.length === 0) {
+      throw new Error('at least one member is required')
+    }
+
+    const teamId = `team-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const teamRoot = path.join(opts.workspacePath, '.claude', 'teams', teamId)
+    await fs.mkdir(teamRoot, { recursive: true })
+
+    const now = Date.now()
+    const leadAgentId = opts.members[0].agentId
+    const wsPath = opts.workspacePath
+    const gitOk = await this.hasGit()
+    const tmuxOk = await this.hasTmux()
+
+    let baseBranch: string | undefined
+    let teamBaseBranch: string | undefined
+    if (gitOk && opts.worktreeStrategy === 'isolated') {
+      baseBranch = await this.resolveBaseBranch(wsPath)
+      teamBaseBranch = `team/${teamId}`
+      await this.ensureBranch(wsPath, teamBaseBranch, baseBranch)
+    } else if (gitOk) {
+      baseBranch = await this.resolveBaseBranch(wsPath)
+    }
+
+    let worktreesCreated = 0
+    let tmuxSessionsStarted = 0
+    const autoStart = opts.autoStartClaude !== false
+
+    const rawMembers: RawMember[] = []
+    for (let idx = 0; idx < opts.members.length; idx++) {
+      const m = opts.members[idx]
+      const safeAgentId = m.agentId.replace(/[^A-Za-z0-9_-]/g, '_')
+      const member: RawMember = {
+        agentId: m.agentId,
+        name: m.agentId,
+        agentType: m.agentId,
+        model: 'sonnet-4.5',
+        joinedAt: now + idx,
+        task: m.task,
+        state: 'active',
+      }
+
+      // ── Worktree provisioning ──────────────────────────────────────
+      let memberCwd: string | null = null
+      if (opts.worktreeStrategy === 'isolated' && gitOk && teamBaseBranch) {
+        const worktreePath = path.join(teamRoot, 'worktrees', safeAgentId)
+        if (!isPathInside(teamRoot, worktreePath)) {
+          member.worktreePath = wsPath
+          member.branch = baseBranch
+          memberCwd = wsPath
+        } else {
+          const memberBranch = `team/${teamId}/${safeAgentId}`
+          try {
+            await fs.mkdir(path.dirname(worktreePath), { recursive: true })
+            await execFileAsync(
+              'git',
+              ['-C', wsPath, 'worktree', 'add', '-b', memberBranch, worktreePath, teamBaseBranch],
+              { timeout: 30_000, env: this.tmuxEnv() }
+            )
+            member.worktreePath = worktreePath
+            member.branch = memberBranch
+            memberCwd = worktreePath
+            worktreesCreated++
+          } catch {
+            memberCwd = wsPath
+          }
+        }
+      } else {
+        member.worktreePath = wsPath
+        member.branch = baseBranch
+        memberCwd = wsPath
+      }
+
+      // ── tmux session ───────────────────────────────────────────────
+      if (tmuxOk && memberCwd) {
+        const session = teamSessionName(teamId, m.agentId)
+        const tmux = this.tmuxBin()
+        const env = this.tmuxEnv()
+        try {
+          await execFileAsync(
+            tmux,
+            ['new-session', '-d', '-s', session, '-c', memberCwd],
+            { timeout: 8000, env }
+          )
+          let realPaneId: string | null = null
+          try {
+            const { stdout } = await execFileAsync(
+              tmux,
+              ['display-message', '-p', '-t', session, '#{pane_id}'],
+              { timeout: 3000, env }
+            )
+            const candidate = stdout.trim()
+            if (isTmuxPaneId(candidate)) realPaneId = candidate
+          } catch {
+            // pane lookup failed
+          }
+          if (autoStart) {
+            try {
+              await execFileAsync(tmux, ['send-keys', '-t', session, 'claude', 'Enter'], {
+                timeout: 4000,
+                env,
+              })
+            } catch {
+              // ignore
+            }
+          }
+          if (realPaneId) {
+            member.tmuxPaneId = realPaneId
+            member.backendType = 'tmux'
+            member.cwd = memberCwd
+            tmuxSessionsStarted++
+          } else {
+            member.cwd = memberCwd
+          }
+        } catch {
+          // tmux unavailable / collision
+        }
+      } else if (memberCwd) {
+        member.cwd = memberCwd
+      }
+
+      rawMembers.push(member)
+    }
+
+    const config: RawConfig = {
+      name: opts.name,
+      goal: opts.goal,
+      workspaceId: opts.workspaceId,
+      workspacePath: wsPath,
+      worktreeStrategy: opts.worktreeStrategy,
+      mergeStrategy: opts.mergeStrategy,
+      createdAt: now,
+      leadAgentId,
+      members: rawMembers,
+      status: 'active',
+      baseBranch: teamBaseBranch,
+    }
+    const configPath = path.join(teamRoot, 'config.json')
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+
+    return { teamId, configPath, worktreesCreated, tmuxSessionsStarted }
+  }
+
+  // ── Read / Write config ──────────────────────────────────────────────
+
+  async readConfig(
+    workspacePath: string | null,
+    teamId: string
+  ): Promise<{ configPath: string; config: RawConfig } | null> {
+    const teamsDir = this.teamsDirFor(workspacePath)
+    const configPath = path.join(teamsDir, teamId, 'config.json')
+    try {
+      const config = JSON.parse(await fs.readFile(configPath, 'utf-8')) as RawConfig
+      return { configPath, config }
+    } catch {
+      return null
+    }
+  }
+
+  async writeConfig(configPath: string, config: RawConfig): Promise<void> {
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  }
+
+  // ── Pause / Resume ───────────────────────────────────────────────────
+
+  private async resolvePanePid(paneId: string): Promise<number | null> {
+    if (!isTmuxPaneId(paneId)) return null
+    try {
+      const { stdout } = await execFileAsync(
+        this.tmuxBin(),
+        ['display-message', '-p', '-t', paneId, '#{pane_pid}'],
+        { timeout: 3000, env: this.tmuxEnv() }
+      )
+      const pid = parseInt(stdout.trim(), 10)
+      return Number.isFinite(pid) && pid > 0 ? pid : null
+    } catch {
+      return null
+    }
+  }
+
+  private signalPaneTree(pid: number, signal: 'SIGSTOP' | 'SIGCONT'): boolean {
+    try {
+      try {
+        process.kill(-pid, signal)
+        return true
+      } catch {
+        process.kill(pid, signal)
+        return true
+      }
+    } catch {
+      return false
+    }
+  }
+
+  async pause(
+    workspacePath: string | null,
+    teamId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(workspacePath, teamId)
+    if (!found) return { ok: false }
+    const tmuxOk = await this.hasTmux()
+    found.config.status = 'paused'
+    let degraded = false
+    for (const m of found.config.members) {
+      m.state = 'idle'
+      if (!tmuxOk || !isTmuxPaneId(m.tmuxPaneId)) {
+        degraded = true
+        continue
+      }
+      const pid = await this.resolvePanePid(m.tmuxPaneId)
+      const stopped = pid != null && this.signalPaneTree(pid, 'SIGSTOP')
+      if (!stopped) {
+        const session = teamSessionName(teamId, m.agentId)
+        await execFileAsync(this.tmuxBin(), ['detach-client', '-s', session], {
+          timeout: 3000,
+          env: this.tmuxEnv(),
+        }).catch(() => {})
+        degraded = true
+      }
+    }
+    await this.writeConfig(found.configPath, found.config)
+    return { ok: true, degraded }
+  }
+
+  async resume(
+    workspacePath: string | null,
+    teamId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(workspacePath, teamId)
+    if (!found) return { ok: false }
+    const tmuxOk = await this.hasTmux()
+    found.config.status = 'active'
+    let degraded = false
+    for (const m of found.config.members) {
+      m.state = 'active'
+      if (!tmuxOk || !isTmuxPaneId(m.tmuxPaneId)) continue
+      const pid = await this.resolvePanePid(m.tmuxPaneId)
+      const cont = pid != null && this.signalPaneTree(pid, 'SIGCONT')
+      if (!cont) degraded = true
+    }
+    await this.writeConfig(found.configPath, found.config)
+    return { ok: true, degraded }
+  }
+
+  async pauseMember(
+    workspacePath: string | null,
+    teamId: string,
+    agentId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
+    const found = await this.readConfig(workspacePath, teamId)
+    if (!found) return { ok: false }
+    const member = found.config.members.find((m) => m.agentId === agentId)
+    if (!member) return { ok: false }
+    member.state = 'idle'
+    let degraded = false
+    const tmuxOk = await this.hasTmux()
+    if (tmuxOk && isTmuxPaneId(member.tmuxPaneId)) {
+      const pid = await this.resolvePanePid(member.tmuxPaneId)
+      const stopped = pid != null && this.signalPaneTree(pid, 'SIGSTOP')
+      if (!stopped) {
+        const session = teamSessionName(teamId, agentId)
+        await execFileAsync(this.tmuxBin(), ['detach-client', '-s', session], {
+          timeout: 3000,
+          env: this.tmuxEnv(),
+        }).catch(() => {})
+        degraded = true
+      }
+    } else {
+      degraded = true
+    }
+    await this.writeConfig(found.configPath, found.config)
+    return { ok: true, degraded }
+  }
+
+  async resumeMember(
+    workspacePath: string | null,
+    teamId: string,
+    agentId: string
+  ): Promise<{ ok: boolean; degraded?: boolean }> {
+    if (!teamId || !agentId) throw new Error('teamId and agentId are required')
+    const found = await this.readConfig(workspacePath, teamId)
+    if (!found) return { ok: false }
+    const member = found.config.members.find((m) => m.agentId === agentId)
+    if (!member) return { ok: false }
+    member.state = 'active'
+    let degraded = false
+    const tmuxOk = await this.hasTmux()
+    if (tmuxOk && isTmuxPaneId(member.tmuxPaneId)) {
+      const pid = await this.resolvePanePid(member.tmuxPaneId)
+      const cont = pid != null && this.signalPaneTree(pid, 'SIGCONT')
+      if (!cont) degraded = true
+    }
+    await this.writeConfig(found.configPath, found.config)
+    return { ok: true, degraded }
+  }
+
+  // ── Merge ────────────────────────────────────────────────────────────
+
+  async merge(
+    workspacePath: string | null,
+    teamId: string,
+    opts: TeamMergeOptions = {}
+  ): Promise<TeamMergeResult> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(workspacePath, teamId)
+    if (!found) return { ok: false, conflicts: [], error: 'team not found' }
+    const cfg = found.config
+    const wsPath = cfg.workspacePath
+    if (!wsPath) {
+      return { ok: false, conflicts: [], error: 'workspacePath missing on team' }
+    }
+    if (!(await this.hasGit())) {
+      return { ok: false, conflicts: [], error: 'git not available' }
+    }
+
+    const baseBranch = cfg.baseBranch ?? `team/${teamId}`
+    const strategy: MergeStrategy = opts.mergeStrategy ?? cfg.mergeStrategy ?? 'squash'
+    const env = this.tmuxEnv()
+
+    const dirty = await this.workspaceDirty(wsPath)
+    if (dirty) {
+      return {
+        ok: false,
+        conflicts: [],
+        error: 'workspace has uncommitted changes; commit or stash before merging the team',
+      }
+    }
+
+    try {
+      await execFileAsync('git', ['-C', wsPath, 'checkout', baseBranch], { timeout: 10_000, env })
+    } catch (err) {
+      return {
+        ok: false,
+        conflicts: [],
+        error: `failed to checkout ${baseBranch}: ${(err as Error).message}`,
+      }
+    }
+
+    const memberBranches = cfg.members
+      .map((m) => m.branch)
+      .filter((b): b is string => !!b && b !== baseBranch)
+
+    for (const branch of memberBranches) {
+      const args = strategy === 'squash'
+        ? ['-C', wsPath, 'merge', '--squash', branch]
+        : ['-C', wsPath, 'merge', '--no-ff', '--no-edit', branch]
+      try {
+        await execFileAsync('git', args, { timeout: 30_000, env })
+      } catch (err) {
+        const conflicts = await this.collectConflicts(wsPath, branch, baseBranch)
+        await execFileAsync('git', ['-C', wsPath, 'merge', '--abort'], {
+          timeout: 5000,
+          env,
+        }).catch(() => {})
+        return {
+          ok: false,
+          conflicts,
+          error: (err as Error).message,
+        }
+      }
+
+      if (strategy === 'squash') {
+        try {
+          await execFileAsync(
+            'git',
+            ['-C', wsPath, 'commit', '-m', `team(${teamId}): squash merge ${branch}`],
+            { timeout: 10_000, env }
+          )
+        } catch (err) {
+          const stderr = ((err as { stderr?: Buffer | string }).stderr ?? '').toString().trim()
+          await execFileAsync('git', ['-C', wsPath, 'reset', '--merge'], {
+            timeout: 5000,
+            env,
+          }).catch(() => {})
+          return {
+            ok: false,
+            conflicts: [],
+            error: `squash commit failed for ${branch}: ${stderr || (err as Error).message}`,
+          }
+        }
+      }
+
+      const stillDirty = await this.workspaceDirty(wsPath)
+      if (stillDirty) {
+        return {
+          ok: false,
+          conflicts: [],
+          error: `workspace not clean after merging ${branch}; aborting`,
+        }
+      }
+    }
+
+    let commitSha: string | undefined
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', wsPath, 'rev-parse', 'HEAD'], {
+        timeout: 4000,
+        env,
+      })
+      commitSha = stdout.trim() || undefined
+    } catch {
+      // ignore
+    }
+
+    const result: TeamMergeResult = { ok: true, mergedBranch: baseBranch }
+    if (commitSha) result.commitSha = commitSha
+    return result
+  }
+
+  private async workspaceDirty(wsPath: string): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['-C', wsPath, 'status', '--porcelain'],
+        { timeout: 5000, env: this.tmuxEnv() }
+      )
+      const lines = stdout.split('\n').map((l) => l.trimEnd()).filter(Boolean)
+      const userDirty = lines.filter((line) => {
+        const rest = line.slice(3)
+        const arrow = rest.indexOf(' -> ')
+        const filePath = (arrow >= 0 ? rest.slice(arrow + 4) : rest).replace(/^"(.*)"$/, '$1')
+        return !this.isForgeOwnedPath(filePath)
+      })
+      return userDirty.length > 0
+    } catch {
+      return true
+    }
+  }
+
+  private isForgeOwnedPath(rel: string): boolean {
+    const normalized = rel.replace(/\\/g, '/')
+    return (
+      normalized === '.claude/teams' ||
+      normalized.startsWith('.claude/teams/') ||
+      normalized === '.claude/worktrees' ||
+      normalized.startsWith('.claude/worktrees/')
+    )
+  }
+
+  private async collectConflicts(
+    wsPath: string,
+    theirsBranch: string,
+    oursBranch: string
+  ): Promise<TeamMergeConflict[]> {
+    let files: string[] = []
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['-C', wsPath, 'diff', '--name-only', '--diff-filter=U'],
+        { timeout: 5000, env: this.tmuxEnv() }
+      )
+      files = stdout.split('\n').map((s) => s.trim()).filter(Boolean)
+    } catch {
+      // ignore
+    }
+    const out: TeamMergeConflict[] = []
+    for (const file of files) {
+      let conflictMarkers = ''
+      try {
+        const buf = await fs.readFile(path.join(wsPath, file), 'utf-8')
+        const start = buf.indexOf('<<<<<<<')
+        const end = buf.indexOf('>>>>>>>', start)
+        if (start >= 0 && end > start) {
+          conflictMarkers = buf.slice(start, end + 80).split('\n').slice(0, 60).join('\n')
+        }
+      } catch {
+        // unreadable
+      }
+      out.push({ file, theirsBranch, oursBranch, conflictMarkers })
+    }
+    return out
+  }
+
+  // ── Remove ───────────────────────────────────────────────────────────
+
+  async remove(workspacePath: string | null, teamId: string): Promise<void> {
+    if (!teamId) throw new Error('teamId is required')
+    const found = await this.readConfig(workspacePath, teamId)
+    const tmuxOk = await this.hasTmux()
+    const gitOk = await this.hasGit()
+
+    if (found) {
+      const cfg = found.config
+      const wsPath = cfg.workspacePath
+      const env = this.tmuxEnv()
+
+      if (tmuxOk) {
+        const tmux = this.tmuxBin()
+        for (const m of cfg.members) {
+          const session = teamSessionName(teamId, m.agentId)
+          await execFileAsync(tmux, ['kill-session', '-t', session], {
+            timeout: 3000,
+            env,
+          }).catch(() => {})
+        }
+      }
+
+      if (gitOk && wsPath) {
+        for (const m of cfg.members) {
+          if (!m.worktreePath || m.worktreePath === wsPath) continue
+          if (!isPathInside(wsPath, m.worktreePath)) continue
+          await execFileAsync(
+            'git',
+            ['-C', wsPath, 'worktree', 'remove', m.worktreePath, '--force'],
+            { timeout: 15_000, env }
+          ).catch(() => {})
+        }
+        for (const m of cfg.members) {
+          if (!m.branch || !m.branch.startsWith(`team/${teamId}`)) continue
+          if (m.branch === cfg.baseBranch) continue
+          await execFileAsync('git', ['-C', wsPath, 'branch', '-D', m.branch], {
+            timeout: 5000,
+            env,
+          }).catch(() => {})
+        }
+        const teamBase = cfg.baseBranch ?? `team/${teamId}`
+        await execFileAsync('git', ['-C', wsPath, 'branch', '-D', teamBase], {
+          timeout: 5000,
+          env,
+        }).catch(() => {})
+      }
+    }
+
+    const teamsDir = this.teamsDirFor(workspacePath)
+    const target = path.join(teamsDir, teamId)
+    await fs.rm(target, { recursive: true, force: true }).catch(() => {})
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "forge-studio",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",
+  "bin": {
+    "forge-team": "bin/forge-team"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && electron-builder",
@@ -17,6 +20,7 @@
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"electron/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"electron/**/*.ts\"",
+    "team": "node --experimental-strip-types --no-warnings bin/forge-team.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "electron-rebuild && node scripts/patch-isbinaryfile.js"
   },
@@ -92,6 +96,16 @@
         "from": "resources/bundled-tools/darwin-arm64",
         "to": "bundled-tools",
         "filter": ["**/*", "!.gitkeep"]
+      },
+      {
+        "from": "bin",
+        "to": "forge-cli/bin",
+        "filter": ["forge-team", "forge-team.ts"]
+      },
+      {
+        "from": "electron/services",
+        "to": "forge-cli/electron/services",
+        "filter": ["TeamOperations.ts"]
       }
     ],
     "directories": {

--- a/resources/harness-template/.claude/commands/agent-team.md
+++ b/resources/harness-template/.claude/commands/agent-team.md
@@ -1,9 +1,13 @@
-"$ARGUMENTS" 작업을 Agent Team으로 병렬 실행한다.
+"$ARGUMENTS" 작업을 Forge Team 으로 병렬 실행한다.
 
-## Agent Team 시스템
+> ⚠️ **이 커맨드는 `forge-team` CLI 를 호출한다**. `Agent` / `Task` 도구는
+> 차단되어 있으므로 절대 사용하지 마라.
 
-독립적인 작업을 여러 에이전트가 **git worktree 기반으로 동시에** 실행.
-각 에이전트는 격리된 브랜치에서 작업하고, 완료 후 메인 브랜치에 머지.
+## Forge Team 시스템
+
+독립적인 작업을 여러 멤버가 **격리 git worktree + tmux 세션 + 별 Claude 인스턴스**
+로 동시에 실행. 각 멤버는 자기 worktree 에서 자기 task 만 수행하고, 완료 후
+베이스 브랜치로 머지.
 
 ## 실행 모드
 
@@ -11,19 +15,25 @@
 ```
 /agent-team "auth API + board UI + CMS dashboard"
 
-→ Worktree A: nestjs-backend → auth API 구현
-→ Worktree B: flutter-ui → board UI 구현
-→ Worktree C: nextjs-cms → CMS dashboard 구현
-→ 완료 후: 각 브랜치 리뷰 → 순차 머지
+→ Bash(forge-team create \
+    --workspace . \
+    --name "multi-feature" \
+    --members "nestjs-backend:auth API,flutter-ui:board UI,nextjs-cms:CMS dashboard" \
+    --worktree-strategy isolated \
+    --merge-strategy squash \
+    --auto-start)
+→ 3개 worktree + 3개 tmux + 3개 Claude
+→ 완료 후 forge-team merge
 ```
 
 ### Mode 2: 병렬 리뷰 (동시 검수)
 ```
 /agent-team "review"
 
-→ Agent A (isolation: worktree): code-reviewer
-→ Agent B (isolation: worktree): security-auditor
-→ Agent C (isolation: worktree): spec-verifier
+→ Bash(forge-team create \
+    --workspace . \
+    --name "review-team" \
+    --members "code-reviewer:diff 리뷰,security-auditor:취약점,spec-verifier:스펙 정합성")
 → 결과 취합 → 종합 보고서
 ```
 
@@ -31,9 +41,10 @@
 ```
 /agent-team "test all"
 
-→ Agent A: flutter test (client/)
-→ Agent B: npm test (server/)
-→ Agent C: npm run build (cms/)
+→ Bash(forge-team create \
+    --workspace . \
+    --name "test-all" \
+    --members "test-writer:flutter test,test-writer:server jest test,test-writer:cms build")
 → 결과 취합
 ```
 
@@ -41,20 +52,26 @@
 
 1. **작업 분해**: $ARGUMENTS를 독립 단위로 분해
 2. **의존성 확인**: 순서 필수인 것과 병렬 가능한 것 분류
-   - 순서 필수: prisma → nestjs → flutter DTO (체이닝)
-   - 병렬 가능: 독립 피처, 리뷰 3종, 테스트
-3. **Agent 실행**: 각 Agent를 `isolation: "worktree"`로 실행
-4. **결과 수집**: 각 Agent 완료 대기
-5. **머지 전략**:
-   - 충돌 없으면: 순차 머지
-   - 충돌 있으면: 수동 해결 요청
+   - 순서 필수: prisma → nestjs → flutter DTO (체이닝 — sequential merge)
+   - 병렬 가능: 독립 피처, 리뷰 3종, 테스트 (squash merge)
+3. **forge-team create**: 멤버 명단 + 전략 결정 후 단일 CLI 호출
+4. **결과 수집**: tmux 세션 관찰 또는 `forge-team list` 로 상태 폴링
+5. **머지 전략**: `forge-team merge` 자동 호출
+   - 충돌 없으면: squash 또는 sequential 머지 진행
+   - 충돌 있으면: exit 2 + conflict 정보 → 수동 해결 요청
 6. **통합 검증**: 머지 후 `/review` 실행
+
+## 절대 하면 안 되는 것
+
+- ❌ `Agent` / `Task` 도구 호출 — `permissions.deny` 차단됨
+- ❌ 메인 세션이 직접 5줄 이상 코드 작성
+- ❌ `git worktree add` 직접 — `forge-team create` 가 처리
 
 ## 워크트리 규칙
 
-- 브랜치 네이밍: `agent/{task-name}-{timestamp}`
-- 작업 완료 후 워크트리 자동 정리 (변경 없으면)
-- 변경 있으면 브랜치 + 경로 반환 → 유저가 머지 결정
+- 멤버 브랜치 네이밍: `team/<teamId>/<agentId>` (forge-team 자동 생성)
+- 베이스 브랜치: `team/<teamId>` (forge-team 자동 생성)
+- 작업 완료 후 `forge-team remove` 로 정리 (worktree + branch + tmux)
 - 메인 브랜치 직접 수정 금지
 
 ## 적합한 작업 vs 부적합
@@ -66,24 +83,24 @@
 - 리팩토링 + 테스트 동시
 
 ❌ 부적합:
-- DB 스키마 → API → DTO 체이닝 (의존성 있음)
+- DB 스키마 → API → DTO 체이닝 (의존성 있음 — sequential merge 권장)
 - 같은 파일 수정하는 작업
 - 순차 워크플로우 (→ `/full-cycle` 사용)
 
 ## Output
 
 ```
-## Agent Team 결과
+## Forge Team 결과
 
-| Agent | 작업 | 브랜치 | 상태 | 변경 파일 |
-|-------|------|--------|------|-----------|
-| A | auth API | agent/auth-xxx | ✅ | 12 files |
-| B | board UI | agent/board-xxx | ✅ | 8 files |
-| C | CMS dash | agent/cms-xxx | ✅ | 6 files |
+| Member | 작업 | 브랜치 | 상태 | 변경 파일 |
+|--------|------|--------|------|-----------|
+| nestjs-backend | auth API | team/<id>/nestjs-backend | ✅ | 12 files |
+| flutter-ui | board UI | team/<id>/flutter-ui | ✅ | 8 files |
+| nextjs-cms | CMS dash | team/<id>/nextjs-cms | ✅ | 6 files |
 
 ### 머지 상태
-- 충돌: 없음 / N건
-- → 순차 머지 진행 / 수동 해결 필요
+- forge-team merge: exit 0 / exit 2 (conflict)
+- → 자동 머지 완료 / 수동 해결 필요
 
 ### 통합 검증
 - flutter analyze: ✅

--- a/resources/harness-template/.claude/rules/common/orchestration.md
+++ b/resources/harness-template/.claude/rules/common/orchestration.md
@@ -1,15 +1,18 @@
 # Orchestration Rules (MANDATORY)
 
-> CLAUDE.md에 ROLE = MANAGER 블록이 있다. 이 파일은 그 룰의 **operational
-> 디테일**이다. 충돌 시 CLAUDE.md ROLE 블록이 우선.
+> CLAUDE.md 에 ROLE = TEAM ORCHESTRATOR 블록이 있다. 이 파일은 그 룰의
+> **operational 디테일**이다. 충돌 시 CLAUDE.md ROLE 블록이 우선.
+
+> **CRITICAL**: `Agent` / `Task` 도구 호출 금지 — `permissions.deny` 등록되어
+> PreToolUse 훅이 차단한다. 모든 병렬/위임은 **`forge-team` CLI** 로만 한다.
 
 ## 핵심 원칙
 
-1. **에이전트 자동 파견**: 요청 분석 → Agent Routing 매칭 → 즉시 파견. "어떤 에이전트 쓸까요?" 묻지 마라.
+1. **팀 자동 파견**: 요청 분석 → Team Routing 매칭 → `forge-team create` 즉시 호출. "어떤 멤버 띄울까요?" 묻지 마라.
 2. **스킬 자동 적용**: 파일 패턴 → Skill Routing 매칭 → 해당 스킬 읽고 적용. 스킬 적용 여부를 묻지 마라.
 3. **커맨드 자동 실행**: verify, review 등 워크플로우 커맨드는 흐름에 따라 자동 트리거. 유저가 `/verify` 칠 필요 없다.
-4. **팀 병렬 실행**: 독립 작업 2개 이상이면 Agent 도구를 한 메시지에서 병렬 호출 (`run_in_background: true`, `isolation: "worktree"`).
-5. **자동 수정 루프**: 빌드/테스트 실패 시 loop-operator 자동 호출. 5회까지 자동 재시도.
+4. **병렬 멤버 spawn**: 독립 작업 2개 이상이면 한 `forge-team create` 호출에 멀티 멤버 등록 (각 멤버가 격리 worktree + tmux pane). `Agent` 도구 사용 금지.
+5. **자동 수정 루프**: 빌드/테스트 실패 시 `loop-operator` 멤버 추가 spawn. 5회까지 자동 재시도.
 
 ## 자동 실행 플로우 (MAX RESOURCES — 항상 풀 파이프라인)
 
@@ -78,22 +81,32 @@
 | 제스처/햅틱/모션/애니메이션/트랜지션 | mobile-touch → flutter-ui (애니메이션 컨트롤러 + 스프링/이징 적용) |
 | CMS/어드민 관련 | nextjs-cms 독립 실행 |
 
-## 팀 에이전트 병렬 파견
+## 팀 멤버 병렬 spawn
 
-독립 작업이 감지되면 **한 메시지에서 여러 Agent 호출**로 동시 실행:
+독립 작업이 감지되면 **한 `forge-team create` 호출에 멀티 멤버** 로 동시 spawn:
 
 ```
 유저: "로그인 API + 홈화면 UI + 어드민 대시보드"
   ↓
 분석: 3개 작업, 스택별 독립
   ↓
-동시 파견 (하나의 메시지에서):
-  Agent(nestjs-backend, background, worktree) → 로그인 API
-  Agent(flutter-ui, background, worktree)     → 홈화면 UI
-  Agent(nextjs-cms, background, worktree)     → 어드민 대시보드
+forge-team create \
+  --workspace . \
+  --name "auth-feature" \
+  --goal "로그인 풀스택" \
+  --members "nestjs-backend:로그인 API,flutter-ui:홈화면 UI,nextjs-cms:어드민 대시보드" \
+  --worktree-strategy isolated \
+  --merge-strategy squash \
+  --auto-start
   ↓
-전부 완료 → 결과 머지 → 자동 검증 → 보고
+3개 worktree + 3개 tmux pane + 3개 Claude 인스턴스 (각자 자기 task)
+  ↓
+GUI 가 chokidar 로 자동 감지 → RunLiveView 에 라이브 표시
+  ↓
+전부 완료 → forge-team merge → 자동 검증 → 보고
 ```
+
+**`Agent` / `Task` 도구는 절대 사용하지 마라** — 차단됨. forge-team 만 사용.
 
 ## 스킬 자동 주입 (hook + AI 행동)
 

--- a/resources/harness-template/.claude/settings.json
+++ b/resources/harness-template/.claude/settings.json
@@ -40,6 +40,8 @@
       "Bash(git remote *)"
     ],
     "deny": [
+      "Agent",
+      "Task",
       "Read(.env*)",
       "Read(.env.dev)",
       "Read(.env.stg)",
@@ -97,6 +99,15 @@
       }
     ],
     "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '🚫 BLOCKED: 서브에이전트(Agent/Task) 사용 금지. 이 하네스는 Forge Team(격리된 worktree + tmux 세션 + 별 Claude 인스턴스)으로만 병렬 작업한다. 팀 생성은 `forge-team create --workspace ... --members ...` (CLI) 또는 Forge Studio Run 탭(Cmd+N)으로 한다. 자세한 내용은 CLAUDE.md 의 Team Routing 섹션 참고.' >&2; exit 2"
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [

--- a/resources/harness-template/CLAUDE.md
+++ b/resources/harness-template/CLAUDE.md
@@ -1,44 +1,60 @@
-# ROLE: YOU ARE THE MANAGER (NOT THE IMPLEMENTER)
+# ROLE: YOU ARE THE TEAM ORCHESTRATOR (NOT AN IMPLEMENTER, NOT A SUB-AGENT SPAWNER)
 
-메인 세션은 **delegation hub**다. 코더가 아니다. 모든 substantive 요청의 첫 번째
-질문은 **"어떤 agent/skill이 담당하고 어떻게 handoff할까"**다.
+메인 세션은 **Forge Team orchestrator** 다. 코더가 아니다. 서브에이전트 spawner 도
+**아니다**. 모든 substantive 요청의 첫 번째 질문은
+**"어떤 멤버 구성으로 `forge-team create` 를 호출해야 하나"** 다.
 
-## STOP-THE-LINE (자신이 다음을 하려고 하면 즉시 중단하고 route)
+## 절대 금지 (PreToolUse 훅이 차단)
 
-- 한 응답에서 5줄 이상 코드 작성하려 함 → 구현 agent로 위임
-- 구현 "방법"을 먼저 설명하려 함 → route 먼저, 설명은 결과 본 후
-- 10단계 터미널 계획을 순차 실행하려 함 → worker agent로 delegate
-- "이건 짧으니까 내가 빨리" 충동 → NO. route.
+- ❌ **`Agent` / `Task` 도구 호출 금지** — 서브에이전트 spawn 은 정책상 허용 안 됨.
+  `permissions.deny` 에 등록되어있고 PreToolUse 훅이 명시 메시지로 차단한다.
+- ❌ 메인 세션이 직접 코드 5줄 이상 작성 — 그건 멤버의 일이지 메인의 일이 아님.
+
+대신: **`Bash(forge-team create ...)` 로 격리된 worktree + tmux 세션 + 별 Claude
+인스턴스를 멤버로 띄운다**. 각 멤버는 자기 worktree 에서 자기 task 만 수행 (병렬).
+
+## STOP-THE-LINE (자신이 다음을 하려고 하면 즉시 중단하고 forge-team 으로 위임)
+
+- 한 응답에서 5줄 이상 코드 작성하려 함 → 멤버에게 위임
+- 구현 "방법"을 먼저 설명하려 함 → 팀 띄우고 결과 본 후 설명
+- 10단계 터미널 계획을 순차 실행하려 함 → forge-team create + 그 안의 tmux 가 실행
+- "이건 짧으니까 내가 빨리" 충동 → NO. 팀 띄워라.
+- "Agent 도구로 빠르게…" 충동 → NO. 차단됨. forge-team only.
 
 ## YOU MUST DO (직접)
 
 - 유저 의도 명확화 질문
-- 요청 이해용 짧은 read (1~2 파일, focused)
+- 요청 분석 → 멤버 구성 결정 (어떤 agentId, 어떤 task 할당)
+- `Bash(forge-team create --workspace ... --name ... --members ...)` 호출
+- 멤버 작업 진행 모니터링 (Forge GUI 가 실시간 반영)
+- merge / pause / resume 제어
 - verified workflow command 트리거 (`/verify`, `/review`, `/checkpoint`)
-- agent 결과 읽고 요약
+- 팀 작업 결과 읽고 요약
 - 최종 "커밋할까요?" 확인
 
-## YOU MUST NOT DO (항상 delegate)
+## YOU MUST NOT DO (모두 forge-team 으로)
 
-- 코드/테스트/마이그레이션/문서 **생성**
-- 빌드/배포/긴 shell 파이프라인
+- 코드/테스트/마이그레이션/문서 **생성** — 멤버 worktree 안에서
+- 빌드/배포/긴 shell 파이프라인 — 멤버가 자기 worktree 에서
 - 인라인 파일 편집 (code-reviewer 거치지 않고)
 - "작은 버그니까 TDD 스킵" — NEVER skip.
+- **`Agent` / `Task` 도구 사용** — 절대 금지. 차단됨.
 
 ## 매 응답 시작 자가점검 (internal, 출력 금지)
 
 ```
-1. 이 요청에 해당하는 agent가 Agent Routing 표에 있나?
-2. 있으면 → 즉시 파견. 설명은 결과 받은 후.
+1. 이 요청에 해당하는 멤버 구성이 Team Routing 표에 있나?
+2. 있으면 → 즉시 `forge-team create` 호출. 설명은 결과 받은 후.
 3. 없으면 → 유저에게 clarify, 또는 위 "MUST DO" 범위 내에서 직접 처리.
-4. 코드를 쓰려는 순간 → STOP. ROUTE.
+4. 코드를 쓰려는 순간 → STOP. forge-team create.
+5. Agent/Task 도구 호출하려는 순간 → STOP. 차단됨. forge-team create.
 ```
 
 ---
 
 # Project: Fullstack Dev Harness
 
-**Flutter 앱 + NestJS 백엔드 + Prisma ORM + Next.js CMS**를 찍어내기 위한
+**Flutter 앱 + NestJS 백엔드 + Prisma ORM + Next.js CMS** 를 찍어내기 위한
 모노레포 하네스. 상세 스택은 [`contexts/tech-stack.md`](.claude/contexts/tech-stack.md),
 아키텍처는 [`rules/common/architecture.md`](.claude/rules/common/architecture.md).
 
@@ -52,28 +68,85 @@
 
 ---
 
-# Agent Routing (요청 → 에이전트)
+# forge-team CLI (메인 세션의 유일한 병렬 실행 메커니즘)
 
-| 요청 유형 | 에이전트 | 스택 |
-|-----------|---------|------|
-| Flutter UI/위젯/화면 | `flutter-ui` | Flutter |
-| Riverpod 상태관리 | `riverpod-logic` | Flutter |
-| NestJS 모듈/서비스/API | `nestjs-backend` | NestJS |
-| Prisma 스키마/마이그레이션 | `prisma-data` | Prisma |
-| CMS 어드민 페이지 | `nextjs-cms` | Next.js |
-| 풀스택 아키텍처 설계 | `tech-architect` | Cross |
-| 피처 기획 → 태스크 분해 | `planner` | Cross |
-| 코드 리뷰 | `code-reviewer` | Cross |
-| 보안 감사 | `security-auditor` | Cross |
-| 테스트 작성 | `test-writer` | Cross |
-| TDD 가이드 | `tdd-guide` | Cross |
-| 스펙-코드 정합성 | `spec-verifier` | Cross |
-| 빌드 에러 자동 해결 | `build-error-resolver` | Cross |
-| 데드코드 정리 | `refactor-cleaner` | Cross |
-| 문서 자동 동기화 | `doc-updater` | Cross |
-| 공식 문서 검색 | `docs-lookup` | Cross |
-| 자율 루프 실행 | `loop-operator` | Cross |
-| 하네스 자체 개선 | `harness-optimizer` | Meta |
+Forge Studio 는 메인 Claude Code 세션이 GUI 없이도 팀을 만들 수 있도록 헤드리스
+CLI 를 제공한다. 이 CLI 가 **서브에이전트 (Agent/Task 도구) 의 대체재** 다.
+
+## 호출 위치
+
+```bash
+# 1. 레포 체크아웃 안 (개발 중)
+bin/forge-team <cmd> [...flags]
+
+# 2. 패키지된 Forge.app 안 (사용자 환경)
+/Applications/Forge\ Studio.app/Contents/Resources/forge-cli/bin/forge-team <cmd> ...
+
+# 3. 글로벌 link (npm link 후)
+forge-team <cmd> ...
+```
+
+## 명령어
+
+```bash
+# 팀 생성 — 워크트리 + tmux 세션 + 별 Claude 인스턴스 spawn
+forge-team create \
+  --workspace <path> \
+  --name "<team-name>" \
+  --goal "<one-line goal>" \
+  --members "agentId:task,agentId:task" \
+  --worktree-strategy isolated \
+  --merge-strategy squash \
+  --auto-start                              # 각 tmux pane 에서 claude 즉시 실행
+# → stdout: {"teamId":"...","configPath":"...","worktreesCreated":N,"tmuxSessionsStarted":N}
+
+# 활성 팀 목록
+forge-team list --workspace <path>
+
+# 머지 (모든 멤버 브랜치 → 베이스 브랜치)
+forge-team merge --workspace <path> --team-id <id>
+# → ok: true 면 exit 0, conflict 면 exit 2
+
+# Pause / Resume (전체 또는 특정 멤버)
+forge-team pause  --workspace <path> --team-id <id> [--agent-id <agentId>]
+forge-team resume --workspace <path> --team-id <id> [--agent-id <agentId>]
+
+# 정리
+forge-team remove --workspace <path> --team-id <id>
+```
+
+stdout 은 항상 단일 라인 JSON. shell 파이프라인에 안전.
+
+GUI 가 같은 워크스페이스 열려있으면 chokidar 가 ~120ms 안에 새 팀 자동 반영 —
+별도 핸드셰이크 없음.
+
+---
+
+# Team Routing (요청 → 팀 멤버 구성)
+
+작업 유형별로 어떤 멤버를 어떤 task 로 띄울지 가이드. 메인 세션은 이 표를 보고
+즉시 `forge-team create` 호출 — "어떤 멤버를 띄울까요?" 묻지 않는다.
+
+| 요청 유형 | 멤버 구성 (`--members`) | 비고 |
+|-----------|----------------------|------|
+| Flutter UI/위젯 단독 | `flutter-ui:<task>` | 단일 멤버 |
+| Riverpod 상태관리 | `riverpod-logic:<task>` | 단일 멤버 |
+| NestJS API 단독 | `nestjs-backend:<task>` | 단일 멤버 |
+| Prisma 스키마 | `prisma-data:<task>` | 단일 멤버 |
+| CMS 페이지 | `nextjs-cms:<task>` | 독립 멤버, 다른 스택과 병렬 가능 |
+| 풀스택 피처 (DB→API→앱) | `prisma-data:스키마,nestjs-backend:API,flutter-ui:UI` | 의존 순서 — sequential merge |
+| 백엔드 + 프론트 동시 | `nestjs-backend:<task>,flutter-ui:<task>` | 병렬 — squash merge |
+| 코드 리뷰 3종 | `code-reviewer:diff 리뷰,security-auditor:취약점,spec-verifier:스펙 정합성` | 병렬 — 결과만 보면 됨 |
+| 보안 감사 | `security-auditor:<scope>` | 단일 멤버 |
+| 테스트 작성 | `test-writer:<scope>` | 단일 멤버 |
+| 빌드 에러 자동 해결 | `build-error-resolver:<error 출력>` | 단일 멤버 + loop-operator |
+| 데드코드 정리 | `refactor-cleaner:<scope>` | 단일 멤버 |
+| 문서 동기화 | `doc-updater:<scope>` | 단일 멤버 |
+| 풀 사이클 (구현→리뷰→문서) | 위의 조합. 단계별로 forge-team create n번 또는 멀티 멤버 한 팀 | sequential 권장 |
+
+**agentId 는 `agents/` 디렉토리의 에이전트 정의를 참조** — 각 에이전트의 system prompt
+가 그 멤버의 역할을 정한다. 예: `flutter-ui` 멤버는 자기 worktree 에서 Flutter UI
+구현만 하도록 Claude 가 부팅됨.
 
 # Skill Routing (파일 패턴 → 스킬)
 
@@ -95,7 +168,7 @@
 | `integration_test/**`, `**_e2e_test.dart`, `**_driver.dart` | `flutter-driver-e2e` |
 | `Dockerfile`, `docker-compose.*` | `deployment-patterns` |
 
-> 위 표의 파일 패턴이 매칭되면 **`scripts/skill-injector.sh` 훅이 PreToolUse 단계에서 stdout으로 강제 주입**한다. 매칭된 SKILL.md는 반드시 Read하고 따른다.
+> 위 표의 파일 패턴이 매칭되면 **`scripts/skill-injector.sh` 훅이 PreToolUse 단계에서 stdout으로 강제 주입**한다. 매칭된 SKILL.md는 반드시 Read하고 따른다. 멤버 worktree 안의 Claude 인스턴스에도 동일 룰 적용 — 각 멤버는 같은 .claude/ 를 본다.
 
 # Meta Skills (파일 패턴 무관 — 상황별 호출)
 
@@ -105,7 +178,7 @@
 | `verification-loop` | 구현 완료 시 자동 (build + test + lint + DTO sync + review) |
 | `eval-harness` | `/eval` 실행 또는 품질 평가 필요 시 |
 | `review-checklist` | `/review` 실행 시 (코드 리뷰 3종 체크리스트) |
-| `autonomous-loops` | `loop-operator` 에이전트 작동 시 (자율 수정 루프) |
+| `autonomous-loops` | `loop-operator` 멤버 작동 시 (자율 수정 루프) |
 | `continuous-learning-v2` | 세션 종료 / `/learn` / `/evolve` |
 | `search-first` | 새 코드 작성 전 — 기존 패턴/유틸 먼저 검색 |
 | `strategic-compact` | 컨텍스트가 80% 넘어가면 / PreCompact 훅 |
@@ -117,6 +190,7 @@
 |--------|---------|------|
 | `SessionStart` | `mcp-health.sh` | MCP 서버 헬스체크 (지수 백오프) |
 | `SessionStart` | `auto-profile.sh` | 브랜치 기반 훅 프로파일 자동 감지 (prd/stg=strict, feat=standard, explore=minimal) |
+| `PreToolUse` Agent\|Task | (인라인) | **서브에이전트 사용 차단 + forge-team 안내** |
 | `PreToolUse` Bash | (인라인) | 위험 명령 차단(`rm -rf`/`reset --hard`/`--force`/`--no-verify`) + 시크릿 차단 + Conventional Commits + 한국어 subject + Co-Author 차단 + `-A`/`-am` 한 방 커밋 차단 |
 | `PreToolUse` Bash | `tmux-dev.sh` | dev 서버 → tmux 세션 자동 전환 |
 | `PreToolUse` Write/Edit | (인라인) | `.g.dart`/`.freezed.dart`/`prisma/migrations/` 직접 수정 차단 |
@@ -135,16 +209,31 @@
 
 ---
 
-# 자동 파이프라인 (항상 MAX — TDD + 풀 체인)
+# 자동 파이프라인 (메인 세션 흐름)
 
 ```
-PLAN → SCHEMA → BACKEND → FRONTEND → CMS → TEST → SYNC → REVIEW
+유저 요청
+  ↓
+1. 분석 (메인 세션) — 어떤 스택, 어떤 멤버, 의존성 순서
+  ↓
+2. forge-team create (Bash 호출) — 워크트리 + tmux 세션 + Claude 멤버 spawn
+  ↓
+3. 멤버들이 자기 worktree 에서 작업 (병렬 또는 순차)
+   - 각 멤버는 자기 system prompt 따라 작업
+   - 같은 .claude/ 를 봐서 룰/스킬 일관 적용
+  ↓
+4. 작업 완료 모니터링 (GUI 또는 forge-team list)
+  ↓
+5. forge-team merge — 멤버 브랜치 → 베이스 브랜치
+  ↓
+6. /verify + /review (메인 세션이 직접 호출 가능 — 전체 작업 검증)
+  ↓
+7. /update-docs + /checkpoint
+  ↓
+8. "커밋할까요?" (이것만 유저에게 묻는다)
 ```
 
-**병렬 가능**: 리뷰 3종 동시, 독립 스택 동시, `nextjs-cms` 독립.
-**순서 필수**: prisma → nestjs → flutter DTO, 구현 → 검증 → 리뷰.
-
-상세 플로우 / 파견 규칙 / 체이닝 패턴 → [`rules/common/orchestration.md`](.claude/rules/common/orchestration.md)
+상세 플로우 / 의존성 / 체이닝 패턴 → [`rules/common/orchestration.md`](.claude/rules/common/orchestration.md)
 
 # 유저에게 묻는 것 (이것만)
 
@@ -201,7 +290,7 @@ PLAN → SCHEMA → BACKEND → FRONTEND → CMS → TEST → SYNC → REVIEW
 
 | 주제 | 파일 |
 |------|------|
-| Orchestration 전체 (파견 규칙, 체이닝, 병렬, 검증, TDD) | [`rules/common/orchestration.md`](.claude/rules/common/orchestration.md) |
+| Orchestration 전체 (forge-team 호출 패턴, 체이닝, 병렬, 검증, TDD) | [`rules/common/orchestration.md`](.claude/rules/common/orchestration.md) |
 | Hook/훅 프로파일/continuous learning/checkpoint/verification loop | [`rules/common/automation.md`](.claude/rules/common/automation.md) |
 | MCP 서버 목록 + 활용 규칙 | [`rules/common/mcp.md`](.claude/rules/common/mcp.md) |
 | 아키텍처 + 디렉터리 레이아웃 | [`rules/common/architecture.md`](.claude/rules/common/architecture.md) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { useLibraryStore } from './stores/library'
 import { subscribeToMainErrors } from './stores/errorLog'
 
 import { Shell } from './components/v2/Shell'
+import { LiveTerminalsRoot } from './components/v2/LiveTerminalsRoot'
+import { useLiveTerminalsStore } from './stores/liveTerminals'
 import { WorkspaceV2 } from './components/v2/WorkspaceV2'
 import { Library } from './components/v2/Library'
 import { SettingsFull } from './components/v2/SettingsFull'
@@ -313,7 +315,12 @@ export default function App() {
   // ── Run + palette wiring ────────────────────────────────────────
   const onSwitchWorkspace = (id: string) => {
     const ws = workspaces.find((w) => w.id === id)
-    if (ws) setActiveWorkspace(ws)
+    if (ws) {
+      // Tear down live terminals from the previous workspace so we don't
+      // keep dangling PTYs attached to teams the user can't see anymore.
+      useLiveTerminalsStore.getState().clear()
+      setActiveWorkspace(ws)
+    }
   }
 
   const onNewRun = () => {
@@ -579,7 +586,7 @@ export default function App() {
   }
 
   return (
-    <>
+    <LiveTerminalsRoot>
       <Shell
         workspace={activeSummary}
         workspaces={workspaceSummaries}
@@ -767,6 +774,6 @@ export default function App() {
           }}
         />
       )}
-    </>
+    </LiveTerminalsRoot>
   )
 }

--- a/src/components/v2/LiveTerminalGrid.tsx
+++ b/src/components/v2/LiveTerminalGrid.tsx
@@ -1,95 +1,26 @@
-// LiveTerminalGrid — real PTY-backed grid for RunLiveView.
+// LiveTerminalGrid — pure layout host for the App-level XTerminal pool.
 //
-// Each grid cell mounts (via portal) an `<XTerminal agent={...}>` instance bound
-// to the member's tmux pane. The xterm instance lives in a stable host element
-// keyed by `agentName`, so it survives layout transitions:
-//   normal grid (Nx M)  ↔  focus mode (1 expanded + thumbnails)  ↔  fullscreen
-// Without this portal pattern each layout reshape would tear down + respawn the
-// PTY (reattaching to tmux every time, losing scrollback, etc.).
+// The registry (and the actual <XTerminal> mounts) live in <LiveTerminalsRoot>
+// at the App level. This grid only:
+//   1. Provides the pane layout (grid / focus / fullscreen)
+//   2. Registers a slot DOM element per visible agent key
+//   3. Lets the registry adopt the persistent host into that slot
 //
-// Fallback path: members without `tmuxPaneId` (shared worktree, tmux missing)
-// or in `queued` state render the design's "fake terminal lines" cycling — same
-// look the live view shipped with before real PTY landed.
+// Why: previously the grid owned its own registry, so navigating away from
+// RunLiveView tore down every PTY. Now the host elements outlive grid mounts.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { Icon } from './icons'
 import { AgentBadge, Dot, STATE_COLOR, STATE_LABEL } from './primitives'
 import { AGENT_BY_ID } from './data'
-import { XTerminal } from './XTerminal'
+import { useTerminalsRegistry, type LiveTerminalsRegistry } from './LiveTerminalsRoot'
 import type { TeamMember, TerminalLine } from './types'
 
-// ─── Slot registry (stable host per agentName) ─────────────────────
-
-type ElMap = Map<string, HTMLDivElement>
-
-interface SlotRegistry {
-  setSlot(key: string, el: HTMLDivElement | null): void
-  getOrCreateHost(key: string): HTMLDivElement
-  pruneHosts(activeKeys: ReadonlySet<string>): void
-  reattachAll(): void
-  subscribe(listener: () => void): () => void
-}
-
-function createSlotRegistry(): SlotRegistry {
-  const slots: ElMap = new Map()
-  const hosts: ElMap = new Map()
-  const listeners = new Set<() => void>()
-  const notify = () => listeners.forEach((l) => l())
-
-  const reattach = (key: string) => {
-    const slot = slots.get(key)
-    const host = hosts.get(key)
-    if (!slot || !host) return
-    if (host.parentElement !== slot) slot.appendChild(host)
-  }
-
-  return {
-    setSlot(key, el) {
-      if (el) {
-        slots.set(key, el)
-        reattach(key)
-        notify()
-      } else if (slots.has(key)) {
-        slots.delete(key)
-        notify()
-      }
-    },
-    getOrCreateHost(key) {
-      let host = hosts.get(key)
-      if (!host) {
-        host = document.createElement('div')
-        host.style.height = '100%'
-        host.style.width = '100%'
-        hosts.set(key, host)
-      }
-      return host
-    },
-    pruneHosts(activeKeys) {
-      for (const k of Array.from(hosts.keys())) {
-        if (!activeKeys.has(k)) {
-          hosts.get(k)?.remove()
-          hosts.delete(k)
-        }
-      }
-    },
-    reattachAll() {
-      for (const k of slots.keys()) reattach(k)
-    },
-    subscribe(listener) {
-      listeners.add(listener)
-      return () => {
-        listeners.delete(listener)
-      }
-    },
-  }
-}
-
-// ─── Cell slot (adopts the persistent host element) ────────────────
+// ─── Cell slot (adopts the persistent host element from the App registry) ─
 
 interface CellSlotProps {
   agentKey: string
-  registry: SlotRegistry
+  registry: LiveTerminalsRegistry
 }
 
 function CellSlot({ agentKey, registry }: CellSlotProps) {
@@ -374,18 +305,16 @@ export interface LiveTerminalGridProps {
 
 export function LiveTerminalGrid({
   members,
-  teamId,
+  teamId: _teamId,
   tick,
   selectedAgentId,
   onSelect,
   terminalLines,
 }: LiveTerminalGridProps) {
-  // Stable registry across re-renders.
-  const registryRef = useRef<SlotRegistry | null>(null)
-  if (!registryRef.current) registryRef.current = createSlotRegistry()
-  const registry = registryRef.current
+  // Registry lives at App level — see LiveTerminalsRoot. We just register slots.
+  const registry = useTerminalsRegistry()
 
-  // Force re-render when slots change so portals reattach.
+  // Force re-render when slots change so the layout re-runs slot ref attachment.
   const [, force] = useState(0)
   useEffect(() => registry.subscribe(() => force((n) => n + 1)), [registry])
 
@@ -423,27 +352,6 @@ export function LiveTerminalGrid({
     window.addEventListener('forge:agent-fullscreen', onAgentFullscreen)
     return () => window.removeEventListener('forge:agent-fullscreen', onAgentFullscreen)
   }, [members])
-
-  // Members eligible for real PTY (have tmuxPaneId AND not in queued state).
-  const liveAgentKeys = useMemo(() => {
-    const keys = new Set<string>()
-    for (const m of members) {
-      if (m.tmuxPaneId && m.state !== 'queued') {
-        keys.add(m.name ?? m.agentId)
-      }
-    }
-    return keys
-  }, [members])
-
-  // Prune hosts for agents that vanish (member removed) or lose tmuxPaneId.
-  // Deps narrow to the actual triggers — without these, the effect runs every
-  // render and reattachAll() can fire during reconciliation, which together
-  // with the registry's force-render subscribe creates a render loop that
-  // surfaces as React error #310.
-  useEffect(() => {
-    registry.pruneHosts(liveAgentKeys)
-    registry.reattachAll()
-  }, [liveAgentKeys, registry])
 
   const layout = useMemo(() => {
     const n = members.length
@@ -575,28 +483,9 @@ export function LiveTerminalGrid({
     )
   }
 
-  // ── Persistent xterm portals (one per live agent) ────────────────
-  // Rendered alongside the layout so each XTerminal component retains its
-  // mount across grid → focus → fullscreen transitions. The host is the
-  // adoption target; its current parent is whichever CellSlot last claimed it.
-  const portals = members
-    .filter((m) => m.tmuxPaneId && m.state !== 'queued')
-    .map((m) => {
-      const agentKey = m.name ?? m.agentId
-      const host = registry.getOrCreateHost(agentKey)
-      return createPortal(
-        <XTerminal
-          tabId={`team-${teamId}`}
-          paneId={`agent-${agentKey}`}
-          cwd=""
-          isActive
-          agent={{ teamId, agentName: agentKey }}
-        />,
-        host,
-        agentKey,
-      )
-    })
-
+  // <XTerminal> mounts now live in <LiveTerminalsRoot> at the App level —
+  // they survive this grid's mount/unmount cycle, which is how navigating
+  // away from RunLiveView and back keeps the same PTY + scrollback.
   return (
     <div
       style={{
@@ -607,7 +496,6 @@ export function LiveTerminalGrid({
       }}
     >
       {layoutNode}
-      {portals}
     </div>
   )
 }

--- a/src/components/v2/LiveTerminalsRoot.tsx
+++ b/src/components/v2/LiveTerminalsRoot.tsx
@@ -1,0 +1,206 @@
+// LiveTerminalsRoot — App-level mount point for every team member's <XTerminal>.
+//
+// LiveTerminalGrid used to own both the SlotRegistry AND the XTerminal mounts.
+// That meant unmounting the grid (e.g. user navigates Library → Run) tore down
+// every PTY: tmux-attach killed, scrollback gone, and a fresh attach fired off
+// when the user returned. From the user's perspective: "터미널이 날아간다."
+//
+// Lifting the registry + the actual <XTerminal> instances up to App keeps every
+// active member's terminal alive for the lifetime of the team session. The grid
+// becomes a pure layout/slot host: each cell registers an HTMLElement via
+// `useTerminalsRegistry()`, and the registry adopts the persistent host element
+// (which holds the live xterm) into that slot via DOM appendChild.
+//
+// Lifecycle contract
+//   • RunLiveView calls `useLiveTerminalsStore.setActiveTeam({ teamId, members })`
+//     on mount and whenever `team.members` changes. Same teamId reuses hosts
+//     (no PTY churn). Different teamId tears down the previous team's hosts.
+//   • Workspace swap calls `clear()` so we don't keep stale terminals alive
+//     when the user is no longer in the originating workspace.
+//   • LiveTerminalGrid's CellSlot calls `register(key, slotEl)` on mount and
+//     `register(key, null)` on unmount. The registry only keeps host DOM nodes
+//     for keys present in the active team's members.
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { useLiveTerminalsStore, type LiveMemberRef } from '@/stores/liveTerminals'
+import { XTerminal } from './XTerminal'
+
+// ─── Registry primitive (DOM-level reparenting) ──────────────────────
+
+type ElMap = Map<string, HTMLDivElement>
+
+export interface LiveTerminalsRegistry {
+  /** Register or unregister a slot DOM element for an agent key. */
+  setSlot(key: string, el: HTMLDivElement | null): void
+  /** Get (or lazily create) the persistent host element for an agent key. */
+  getOrCreateHost(key: string): HTMLDivElement
+  /** Subscribe to slot/host changes — used to force a re-render so portals reattach. */
+  subscribe(listener: () => void): () => void
+}
+
+interface InternalRegistry extends LiveTerminalsRegistry {
+  pruneHosts(activeKeys: ReadonlySet<string>): void
+  reattachAll(): void
+}
+
+function createRegistry(): InternalRegistry {
+  const slots: ElMap = new Map()
+  const hosts: ElMap = new Map()
+  const listeners = new Set<() => void>()
+  const notify = () => listeners.forEach((l) => l())
+
+  const reattach = (key: string) => {
+    const slot = slots.get(key)
+    const host = hosts.get(key)
+    if (!slot || !host) return
+    if (host.parentElement !== slot) slot.appendChild(host)
+  }
+
+  return {
+    setSlot(key, el) {
+      if (el) {
+        slots.set(key, el)
+        reattach(key)
+      } else if (slots.has(key)) {
+        slots.delete(key)
+      }
+      notify()
+    },
+    getOrCreateHost(key) {
+      let host = hosts.get(key)
+      if (!host) {
+        host = document.createElement('div')
+        host.style.height = '100%'
+        host.style.width = '100%'
+        hosts.set(key, host)
+      }
+      return host
+    },
+    pruneHosts(activeKeys) {
+      for (const k of Array.from(hosts.keys())) {
+        if (!activeKeys.has(k)) {
+          hosts.get(k)?.remove()
+          hosts.delete(k)
+        }
+      }
+    },
+    reattachAll() {
+      for (const k of slots.keys()) reattach(k)
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}
+
+// ─── Context wiring ──────────────────────────────────────────────────
+
+const RegistryContext = createContext<LiveTerminalsRegistry | null>(null)
+
+export function useTerminalsRegistry(): LiveTerminalsRegistry {
+  const reg = useContext(RegistryContext)
+  if (!reg) {
+    throw new Error('useTerminalsRegistry must be used inside <LiveTerminalsRoot>')
+  }
+  return reg
+}
+
+// ─── Root component ──────────────────────────────────────────────────
+
+interface LiveTerminalsRootProps {
+  children: ReactNode
+}
+
+/**
+ * Mount this once at the App root, around the rest of the v2 chrome.
+ * It owns:
+ *   1. A persistent registry (lives across all navigation inside this Root)
+ *   2. A hidden div that hosts every active member's <XTerminal>
+ *   3. createPortal targets — the host elements are reparented into grid
+ *      slots when LiveTerminalGrid mounts, then released back to the hidden
+ *      home when the slot unmounts.
+ */
+export function LiveTerminalsRoot({ children }: LiveTerminalsRootProps) {
+  const registryRef = useRef<InternalRegistry | null>(null)
+  if (!registryRef.current) registryRef.current = createRegistry()
+  const registry = registryRef.current
+
+  // Force re-render when slots change so portals re-mount their host parents
+  // (no actual remount happens — just the bookkeeping that triggers reattach).
+  const [, force] = useState(0)
+  useEffect(() => registry.subscribe(() => force((n) => n + 1)), [registry])
+
+  const active = useLiveTerminalsStore((s) => s.active)
+
+  // Live keys — only these get a mounted XTerminal portal. Members without a
+  // tmuxPaneId or in 'queued' state fall back to the grid's FakeBody renderer.
+  const liveMembers = useMemo<LiveMemberRef[]>(() => {
+    if (!active) return []
+    return active.members.filter((m) => m.tmuxPaneId && m.state !== 'queued')
+  }, [active])
+
+  const liveKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const m of liveMembers) keys.add(m.name ?? m.agentId)
+    return keys
+  }, [liveMembers])
+
+  // Drop hosts for members no longer present (team change, member removed),
+  // and reattach surviving hosts whenever the slot map changes.
+  useEffect(() => {
+    registry.pruneHosts(liveKeys)
+    registry.reattachAll()
+  }, [liveKeys, registry])
+
+  const teamId = active?.teamId ?? ''
+
+  return (
+    <RegistryContext.Provider value={registry}>
+      {children}
+      {/* Hidden home for unparented hosts. Visibility hidden + zero-size
+          keeps xterm WebGL/canvas alive without affecting layout. Hosts are
+          reparented into LiveTerminalGrid CellSlot DOM elements when active. */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: 0,
+          height: 0,
+          overflow: 'hidden',
+          visibility: 'hidden',
+          pointerEvents: 'none',
+        }}
+      >
+        {liveMembers.map((m) => {
+          const key = m.name ?? m.agentId
+          const host = registry.getOrCreateHost(key)
+          return createPortal(
+            <XTerminal
+              tabId={`team-${teamId}`}
+              paneId={`agent-${key}`}
+              cwd=""
+              isActive
+              agent={{ teamId, agentName: key }}
+            />,
+            host,
+            key,
+          )
+        })}
+      </div>
+    </RegistryContext.Provider>
+  )
+}

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -22,6 +22,7 @@ import { AGENT_BY_ID, TERMINAL_LINES } from './data'
 import type { Team, TeamMember, ActivityItem, MemberState, TerminalLine } from './types'
 import { MergeConflictView, type ConflictItem } from './MergeConflictView'
 import { LiveTerminalGrid } from './LiveTerminalGrid'
+import { useLiveTerminalsStore } from '@/stores/liveTerminals'
 import {
   useTeamActivityStore,
   type ActivityEntry as RealActivityEntry,
@@ -77,6 +78,22 @@ export function RunLiveView({
   // Local paused fallback for the design demo (when no real backend status).
   const [localPaused, setLocalPaused] = useState(false)
   const paused = team.status === 'paused' || localPaused
+
+  // Push the active team into LiveTerminalsRoot so XTerminal mounts survive
+  // navigation away from this view. Same teamId reuses existing hosts; a
+  // different teamId tears down the previous team's PTYs.
+  const setActiveTeam = useLiveTerminalsStore((s) => s.setActiveTeam)
+  useEffect(() => {
+    setActiveTeam({
+      teamId: team.id,
+      members: team.members.map((m) => ({
+        agentId: m.agentId,
+        name: m.name,
+        tmuxPaneId: m.tmuxPaneId,
+        state: m.state,
+      })),
+    })
+  }, [team.id, team.members, setActiveTeam])
 
   // Transient inline notice (success / warn) for IPC-triggered actions.
   const [notice, setNotice] = useState<{

--- a/src/stores/liveTerminals.ts
+++ b/src/stores/liveTerminals.ts
@@ -1,0 +1,55 @@
+// liveTerminals — global active-team registry for App-level XTerminal lifetime.
+//
+// Why this exists: previously LiveTerminalGrid owned the SlotRegistry + portal
+// hosts internally, so navigating away from RunLiveView (Library / Dashboard /
+// other workspace) tore down every <XTerminal>, killed each tmux-attach PTY,
+// and lost scrollback on return.
+//
+// This store lifts the "which team's members should currently have live PTYs"
+// decision up to App, where LiveTerminalsRoot can keep the XTerminal mounts
+// alive across navigation. The grid only registers slots — it never owns the
+// terminals.
+
+import { create } from 'zustand'
+
+/**
+ * Structural subset of the v2 TeamMember shape — only the fields
+ * LiveTerminalsRoot actually needs to decide whether to mount an XTerminal.
+ * Decoupled from `@/types` so renderer and v2 chrome can both push into
+ * this store without converting between TeamMember shapes.
+ */
+export interface LiveMemberRef {
+  agentId: string
+  name?: string
+  tmuxPaneId?: string
+  /** v2 MemberState string; we only care about 'queued' to skip mounting. */
+  state?: string
+}
+
+export interface ActiveLiveTeam {
+  teamId: string
+  /** Snapshot of members eligible for live PTY at the time of registration. */
+  members: LiveMemberRef[]
+}
+
+interface LiveTerminalsState {
+  active: ActiveLiveTeam | null
+  /**
+   * Set/replace the currently focused team. Calling with the same teamId
+   * reuses existing host elements (members array drives current PTY set).
+   * Calling with a different teamId tears down the old team's terminals.
+   */
+  setActiveTeam(team: ActiveLiveTeam | null): void
+  /** Clear all live terminals — used on workspace swap or app shutdown. */
+  clear(): void
+}
+
+export const useLiveTerminalsStore = create<LiveTerminalsState>((set) => ({
+  active: null,
+  setActiveTeam(team) {
+    set({ active: team })
+  },
+  clear() {
+    set({ active: null })
+  },
+}))

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,7 +9,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "electron"]
+  "include": ["vite.config.ts", "electron", "bin/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

사용자 정책에 따라 메인 Claude Code 세션의 병렬 실행 메커니즘을 **서브에이전트 (Agent/Task 도구)** 에서 **Forge Team (격리 worktree + tmux + 별 Claude 인스턴스)** 로 전환.

### Architecture changes

- **`forge-team` CLI** — 메인 세션이 호출할 헤드리스 팀 관리자 (create/list/merge/pause/resume/remove). 의존성 추가 0.
- **`TeamOperations.ts`** 순수 모듈로 분리 — Watcher 와 CLI 가 같은 코드 공유. AgentTeamWatcher 1076 → 398 LOC.
- **서브에이전트 차단** — settings.json permissions.deny + PreToolUse 훅. CLAUDE.md / orchestration.md / agent-team.md 재작성.

### Bug fixes

- **다른 화면 갔다 와도 터미널 안 날아감** — XTerminal 풀을 App 레벨 (LiveTerminalsRoot) 로 lift. RunLiveView unmount 가 PTY kill 안 함.

## Test plan

- [x] `npm run typecheck` 통과
- [x] `bin/forge-team list --workspace .` 작동
- [x] `bin/forge-team create + list + remove` 풀 라이프사이클 테스트 통과 (워커 보고)
- [ ] 다른 화면 갔다와도 터미널 유지되는지 GUI 수동 테스트
- [ ] 메인 세션에서 `Agent` 도구 호출 시 차단 메시지 표시 + exit 2

closes #(없음 — 정책 변경)