### PR TITLE
fix(v0.6.1): React 'Rendered more hooks' 핫픽스 + dev API stub 인프라

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ build/*.iconset/
 resources/bundled-tools/darwin-arm64/bin/
 resources/bundled-tools/darwin-arm64/python/
 resources/bundled-tools/darwin-arm64/cr-graph-venv/
-resources/bundled-tools/darwin-arm64/.download-stamp.json
+resources/bundled-tools/darwin-arm64/.download-stamp.json.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.6.1] — 2026-05-08
+
+### Fixed — Playwright 동적 검수에서 발견된 React 결함 3개
+
+#### React "Rendered more hooks than during the previous render" (App.tsx)
+boot 흐름:
+1. activeWorkspace 가 null 인 첫 렌더 → `if (!activeSummary) return ...` 가
+   line 389 에서 early return → useAgentTeamStore (line 552) 까지 도달 안 함
+   → 26 hooks
+2. workspace 가 채워진 다음 렌더 → return 안 됨 → 27 hooks
+3. React 가 hook order 불일치 감지 → ErrorBoundary 잡힘
+
+0.5.x 에선 부팅 시 workspace 항상 있어서 발현 안 됐을 뿐. dev API stub 으로
+처음 발견. fix: realTeams/runs hook 을 early return 위로 hoist —
+hook order 안정화.
+
+#### DashboardPanelWired `undefined.length`
+`harnessInfo?.agents.length` 패턴이 `harnessInfo` 는 객체이지만 `agents`
+필드가 undefined 일 때 throw. 백엔드가 부분 응답을 보내거나 dev stub 이
+필드를 빠뜨리면 발생. fix: `harnessInfo?.agents?.length` 등 defensive
+optional chaining 으로 바꿈 (5 fields).
+
+#### GitPanelWired 진입 시 `undefined.filter`
+status 가 객체이지만 staged/unstaged/untracked 필드가 undefined 일 때
+filter 호출에서 throw. dev stub 이 status shape 을 누락한 게 원인 — 실제
+backend 는 항상 채움. fix: dev stub 의 git.status 가 staged/unstaged/
+untracked/ahead/behind 모두 빈 값으로 반환하도록 보강.
+
+### Added — dev API stub 인프라
+
+`src/devApiStub.ts` (NEW) — Vite dev / Playwright / chromium MCP 환경에서
+앱이 부팅하도록 `window.api.*` 을 채우는 stub. Electron production 에선
+preload 가 먼저 채우므로 무동작.
+
+main.tsx 가 `import.meta.env.DEV` 일 때만 conditional import. Promise
+returning 메서드는 빈 데이터로 resolve, subscribe 류는 noop unsubscribe.
+누락된 메서드는 logging proxy 가 첫 호출 시 한번만 warn 출력.
+
+이 인프라 덕에 다음 라운드부터:
+- `npm run dev` + chromium MCP 로 모든 화면 routing/onClick 검증 가능
+- React invariant 위반 (#310, "more hooks", 등) 부팅 흐름에서 발견 가능
+
 ## [0.6.0] — 2026-05-08
 
 ### Architecture — Forge Team only (서브에이전트 폐지)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -385,6 +385,25 @@ export default function App() {
     }
   }
 
+  // Real teams from the watcher, scoped to the active workspace.
+  // No seed fallback — empty workspace gets an empty Teams section, not fake
+  // "회원가입 피처팀" cards. Lying to the user is worse than an empty list.
+  // NOTE: hoisted ABOVE the early-return below so React's hook order stays
+  // stable whether or not a workspace is active. Otherwise the workspace-
+  // empty boot path returns 26 hooks and the post-boot path returns 27,
+  // tripping "Rendered more hooks than during the previous render".
+  const realTeams = useAgentTeamStore((s) => s.teams)
+  const runs = useMemo<V2Team[]>(() => {
+    return realTeams
+      .filter((t) => !t.workspaceId || t.workspaceId === activeWorkspace?.id)
+      .map(toV2Team)
+  }, [realTeams, activeWorkspace])
+
+  const harnessUpdateAvailable =
+    installedHarnessVersion &&
+    bundledHarnessVersion &&
+    installedHarnessVersion !== bundledHarnessVersion
+
   // ── Render ──────────────────────────────────────────────────────
   if (!activeSummary) {
     const recentList = [...workspaces].sort((a, b) => {
@@ -540,21 +559,6 @@ export default function App() {
       </div>
     )
   }
-
-  const harnessUpdateAvailable =
-    installedHarnessVersion &&
-    bundledHarnessVersion &&
-    installedHarnessVersion !== bundledHarnessVersion
-
-  // Real teams from the watcher, scoped to the active workspace.
-  // No seed fallback — empty workspace gets an empty Teams section, not fake
-  // \"회원가입 피처팀\" cards. Lying to the user is worse than an empty list.
-  const realTeams = useAgentTeamStore((s) => s.teams)
-  const runs = useMemo<V2Team[]>(() => {
-    return realTeams
-      .filter((t) => !t.workspaceId || t.workspaceId === activeWorkspace?.id)
-      .map(toV2Team)
-  }, [realTeams, activeWorkspace])
 
   // Map current view → main content
   let main: React.ReactNode

--- a/src/components/v2/wired/DashboardPanelWired.tsx
+++ b/src/components/v2/wired/DashboardPanelWired.tsx
@@ -154,11 +154,13 @@ export function DashboardPanelWired({ onCmdK }: DashboardPanelWiredProps) {
 
   // Graceful defaults for missing data — a freshly-opened workspace whose
   // scan hasn't completed yet, or a workspace without `.claude/` at all.
-  const agents = harnessInfo?.agents.length ?? 0
-  const skills = harnessInfo?.skills.length ?? 0
-  const commands = harnessInfo?.commands.length ?? 0
-  const scripts = harnessInfo?.scripts.length ?? 0
-  const rules = harnessInfo?.rules.length ?? 0
+  // Defensive optional chaining — backend may push partial info during the
+  // first scan tick, and the dev stub may omit fields entirely.
+  const agents = harnessInfo?.agents?.length ?? 0
+  const skills = harnessInfo?.skills?.length ?? 0
+  const commands = harnessInfo?.commands?.length ?? 0
+  const scripts = harnessInfo?.scripts?.length ?? 0
+  const rules = harnessInfo?.rules?.length ?? 0
   const hooks = harnessInfo
     ? Object.values(harnessInfo.hooks).reduce((a, b) => a + b, 0)
     : 0

--- a/src/devApiStub.ts
+++ b/src/devApiStub.ts
@@ -1,0 +1,188 @@
+// Dev-only stub for window.api so the app can boot in a plain browser
+// (Vite dev server, Playwright/chromium MCP) without an Electron preload.
+//
+// In production (packaged Electron) the real preload runs first and populates
+// window.api with IPC-backed implementations — this stub never installs.
+//
+// Stubs are intentionally noisy:
+//   - Promise-returning methods resolve to neutral empty values (`null`, `[]`,
+//     `''`, etc.) so callers that ignore errors render their empty/loading state.
+//   - Subscriptions return a no-op unsubscribe so cleanup is safe.
+//   - Anything we forgot is logged once via the proxy fallback so the next
+//     run of the dev test points to it.
+//
+// This is a pure side-effect import; main.tsx wires it conditionally.
+
+type AnyFn = (...args: unknown[]) => unknown
+
+const noopUnsub = () => () => {}
+const resolveNull = () => Promise.resolve(null)
+const resolveEmptyArr = () => Promise.resolve([])
+const resolveEmptyStr = () => Promise.resolve('')
+const resolveOk = () => Promise.resolve({ ok: true })
+
+/**
+ * Wrap a namespace object with a Proxy that returns a logging no-op for any
+ * accessed method we didn't explicitly stub. Keeps the surface small while
+ * preventing `Cannot read properties of undefined (reading 'foo')` crashes.
+ */
+function loggingProxy<T extends Record<string, unknown>>(name: string, base: T): T {
+  return new Proxy(base, {
+    get(target, prop: string) {
+      if (prop in target) return (target as Record<string, unknown>)[prop]
+      const path = `${name}.${String(prop)}`
+      // Return a noop function. Logging is one-shot per access path so the
+      // console doesn't get flooded under a tight render loop.
+      let warned = false
+      return (..._args: unknown[]) => {
+        if (!warned) {
+          // eslint-disable-next-line no-console
+          console.warn(`[devApiStub] ${path}() called — returning noop`)
+          warned = true
+        }
+        return Promise.resolve(null)
+      }
+    },
+  }) as T
+}
+
+export function installDevApiStub(): void {
+  if (typeof window === 'undefined') return
+  if ((window as { api?: unknown }).api) return // real preload already loaded
+
+  const stub = {
+    pty: loggingProxy('pty', {
+      create: (() => Promise.resolve('dev-pty-0')) as AnyFn,
+      write: (() => {}) as AnyFn,
+      resize: (() => {}) as AnyFn,
+      dispose: (() => {}) as AnyFn,
+      getCwd: resolveEmptyStr as AnyFn,
+      onData: noopUnsub as AnyFn,
+      onExit: noopUnsub as AnyFn,
+    }),
+    workspace: loggingProxy('workspace', {
+      // Provide one fake workspace so the main UI renders. Real Electron
+      // pushes the persisted workspace list here; in dev we just need
+      // *something* to satisfy the boot path.
+      list: (() =>
+        Promise.resolve([
+          {
+            id: 'dev-ws',
+            name: 'Dev Workspace',
+            path: '/tmp/forge-dev-workspace',
+            createdAt: Date.now(),
+            lastOpened: Date.now(),
+            harnessApplied: true,
+          },
+        ])) as AnyFn,
+      open: (() =>
+        Promise.resolve({
+          id: 'dev-ws',
+          name: 'Dev Workspace',
+          path: '/tmp/forge-dev-workspace',
+          createdAt: Date.now(),
+          lastOpened: Date.now(),
+          harnessApplied: true,
+        })) as AnyFn,
+      create: (() =>
+        Promise.resolve({
+          id: 'dev-ws',
+          name: 'Dev Workspace',
+          path: '/tmp/forge-dev-workspace',
+          createdAt: Date.now(),
+          lastOpened: Date.now(),
+          harnessApplied: true,
+        })) as AnyFn,
+      remove: (() => Promise.resolve()) as AnyFn,
+      getTemplatePath: resolveEmptyStr as AnyFn,
+      getClaudeMdPath: resolveEmptyStr as AnyFn,
+      setActive: (() => Promise.resolve()) as AnyFn,
+    }),
+    harness: loggingProxy('harness', {
+      scan: (() =>
+        Promise.resolve({
+          scripts: [],
+          rules: [],
+          skills: [],
+          agents: [],
+          commands: [],
+          hooks: {},
+        })) as AnyFn,
+      readFile: resolveEmptyStr as AnyFn,
+      getMcpStatus: resolveEmptyArr as AnyFn,
+      getBundledVersion: resolveEmptyStr as AnyFn,
+      getInstalledVersion: resolveNull as AnyFn,
+      update: resolveOk as AnyFn,
+      lint: (() =>
+        Promise.resolve({ errors: [], warnings: [], info: [], checkedAt: new Date().toISOString() })) as AnyFn,
+      previewUpdate: (() =>
+        Promise.resolve({ added: [], removed: [], modified: [], unchanged: 0 })) as AnyFn,
+      previewSessionContext: (() =>
+        Promise.resolve({ sections: [], totalChars: 0, tokenEstimate: 0 })) as AnyFn,
+      listAgents: resolveEmptyArr as AnyFn,
+      listSkills: resolveEmptyArr as AnyFn,
+      listCommands: resolveEmptyArr as AnyFn,
+      listHooks: resolveEmptyArr as AnyFn,
+      listCompositions: resolveEmptyArr as AnyFn,
+    }),
+    teams: loggingProxy('teams', {
+      list: resolveEmptyArr as AnyFn,
+      create: (() =>
+        Promise.resolve({ teamId: 'dev-team-0', configPath: '', worktreesCreated: 0, tmuxSessionsStarted: 0 })) as AnyFn,
+      remove: (() => Promise.resolve()) as AnyFn,
+      pause: resolveOk as AnyFn,
+      resume: resolveOk as AnyFn,
+      pauseMember: resolveOk as AnyFn,
+      resumeMember: resolveOk as AnyFn,
+      merge: (() => Promise.resolve({ ok: true, mergedBranch: 'main' })) as AnyFn,
+      openAgentTerminal: (() => Promise.resolve('dev-pty-1')) as AnyFn,
+      subscribe: noopUnsub as AnyFn,
+      onUpdate: noopUnsub as AnyFn,
+    }),
+    git: loggingProxy('git', {
+      status: (() =>
+        Promise.resolve({
+          branch: 'main',
+          clean: true,
+          staged: [],
+          unstaged: [],
+          untracked: [],
+          ahead: 0,
+          behind: 0,
+        })) as AnyFn,
+      branches: resolveEmptyArr as AnyFn,
+      log: resolveEmptyArr as AnyFn,
+      diff: resolveEmptyStr as AnyFn,
+    }),
+    files: loggingProxy('files', {
+      list: resolveEmptyArr as AnyFn,
+      read: resolveEmptyStr as AnyFn,
+      write: (() => Promise.resolve()) as AnyFn,
+    }),
+    system: loggingProxy('system', {
+      openExternal: (() => Promise.resolve()) as AnyFn,
+      showItemInFolder: (() => Promise.resolve()) as AnyFn,
+    }),
+    crGraph: loggingProxy('crGraph', {
+      build: resolveOk as AnyFn,
+      query: resolveEmptyArr as AnyFn,
+      isAvailable: (() => Promise.resolve(false)) as AnyFn,
+    }),
+    teamActivity: loggingProxy('teamActivity', {
+      list: resolveEmptyArr as AnyFn,
+      onEvent: noopUnsub as AnyFn,
+    }),
+    resource: loggingProxy('resource', {
+      snapshot: (() => Promise.resolve({ cpu: 0, mem: 0, disk: 0, ptyCount: 0 })) as AnyFn,
+    }),
+    onMainError: noopUnsub as AnyFn,
+    // Generic main-process event channel. App.tsx subscribes to 'action',
+    // 'workspace-opened', 'navigate' here. Stub returns a no-op unsubscribe.
+    on: ((_event: string, _cb: AnyFn) => () => {}) as AnyFn,
+    off: ((_event: string, _cb: AnyFn) => {}) as AnyFn,
+  }
+
+  ;(window as unknown as { api: typeof stub }).api = stub
+  // eslint-disable-next-line no-console
+  console.info('[devApiStub] installed — all window.api.* return neutral values')
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,16 @@ import './styles/globals.css'
 // Initialize i18n side-effect import (registers resources + chosen language).
 import './i18n'
 
+// Browser/dev-only: when there's no Electron preload, install a stub so the
+// app boots and routes can be tested with Playwright/chromium MCP. Real
+// preload (production Forge.app) populates window.api first, so the stub
+// becomes a no-op there.
+if (import.meta.env.DEV) {
+  // Top-level await is fine in Vite — this resolves before render.
+  const { installDevApiStub } = await import('./devApiStub')
+  installDevApiStub()
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>


### PR DESCRIPTION
## Summary

Playwright/chromium MCP 로 동적 검수 가능하게 만들고, 그 과정에서 발견된 React 결함 3개 핫픽스.

### 발견된 결함

1. **App.tsx — React 'Rendered more hooks than during the previous render'** — early return 후 useAgentTeamStore 호출 → hook 26 vs 27. ErrorBoundary 가 앱 잡아먹음. 0.5.x 에서도 잠재 결함이었지만 boot 시 workspace 항상 있어 발현 안 됐을 뿐.
2. **DashboardPanelWired undefined.length** — `harnessInfo?.agents.length` 가 agents 가 undefined 일 때 throw.
3. **GitPanelWired undefined.filter** — stub 누락 (실제 backend 는 OK, dev 환경만 영향).

### 추가

- **dev API stub 인프라** (`src/devApiStub.ts`) — Vite dev/Playwright/chromium MCP 부팅 가능. Electron production 영향 0.

## Test plan

- [x] typecheck
- [x] Vite dev + chromium MCP 로 5개 sidebar 탭 (Workspace/Git/Dashboard/Library/Settings) 모두 console error 0 확인
- [ ] DMG 빌드 후 실제 Forge.app 에서 화면 이동 확인