### PR TITLE
fix(v0.6.3): claude 화면 이동 시 종료 — PTY ownership 분리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to Forge Studio are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [0.6.3] — 2026-05-08
+
+### Fixed — claude 프로세스가 화면 이동 시 죽던 진짜 원인
+
+사용자 보고: "다른 화면 갔다오면 클로드가 꺼져있고 그냥 터미널만 보임".
+v0.6.0~0.6.2 의 portal lift / host home reparent 까지 했는데도 여전.
+
+#### 진짜 원인
+
+XTerminal 의 두 코드 path 가 PTY dispose 를 호출:
+1. **useEffect cleanup** — React 의 어떤 lifecycle (StrictMode double-mount,
+   concurrent rendering, transient detach/reattach) 에서든 fire 가능.
+2. **init 안의 disposed race** — pty.create 가 await 인 동안 cleanup 이
+   먼저 실행되면 disposed=true 로 들어감. 그 후 ptyId 가 도착해서 `if
+   (disposed) { pty.dispose(ptyId) }` 분기 진입.
+
+두 path 어느 쪽이든 fire 되면 main process 가 PTY master 를 close →
+slave (tmux pane) 에 SIGHUP → pane 안의 claude 프로세스가 종료.
+
+UI 상으로는 터미널 컨테이너 (xterm 인스턴스) 는 살아있고 (lift 작동) 새 attach 가
+일어나지만, 안의 claude 는 이미 죽음 → 사용자 눈엔 "터미널만 있고 클로드는
+꺼진" 상태로 보임.
+
+#### 수정 — PTY ownership 을 lifecycle 에서 host pruning 으로 이동
+
+PTY 라이프사이클을 React 컴포넌트의 mount/unmount 에 묶지 않고
+LiveTerminalsRoot 의 host pruning 에 위임:
+
+- `XTerminal` cleanup 에서 `pty.dispose()` 호출 제거 — 컴포넌트 unmount
+  와 PTY 종료를 분리.
+- init 의 `if (disposed)` race 분기에서도 `pty.dispose()` 호출 제거. 대신
+  `onPtyCreated` 콜백으로 ptyId 를 부모에게 전달 (race 이후라도) — 부모가
+  추적 후 host prune 시 정리.
+- `LiveTerminalsRegistry`:
+  - `setHostPtyId(key, ptyId)` API 추가 — XTerminal 의 onPtyCreated 가
+    여기로 보고.
+  - `pruneHosts(activeKeys)` 가 활성 키에서 빠진 host 를 제거할 때 해당
+    `ptyId` 만 명시적으로 `pty.dispose()` 호출.
+  - `disposeAllPtys()` API — 윈도우 close 시 일괄 정리 (main process 의
+    ptyManager.disposeAll 과 별개의 안전망).
+
+이제 PTY 는:
+- 멤버가 active team 에서 사라질 때 (팀 swap, 멤버 제거) → host 와 함께 dispose
+- 워크스페이스 swap → store.clear() → 모든 host prune → 모든 PTY dispose
+- .app 종료 → main 의 ptyManager.disposeAll
+
+화면 이동 / React 사이클 / StrictMode 어느 것도 PTY 못 건드림.
+
+#### Verified
+
+dev 서버 + chromium MCP 로 PTY dispose 호출 카운트:
+- setActiveTeam('A') → 0번 호출 (이전엔 1번) ✅
+- setActiveTeam('A') 재호출 → 0번 ✅
+- setActiveTeam('B') (팀 swap) → 1번 (host A 만 정리) ✅
+
 ## [0.6.2] — 2026-05-08
 
 ### Fixed — 화면 이동 시 터미널 진짜로 유지

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/components/v2/LiveTerminalsRoot.tsx
+++ b/src/components/v2/LiveTerminalsRoot.tsx
@@ -43,6 +43,11 @@ export interface LiveTerminalsRegistry {
   setSlot(key: string, el: HTMLDivElement | null): void
   /** Get (or lazily create) the persistent host element for an agent key. */
   getOrCreateHost(key: string): HTMLDivElement
+  /** Record the PTY id that the XTerminal at `key` is currently attached to.
+   *  Owned by the registry so that pruneHosts() can dispose it cleanly when
+   *  the corresponding member is no longer active. XTerminal must NOT call
+   *  pty.dispose() in its own effect cleanup (see comment there). */
+  setHostPtyId(key: string, ptyId: string | null): void
   /** Subscribe to slot/host changes — used to force a re-render so portals reattach. */
   subscribe(listener: () => void): () => void
 }
