### PR TITLE
fix(v0.6.2): 화면 이동 시 터미널 진짜 유지 — host home reparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.6.2] — 2026-05-08
+
+### Fixed — 화면 이동 시 터미널 진짜로 유지
+
+0.6.0 의 LiveTerminalsRoot lift 가 충분하지 않았다. 사용자 보고: "여전히 다른
+화면 갔다오면 터미널 초기화됨".
+
+#### 진짜 원인
+
+`CellSlot` 이 unmount 되면 `setSlot(key, null)` 만 호출하고 host 는 grid
+cell DOM 안에 그대로 남았음. 그 직후 React 가 grid cell DOM 을 tear down
+하면 host 도 함께 detach 되고, host 안의 xterm/PTY 도 사라짐.
+
+다음 mount 시 `hosts.get(key)` 는 같은 element 를 반환하지만 그 element 는
+이미 destroy 된 grid cell 의 잔재 — 비어있는 컨테이너. → 사용자에겐
+"초기화" 로 보임.
+
+#### 수정
+
+- `LiveTerminalsRegistry.setHomeElement(el)` API 추가 — `LiveTerminalsRoot`
+  의 hidden div ref 를 registry 에 등록.
+- `setSlot(key, null)` 호출 시 `sendHome(key)` 자동 실행 — host 를 home
+  으로 미리 reparent. **grid cell tear-down 시 host 가 따라 사라지지 않음**.
+- `getOrCreateHost(key)` 새 host 생성 시 home 에 즉시 부착 — React portal
+  이 처음부터 DOM 에 valid parent 를 가짐.
+- home div 사이즈 0×0 → 800×600 + off-screen `top:-99999px` — xterm
+  fitAddon 이 cols=0/rows=0 으로 망가지는 부수 결함 차단. opacity:0 +
+  pointer-events:none 으로 숨김 유지.
+
+#### 검증
+
+dev 서버 + chromium MCP 로 host lifecycle 직접 확인:
+- `setActiveTeam(...)` 호출 후 home div 안에 host 1개 + xterm 렌더링 정상
+- 코드 경로: setSlot(key, null) → sendHome → home.appendChild(host) → grid
+  cell tear-down 영향 0
+
 ## [0.6.1] — 2026-05-08
 
 ### Fixed — Playwright 동적 검수에서 발견된 React 결함 3개

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/components/v2/LiveTerminalsRoot.tsx
+++ b/src/components/v2/LiveTerminalsRoot.tsx
@@ -50,6 +50,7 @@ export interface LiveTerminalsRegistry {
 interface InternalRegistry extends LiveTerminalsRegistry {
   pruneHosts(activeKeys: ReadonlySet<string>): void
   reattachAll(): void
+  setHomeElement(el: HTMLDivElement | null): void
 }
 
 function createRegistry(): InternalRegistry {
@@ -58,11 +59,29 @@ function createRegistry(): InternalRegistry {
   const listeners = new Set<() => void>()
   const notify = () => listeners.forEach((l) => l())
 
+  /**
+   * Persistent off-screen home for hosts that aren't currently adopted by a
+   * grid cell. Set by LiveTerminalsRoot via the hidden div ref. Hosts MUST
+   * land here on cell unmount — otherwise the React-managed grid cell DOM
+   * carries the host (and its xterm children) down with it on tear-down,
+   * which is the exact "터미널이 초기화" symptom users hit when navigating
+   * away from RunLiveView and back.
+   */
+  let homeElement: HTMLDivElement | null = null
+
   const reattach = (key: string) => {
     const slot = slots.get(key)
     const host = hosts.get(key)
     if (!slot || !host) return
     if (host.parentElement !== slot) slot.appendChild(host)
+  }
+
+  const sendHome = (key: string) => {
+    const host = hosts.get(key)
+    if (!host) return
+    if (homeElement && host.parentElement !== homeElement) {
+      homeElement.appendChild(host)
+    }
   }
 
   return {
@@ -72,6 +91,11 @@ function createRegistry(): InternalRegistry {
         reattach(key)
       } else if (slots.has(key)) {
         slots.delete(key)
+        // CRITICAL: park the host back at home before the cell DOM is torn
+        // down. Without this, the host follows the unmounting grid cell into
+        // detachment, the xterm renderer goes with it, and the next mount
+        // sees an empty container — exactly the regression we're fixing.
+        sendHome(key)
       }
       notify()
     },
@@ -82,6 +106,9 @@ function createRegistry(): InternalRegistry {
         host.style.height = '100%'
         host.style.width = '100%'
         hosts.set(key, host)
+        // New hosts also start at home so the React portal has a valid
+        // parent to render into before any slot adopts them.
+        if (homeElement) homeElement.appendChild(host)
       }
       return host
     },
@@ -95,6 +122,18 @@ function createRegistry(): InternalRegistry {
     },
     reattachAll() {
       for (const k of slots.keys()) reattach(k)
+    },
+    setHomeElement(el) {
+      homeElement = el
+      // When the home becomes available (first mount), pull every orphan
+      // host that isn't currently in a slot back to the home node.
+      if (el) {
+        for (const [k, host] of hosts) {
+          if (!slots.has(k)) {
+            if (host.parentElement !== el) el.appendChild(host)
+          }
+        }
+      }
     },
     subscribe(listener) {
       listeners.add(listener)
@@ -137,6 +176,14 @@ export function LiveTerminalsRoot({ children }: LiveTerminalsRootProps) {
   if (!registryRef.current) registryRef.current = createRegistry()
   const registry = registryRef.current
 
+  // Hidden home div ref — registry parks unattached hosts here so they
+  // don't ride a destroyed grid cell DOM into oblivion.
+  const homeRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    registry.setHomeElement(homeRef.current)
+    return () => registry.setHomeElement(null)
+  }, [registry])
+
   // Force re-render when slots change so portals re-mount their host parents
   // (no actual remount happens — just the bookkeeping that triggers reattach).
   const [, force] = useState(0)
@@ -169,20 +216,23 @@ export function LiveTerminalsRoot({ children }: LiveTerminalsRootProps) {
   return (
     <RegistryContext.Provider value={registry}>
       {children}
-      {/* Hidden home for unparented hosts. Visibility hidden + zero-size
-          keeps xterm WebGL/canvas alive without affecting layout. Hosts are
-          reparented into LiveTerminalGrid CellSlot DOM elements when active. */}
+      {/* Hidden home for unparented hosts. Off-screen but with real size so
+          xterm.js + fitAddon don't compute cols/rows = 0 while parked here.
+          Hosts are reparented into LiveTerminalGrid CellSlot DOM when active,
+          then sent back here on cell unmount (so a tear-down grid doesn't
+          drag the host into detachment). */}
       <div
+        ref={homeRef}
         aria-hidden="true"
         style={{
           position: 'fixed',
-          top: 0,
-          left: 0,
-          width: 0,
-          height: 0,
+          top: '-99999px',
+          left: '-99999px',
+          width: 800,
+          height: 600,
           overflow: 'hidden',
-          visibility: 'hidden',
           pointerEvents: 'none',
+          opacity: 0,
         }}
       >
         {liveMembers.map((m) => {


### PR DESCRIPTION
## Summary

0.6.0 의 LiveTerminalsRoot lift 만으로 부족했다. 사용자 보고: "여전히 다른 화면 갔다오면 터미널 초기화됨".

진짜 원인: CellSlot unmount → setSlot(key, null) → host 는 grid cell DOM 안에 잔류 → React tear-down 이 grid cell 과 함께 host + xterm 모두 detach.

수정: setSlot(null) 시 host 를 hidden home div 으로 미리 reparent. setHomeElement API 추가. home size 0→800x600 off-screen (xterm fitAddon cols=0 결함도 차단).

## Test plan

- [x] typecheck
- [x] dev 서버 + chromium MCP — home div 안에 host + xterm 렌더링 정상 확인
- [ ] 실제 DMG 에서 화면 이동 후 터미널 유지 확인 (사용자)