@@ -51,10 +56,16 @@ interface InternalRegistry extends LiveTerminalsRegistry {
   pruneHosts(activeKeys: ReadonlySet<string>): void
   reattachAll(): void
   setHomeElement(el: HTMLDivElement | null): void
+  disposeAllPtys(): void
 }
 
 function createRegistry(): InternalRegistry {
   const slots: ElMap = new Map()
+  // host key → most recently reported PTY id, captured via XTerminal's
+  // onPtyCreated callback. We dispose this when the host is pruned — it's
+  // the ONLY place a PTY should be torn down for an agent terminal. See
+  // XTerminal cleanup comment for why component unmount can NOT own dispose.
+  const hostPtyIds: Map<string, string> = new Map()
   const hosts: ElMap = new Map()
   const listeners = new Set<() => void>()
   const notify = () => listeners.forEach((l) => l())
@@ -115,9 +126,31 @@ function createRegistry(): InternalRegistry {
     pruneHosts(activeKeys) {
       for (const k of Array.from(hosts.keys())) {
         if (!activeKeys.has(k)) {
+          // Dispose the PTY first — once we drop the host, no one will
+          // reattach to it, so the underlying tmux session must be torn down
+          // here rather than leaked. This is also the ONLY place we dispose
+          // an agent PTY (XTerminal cleanup intentionally skips dispose).
+          const ptyId = hostPtyIds.get(k)
+          if (ptyId) {
+            window.api?.pty?.dispose?.(ptyId)
+            hostPtyIds.delete(k)
+          }
           hosts.get(k)?.remove()
           hosts.delete(k)
         }
+      }
+    },
+    disposeAllPtys() {
+      for (const [k, ptyId] of hostPtyIds) {
+        window.api?.pty?.dispose?.(ptyId)
+        hostPtyIds.delete(k)
+      }
+    },
+    setHostPtyId(key, ptyId) {
+      if (ptyId == null) {
+        hostPtyIds.delete(key)
+      } else {
+        hostPtyIds.set(key, ptyId)
       }
     },
     reattachAll() {
@@ -245,6 +278,7 @@ export function LiveTerminalsRoot({ children }: LiveTerminalsRootProps) {
               cwd=""
               isActive
               agent={{ teamId, agentName: key }}
+              onPtyCreated={(ptyId) => registry.setHostPtyId(key, ptyId)}
             />,
             host,
             key,

--- a/src/components/v2/XTerminal.tsx
+++ b/src/components/v2/XTerminal.tsx
@@ -155,9 +155,15 @@ export function XTerminal({ tabId, paneId, cwd, isActive, searchVisible, agent, 
         return
       }
 
-      // Bail if disposed during async PTY creation
+      // Bail if disposed during async PTY creation. We dispose the renderer
+      // but NOT the PTY — same ownership policy as the cleanup return below:
+      // if this is an agent terminal, LiveTerminalsRoot owns dispose via
+      // host pruning, so we hand the ptyId off via onPtyCreated even when
+      // bailing. Without this, a StrictMode double-mount or transient
+      // unmount would call pty.dispose() and SIGHUP the agent's claude
+      // process — exactly the regression we're guarding against.
       if (disposed || !ptyId) {
-        if (ptyId) window.api.pty.dispose(ptyId)
+        if (ptyId) onPtyCreatedRef.current?.(ptyId)
         terminal.dispose()
         return
       }
@@ -224,6 +230,20 @@ export function XTerminal({ tabId, paneId, cwd, isActive, searchVisible, agent, 
     init()
 
     return () => {
+      // PTY ownership policy:
+      //   We DO NOT call pty.dispose() here on every effect cleanup. When
+      //   <XTerminal> lives inside <LiveTerminalsRoot>'s persistent portal
+      //   pool, this cleanup can fire on transient React lifecycle events
+      //   (StrictMode double-mount, concurrent rendering, even brief
+      //   detach/reattach during reparenting). Disposing the PTY there sends
+      //   SIGHUP to the tmux pane and kills the agent's `claude` process —
+      //   exactly the regression users hit ("다른 화면 갔다오면 클로드가 꺼짐").
+      //
+      //   The PTY is owned by the App-level pool: LiveTerminalsRoot disposes
+      //   it when a host is pruned (member removed, team swap) or when the
+      //   window closes (main process ptyManager.disposeAll on window-all-
+      //   closed). For shell tabs (no agent), the parent UI already owns the
+      //   tab lifecycle and explicitly disposes via the terminals store.
       disposed = true
       cleanupData?.()
       cleanupExit?.()
@@ -231,12 +251,15 @@ export function XTerminal({ tabId, paneId, cwd, isActive, searchVisible, agent, 
       if (terminal) {
         ;(terminal as unknown as { __detachWheel?: () => void }).__detachWheel?.()
       }
-      if (ptyId) window.api.pty.dispose(ptyId)
+      // Only dispose the renderer (xterm canvas/WebGL). The PTY survives.
       if (terminal) terminal.dispose()
       terminalRef.current = null
       fitAddonRef.current = null
       searchAddonRef.current = null
-      ptyIdRef.current = null
+      // Keep ptyIdRef populated so a re-mount can re-attach to the same PTY
+      // if the parent component (LiveTerminalsRoot via portal) hands us back
+      // the same agent binding. Today XTerminal always creates a fresh PTY
+      // on mount; a follow-up can wire the pool to reuse ptyId on re-mount.
     }
   }, [cwd, tabId, paneId])
 


### PR DESCRIPTION
## Summary

사용자 보고 \"다른 화면 갔다오면 클로드가 꺼지고 터미널만 보임\" — v0.6.0~0.6.2 까지 portal lift / host reparent 다 했는데 여전.

## 진짜 원인

XTerminal 의 두 path 가 PTY dispose 호출:
1. **useEffect cleanup** — StrictMode / concurrent / transient reattach 어느 React lifecycle 에서든 fire 가능
2. **init 의 disposed race** — pty.create await 동안 cleanup 이 먼저 → disposed=true → ptyId 도착 시 dispose 분기

둘 다 main 의 PTY master close → tmux slave 에 SIGHUP → pane 안 claude 종료. Lift 가 작동해도 PTY 자체가 죽음.

## Fix

PTY ownership 을 React 컴포넌트에서 host pruning 으로 이동:
- XTerminal 의 두 dispose path 모두 제거. onPtyCreated 콜백으로만 ptyId 전달.
- LiveTerminalsRegistry 가 ptyId 추적 + host prune 시 명시적 dispose.
- 멤버가 active 에서 빠질 때만 PTY 정리. 화면 이동 / React 사이클 영향 0.

## Verified

dev 서버 + chromium MCP 로 dispose 호출 카운트:
- activate(A): 0 (이전 1)
- reactivate same: 0
- swap(A→B): 1 (host A 만 정리)