### PR TITLE
feat(v0.6.6): worktree fix + inbox UI + bypass mode 모델 분기

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Forge Studio v2 — Project CLAUDE.md
+
+이 프로젝트는 **Forge Studio** — Claude Code 를 데스크톱 앱으로 감싼 Electron + React + Vite 프로젝트.
+
+## 다음 세션이 반드시 먼저 읽을 것
+
+**[docs/roadmap-v0.6.6-v0.8.md](docs/roadmap-v0.6.6-v0.8.md)** —
+컨텍스트 클리어 이후 작업 이어가는 기준 문서. 현재 단계, 막힌 이슈, 단계별
+plan, 모델 매핑, Council 메커니즘, 빌드 명령 모두 정리.
+
+## 현재 상태 (요약)
+
+- **버전**: v0.6.5 빌드 완료, 사용자 검증 대기 중
+- **다음 작업**: v0.6.6 — worktree 생성 fix (baseBranch 네이밍 변경) + inbox UI
+- **이후 milestone**: v0.7.0 (Council + ProviderRouter), v0.8.0 (Sprint Manager UI)
+
+## 절대 정책
+
+- **서브에이전트 (`Agent` / `Task` 도구) 사용 금지** — `permissions.deny` + PreToolUse 훅 차단됨
+- 모든 위임은 **`forge-team` CLI** 로만 (격리 worktree + tmux + 별 Claude 인스턴스)
+- 커밋 메시지 **한국어 필수** (subject 에 한글 1자 이상). Co-Author trailer 금지. `git add -A` / `-am` 한 방 커밋 금지
+- 위 룰들 PreToolUse 훅이 자동 차단
+
+## 빠른 참조
+
+| 항목 | 위치 |
+|---|---|
+| 다음 단계 plan | `docs/roadmap-v0.6.6-v0.8.md` |
+| 메인 세션 ROLE | `resources/harness-template/CLAUDE.md` |
+| forge-team CLI | `bin/forge-team` + `bin/forge-team.ts` |
+| 팀 라이프사이클 (순수) | `electron/services/TeamOperations.ts` |
+| App 레벨 PTY pool | `src/components/v2/LiveTerminalsRoot.tsx` |
+| 활성 팀 store | `src/stores/liveTerminals.ts` |
+| 빌드 명령 | `npm run release:dmg` |
+
+## 사용자 호출 패턴
+
+```bash
+# 현재 빌드 띄우기
+pkill -f "Forge Studio" ; sleep 1
+xattr -cr "/Applications/Forge Studio.app" 2>/dev/null
+open "release/mac-arm64/Forge Studio.app"
+```
+
+## 메모
+
+- 사용자 GitHub: mstagon
+- 릴리즈 시 `gh auth switch -u mstagon` 필요
+- Apple Developer ID 없음 (ad-hoc codesign) — 사용자가 quarantine 우회 필요

--- a/docs/roadmap-v0.6.6-v0.8.md
+++ b/docs/roadmap-v0.6.6-v0.8.md
@@ -1,0 +1,298 @@
+# Forge Studio Roadmap v0.6.6 → v0.8.0
+
+> 다음 세션이 컨텍스트 클리어 후에도 이어가도록 영구 저장 문서.
+> 이 파일은 항상 최신 상태로 유지하고, 작업 진행에 따라 업데이트한다.
+
+## 0. 사용자 정책 (절대 변경 금지)
+
+- 서브에이전트 (`Agent` / `Task` 도구) **사용 금지**. v0.6.0 의 `permissions.deny` + PreToolUse 훅이 차단.
+- 모든 위임은 **Forge Team** 으로만 — 격리 worktree + tmux session + 별 Claude 인스턴스.
+- 메인 세션의 호출 인터페이스는 `forge-team` CLI (`bin/forge-team` 또는 `Forge.app/Contents/Resources/forge-cli/bin/forge-team`).
+
+## 1. 현재 상태 (v0.6.5 기준 — 빌드 완료, 사용자 검증 대기 중)
+
+### 작동 중인 것
+- LiveTerminalsRoot (App 레벨 portal pool)
+- forge-team CLI (create / list / pause / resume / merge / remove)
+- TeamOperations.ts 순수 모듈
+- React `Rendered more hooks` fix
+- agent PTY cache (teams:openAgentTerminal)
+- WorkspaceV2 항상 mount + display 토글
+
+### 미해결 / 절반만 구현
+- **worktree 생성 실패** — `team/<id>` baseBranch 와 `team/<id>/<agent>` 멤버 브랜치 git refs 디렉토리 hierarchy 충돌. silent fallback to shared 모드 → 모든 멤버 같은 root 에서 작업 → 메인 세션이 위험 감지하고 멈춤. **사용자가 즉시 막힌 이슈**.
+- **inbox 백엔드만 구현** — `<teamDir>/inboxes/<member>.json` 읽기, `messageCount`/`unreadCount` 필드 다 있음. **send IPC 없음, UI 없음**.
+- **Sprint 분배 메커니즘 없음** — planner agent 가 자유 텍스트로 plan, 표준 output 형식 없음, 자동 dependency 분석 없음.
+- **Council (다모델 토론) 없음** — Opus + GPT 동시 활용 메커니즘 부재.
+- **ProviderRouter 없음** — 멤버에 model 명시 + provider 별 CLI 분기 없음.
+
+## 2. 사용자 요구사항 정리
+
+### 채팅앱 만들기 시나리오 (이상적 플로우)
+1. **Plan**: planner 가 phase + dependency graph 출력
+2. **TDD**: test-writer 가 실패 테스트 먼저
+3. **Phase 별 sequential** spawn — 안의 멤버는 병렬 (worktree 격리)
+4. **충돌 방지**: 같은 파일 건드릴 가능성 있는 작업은 자동 sequential 변환
+5. **소통**: inbox 메시지 + shared status 보드
+6. **검증**: merge → /verify (build + test + lint) → 충돌 시 loop-operator
+
+### 모델 활용 (사용자 의견)
+- **Opus 4.7**: 큰 그림, creative, 긴 reasoning
+- **GPT-5.5**: blast radius / 영향 분석 / 형식적 검증 / 세부 디테일
+
+### Council (CCC 토론) 적용
+- Plan / Tech-architect / Code review / Merge conflict resolution
+
+## 3. 모델 매핑 표 (에이전트별)
+
+| 에이전트 | 모델 | 이유 |
+|---|---|---|
+| `planner` | Opus | phase 분해 + creative |
+| `tech-architect` | **Council** (Opus+GPT) | 큰 결정 trade-off 다양 |
+| `flutter-ui` | Opus | UI = creative |
+| `riverpod-logic` | Opus | state 설계 |
+| `nestjs-backend` | Opus | API 구현 |
+| `prisma-data` | **GPT** | 스키마/FK/인덱스 정확성 |
+| `code-reviewer` | **Council** | 다른 시각 가치 |
+| `security-auditor` | **GPT** | OWASP 형식적 |
+| `spec-verifier` | **GPT** | 영향 분석 |
+| `test-writer` | Opus | TDD creative |
+| `refactor-cleaner` | **GPT** | blast radius |
+| `doc-updater` | Opus | 자연어 |
+| `build-error-resolver` | Opus | reasoning chain |
+| `loop-operator` | Opus | 반복 reasoning |
+
+## 4. CCC 토론 메커니즘 설계
+
+### Round 구조
+```
+Round 1: 각 모델 독립 제안
+Round 2: 상호 비판 + 보완 (상대 제안 본 후)
+Round 3: 합의안 또는 escalate (사용자 결정 요청)
+```
+
+### 적용 지점 4개
+1. **Plan phase** — planner Council. Opus 가 phase 분해, GPT 가 영향 분석/edge case
+2. **Tech-architect** — 아키텍처 결정 (DB, 인증, 상태관리 등)
+3. **Code review 3종** — code-reviewer/security-auditor/spec-verifier 모델 다양화
+4. **Merge conflict resolution** — 두 모델이 각자 strategy 제안
+
+### 데이터 흐름 (inbox 활용)
+- 멤버 A 의 inbox = 자기 의견
+- 멤버 B 의 inbox = 자기 의견
+- Round 마다 서로 inbox 읽기 + 추가 메시지
+- 합의 시 final inbox entry 출력 (메인 세션이 읽고 적용)
+
+## 5. config.json 확장 안
+
+```json
+{
+  "members": [
+    { "agentId": "planner", "model": "opus-4.7", "task": "..." },
+    { "agentId": "spec-verifier", "model": "gpt-5.5", "task": "..." }
+  ],
+  "council": {
+    "phases": ["plan", "review"],
+    "rounds": 3,
+    "consensus": "manual"
+  }
+}
+```
+
+## 6. 단계별 plan
+
+### v0.6.6 (즉시 — 사용자 막힌 거 풀기)
+
+#### A. worktree 생성 fix
+**파일**: `electron/services/TeamOperations.ts`
+
+baseBranch 네이밍 변경:
+- 현재: `team/<teamId>` (충돌)
+- 신규: `team/<teamId>-base` (refs 디렉토리 hierarchy 충돌 해소)
+
+멤버 브랜치는 그대로 `team/<teamId>/<agentId>`. baseBranch 만 `-base` suffix.
+
+create + merge 로직에서 baseBranch 참조하는 모든 곳 수정. resolveBaseBranch / ensureBranch / merge 의 checkout / branch 정리 path.
+
+#### B. inbox sendMessage IPC + 간단 UI
+**파일**:
+- `electron/main.ts`: `teams:sendMessage(teamId, fromAgent, toAgent, text)` IPC handler 추가
+- `electron/services/TeamOperations.ts`: `sendInboxMessage(teamId, fromAgent, toAgent, text)` 메서드
+- `electron/preload.ts`: `window.api.teams.sendMessage` 노출
+- `src/components/v2/RunLiveView.tsx`: 멤버 카드 클릭 → 사이드 패널 (inbox list + send box)
+- `src/stores/agentTeam.ts`: `sendMessage` action
+
+inbox JSON 포맷 (이미 존재):
+```json
+{ "from": "planner", "text": "...", "summary": "...", "timestamp": "ISO", "color": "#...", "read": false }
+```
+
+#### C. 멤버 config 에 model 필드 (조용한 추가)
+**파일**: `electron/services/TeamOperations.ts` RawMember + Wizard
+- model 필드 추가 (선택, 기본값 `claude-opus-4-7`)
+- 사용은 v0.7.0 부터, 일단 저장만
+
+### v0.7.0 (Council + ProviderRouter)
+
+#### A. ProviderRouter
+**파일**: `electron/services/ProviderRouter.ts` (NEW)
+- model 패턴 → CLI 명령 매핑:
+  - `opus-*` / `claude-*` → `claude` (Anthropic)
+  - `gpt-*` / `o1-*` → `codex` (OpenAI, plugins 에 이미 있음)
+- TeamOperations.create 가 멤버 spawn 시 ProviderRouter 통해 적절한 CLI 실행
+
+#### B. planner Council 메커니즘
+**파일**: `electron/services/CouncilOrchestrator.ts` (NEW)
+- 두 멤버 (Opus planner + GPT planner) spawn
+- inbox round-robin: Round 1 propose → Round 2 critique → Round 3 consensus
+- 결과 plan.json 출력 (phase + dependencies)
+
+#### C. forge-team plan / execute CLI
+**파일**: `bin/forge-team.ts`
+```bash
+forge-team plan --workspace . --goal "채팅앱"
+# → plan.json (phases, dependencies, members)
+
+forge-team execute --plan plan.json
+# → 의존성 순서로 forge-team create 자동 호출
+# → 각 phase 완료 대기 → forge-team merge → next phase
+```
+
+### v0.7.1 (Code review Council)
+
+3종 리뷰에 모델 다양화:
+- code-reviewer (Opus) + security-auditor (GPT) + spec-verifier (GPT) 병렬 spawn
+- 충돌 의견 시 추가 round (Council escalation)
+- 결과 합의 안 되면 사용자에게 표시
+
+### v0.8.0 (UI 통합)
+
+#### A. Sprint Manager 탭
+- 새 sidebar view (Sprint)
+- 현재 plan 의 phase 진행률
+- 각 phase 의 멤버 status
+- merge 한 번에 (sequential)
+
+#### B. RunLiveView Discussion 탭
+- 멤버 옆 "Discussion" 탭
+- Council round 별 메시지 리스트
+- 합의/escalate 상태
+
+#### C. Wizard "Council mode" 토글
+- 팀 생성 시 Council 적용 여부
+- 적용할 phase 선택 (plan / review)
+
+#### D. 멤버 카드 model 배지
+- Opus 또는 GPT 배지 표시
+- composition 미리보기에 model 정보
+
+#### E. 자동 dependency 분석
+- planner 결과의 expected_files 추적
+- 같은 파일 건드릴 멤버 자동 sequential 변환
+- 충돌 가능성 시 사용자에게 경고
+
+## 7. 메인 세션 호출 패턴 (이미 작동 중)
+
+```
+유저: "채팅앱 만들어줘"
+  ↓
+메인 세션 (Claude Code, Opus):
+  1. (v0.7.0+) Bash(forge-team plan --goal "채팅앱") → plan.json
+  2. (v0.7.0+) Bash(forge-team execute --plan plan.json)
+  또는 (v0.6.x):
+  1. Bash(forge-team create --members "prisma-data:Message+Room 스키마")
+  2. forge-team list 폴링 → 완료 대기
+  3. Bash(forge-team merge --team-id <id>)
+  4. 다음 phase 반복
+  ↓
+GUI 가 chokidar 로 자동 반영 (~120ms)
+사용자가 RunLiveView 에서 라이브 보기
+```
+
+## 8. 진행 추적 체크리스트
+
+### v0.6.5 (현재 빌드 완료, 검증 대기)
+- [x] WorkspaceV2 mount 보존
+- [ ] 사용자가 새 .app 으로 시나리오 검증 (+ 버튼 → claude → Library → 다시)
+- [ ] 결과 보고 — 통과 / 실패
+
+### v0.6.6 (다음)
+- [ ] baseBranch 네이밍 fix (`team/<id>-base`)
+- [ ] worktree 생성 정상 작동 검증
+- [ ] inbox sendMessage IPC + handler
+- [ ] inbox UI (RunLiveView 멤버 카드 클릭 → 패널)
+- [ ] 멤버 config 에 model 필드 (조용히 추가)
+- [ ] CHANGELOG + tag + DMG + release
+
+### v0.7.0
+- [ ] ProviderRouter
+- [ ] CouncilOrchestrator (planner)
+- [ ] forge-team plan / execute CLI
+- [ ] CHANGELOG + tag + DMG + release
+
+### v0.7.1
+- [ ] Code review 3종 모델 다양화
+- [ ] Council escalation 메커니즘
+
+### v0.8.0
+- [ ] Sprint Manager 탭
+- [ ] Discussion 탭
+- [ ] Wizard Council 토글
+- [ ] 멤버 model 배지
+- [ ] 자동 dependency 분석
+
+## 9. Known issues / 결정사항
+
+### 결정
+- 서브에이전트 사용 금지 (정책)
+- 모든 위임은 forge-team CLI
+- 한국어 커밋 메시지 + Co-Author 금지 (PreToolUse 훅 차단)
+- ad-hoc codesign (Apple Developer ID 없음) — 사용자 quarantine 우회 필요
+
+### Known issues
+- macOS quarantine — 사용자가 새 DMG 받을 때마다 `xattr -cr "/Applications/Forge Studio.app"` 필요
+- forge-team 의 worktree-strategy `isolated` 시 baseBranch 충돌 (v0.6.6 fix)
+- gh CLI release create 시 mstagon 활성 계정 필요 (`gh auth switch -u mstagon`)
+
+## 10. 빠른 참조
+
+### 빌드 + 릴리즈 명령
+```bash
+cd "/Users/macms/Downloads/forge-studiov2-main 2"
+sed -i "" "s/\"version\": \"0.6.X\"/\"version\": \"0.6.Y\"/" package.json
+npm run typecheck
+git checkout -b fix/v0.6.Y-name
+git add ... && git commit -m "fix(...): 한글 메시지"
+git push -u origin fix/v0.6.Y-name
+gh pr create --title "..." --body "..."
+gh pr merge --squash --delete-branch
+git checkout main && git pull origin main
+git tag -a v0.6.Y -m "Release v0.6.Y"
+git push origin v0.6.Y
+npm run release:dmg
+gh auth switch -u mstagon  # 필요 시
+gh release create v0.6.Y --title "..." --notes "..." \
+  "release/Forge Studio-0.6.Y-arm64.dmg" \
+  "release/Forge Studio-0.6.Y-arm64-mac.zip"
+```
+
+### 사용자 .app 띄우기
+```bash
+pkill -f "Forge Studio" ; sleep 1
+xattr -cr "/Applications/Forge Studio.app"
+open "/Users/macms/Downloads/forge-studiov2-main 2/release/mac-arm64/Forge Studio.app"
+```
+
+### 핵심 파일
+- `electron/services/TeamOperations.ts` — 팀 라이프사이클 순수 모듈
+- `electron/services/AgentTeamWatcher.ts` — chokidar + IPC bridge
+- `electron/main.ts` — IPC handlers
+- `bin/forge-team` + `bin/forge-team.ts` — 헤드리스 CLI
+- `src/App.tsx` — view 라우팅 + LiveTerminalsRoot
+- `src/components/v2/LiveTerminalsRoot.tsx` — App 레벨 PTY pool
+- `src/components/v2/LiveTerminalGrid.tsx` — RunLiveView 의 멤버 grid
+- `src/components/v2/TerminalAreaV2.tsx` — shell 터미널 (+ 버튼)
+- `src/stores/liveTerminals.ts` — active team store
+- `src/stores/agentTeam.ts` — teams 데이터
+- `resources/harness-template/CLAUDE.md` — 메인 세션 ROLE 정의
+- `resources/harness-template/.claude/settings.json` — 훅/permissions

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1223,6 +1223,30 @@ ipcMain.handle('teams:openAgentTerminal', (_event, options: { teamId: string; ag
   return id
 })
 
+// ─── IPC Handlers: Inbox (member ↔ member 메시지) ───────────────────
+
+ipcMain.handle('teams:sendMessage', async (_event, opts: { teamId: string; fromAgent: string; toAgent: string; text: string; summary?: string }) => {
+  const ws = workspaceManager.getActive()
+  return agentTeamWatcher.sendInboxMessage(
+    ws?.path ?? null,
+    opts.teamId,
+    opts.fromAgent,
+    opts.toAgent,
+    opts.text,
+    opts.summary,
+  )
+})
+
+ipcMain.handle('teams:readInbox', async (_event, opts: { teamId: string; agentName: string }) => {
+  const ws = workspaceManager.getActive()
+  return agentTeamWatcher.readInbox(ws?.path ?? null, opts.teamId, opts.agentName)
+})
+
+ipcMain.handle('teams:markInboxRead', async (_event, opts: { teamId: string; agentName: string }) => {
+  const ws = workspaceManager.getActive()
+  return agentTeamWatcher.markInboxRead(ws?.path ?? null, opts.teamId, opts.agentName)
+})
+
 // ─── IPC Handlers: Team Activity ────────────────────────────────────
 
 ipcMain.handle('team-activity:list', async (_event, teamId: string, limit?: number) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -408,6 +408,15 @@ const api = {
       conflicts?: { file: string; theirsBranch: string; oursBranch: string; conflictMarkers: string }[]
       error?: string
     }> => ipcRenderer.invoke('teams:merge', teamId, opts),
+    /** Member ↔ member 메시지: 상대 멤버의 inbox 에 entry append. */
+    sendMessage: (opts: { teamId: string; fromAgent: string; toAgent: string; text: string; summary?: string }): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke('teams:sendMessage', opts),
+    /** 멤버의 inbox 읽기 (newest first). */
+    readInbox: (opts: { teamId: string; agentName: string }): Promise<Array<{ from: string; text: string; summary?: string; timestamp: string; read?: boolean }>> =>
+      ipcRenderer.invoke('teams:readInbox', opts),
+    /** 멤버의 inbox 모든 메시지 read 플래그 갱신. */
+    markInboxRead: (opts: { teamId: string; agentName: string }): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke('teams:markInboxRead', opts),
   },
 
   // ─── Team Activity ───────────────────────────────────────────────

--- a/electron/services/AgentTeamWatcher.ts
+++ b/electron/services/AgentTeamWatcher.ts
@@ -375,6 +375,26 @@ export class AgentTeamWatcher extends EventEmitter {
     return this.ops.merge(this.workspacePath, teamId, opts)
   }
 
+  /** Member ↔ member 메시지: 상대 멤버의 inbox 에 entry append. */
+  async sendInboxMessage(
+    workspacePath: string | null,
+    teamId: string,
+    fromAgent: string,
+    toAgent: string,
+    text: string,
+    summary?: string
+  ): Promise<{ ok: boolean; error?: string }> {
+    return this.ops.sendInboxMessage(workspacePath ?? this.workspacePath, teamId, fromAgent, toAgent, text, summary)
+  }
+
+  async readInbox(workspacePath: string | null, teamId: string, agentName: string) {
+    return this.ops.readInbox(workspacePath ?? this.workspacePath, teamId, agentName)
+  }
+
+  async markInboxRead(workspacePath: string | null, teamId: string, agentName: string) {
+    return this.ops.markInboxRead(workspacePath ?? this.workspacePath, teamId, agentName)
+  }
+
   /**
    * Tear down a team:
    *   1. Kill each member tmux session.

--- a/electron/services/TeamOperations.ts
+++ b/electron/services/TeamOperations.ts
@@ -31,6 +31,23 @@ export type MergeStrategy = 'squash' | 'sequential'
 export interface TeamCreateMember {
   agentId: string
   task?: string
+  /**
+   * Provider model id. Routes to the correct CLI on autoStart:
+   *   - claude / opus / sonnet / haiku  →  `claude --dangerously-skip-permissions`
+   *   - gpt / o1 / o3 / codex            →  `codex --dangerously-bypass-approvals-and-sandbox`
+   * Defaults to claude (Anthropic) when omitted.
+   */
+  model?: string
+}
+
+/** Map a model identifier to the bypass-mode launch command. */
+export function modelLaunchCommand(model: string | undefined): string {
+  const m = (model ?? '').toLowerCase()
+  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('codex')) {
+    return 'codex --dangerously-bypass-approvals-and-sandbox'
+  }
+  // Default: claude (opus / sonnet / haiku / claude-* / unspecified).
+  return 'claude --dangerously-skip-permissions'
 }
 
 export interface TeamCreateOptions {
@@ -300,7 +317,13 @@ export class TeamOperations {
     let teamBaseBranch: string | undefined
     if (gitOk && opts.worktreeStrategy === 'isolated') {
       baseBranch = await this.resolveBaseBranch(wsPath)
-      teamBaseBranch = `team/${teamId}`
+      // baseBranch suffix `-base` — git refs hierarchy is filesystem-like and
+      // a branch named `team/<id>` cannot coexist with member branches
+      // `team/<id>/<agent>` (file vs directory clash). Pre-v0.6.6 layouts
+      // hit this and silently fell back to shared mode. The `-base` suffix
+      // keeps the parent dir `team/` clean: `team/<id>-base` is a file,
+      // `team/<id>/` is a directory, both fit under the same parent.
+      teamBaseBranch = `team/${teamId}-base`
       await this.ensureBranch(wsPath, teamBaseBranch, baseBranch)
     } else if (gitOk) {
       baseBranch = await this.resolveBaseBranch(wsPath)
@@ -318,7 +341,10 @@ export class TeamOperations {
         agentId: m.agentId,
         name: m.agentId,
         agentType: m.agentId,
-        model: 'sonnet-4.5',
+        // Honor the caller's model override; default to claude opus for new
+        // members. The autoStart spawner reads this to pick the right CLI
+        // (claude vs codex) with the matching bypass flag.
+        model: m.model ?? 'claude-opus-4-7',
         joinedAt: now + idx,
         task: m.task,
         state: 'active',
@@ -380,7 +406,12 @@ export class TeamOperations {
           }
           if (autoStart) {
             try {
-              await execFileAsync(tmux, ['send-keys', '-t', session, 'claude', 'Enter'], {
+              // bypass-permissions: 멤버는 자율 실행이 정책. 사용자가 매 도구마다
+              // 승인할 수 없으므로 모델별 적절한 bypass flag 로 spawn.
+              // 격리 worktree + isolated tmux session 이라 blast radius 는 멤버 본인
+              // worktree 로 한정됨 (메인 세션 + 다른 멤버 분리).
+              const launchCmd = modelLaunchCommand(member.model)
+              await execFileAsync(tmux, ['send-keys', '-t', session, launchCmd, 'Enter'], {
                 timeout: 4000,
                 env,
               })
@@ -582,6 +613,93 @@ export class TeamOperations {
   }
 
   // ── Merge ────────────────────────────────────────────────────────────
+
+  /**
+   * Append a message to a team member's inbox file. The watcher's
+   * loadInbox/summariseInbox already reads `<teamDir>/inboxes/<member>.json`
+   * — this method just writes new entries that conform to the InboxMessage
+   * shape. Used for inter-member communication (Council, async hand-off).
+   */
+  async sendInboxMessage(
+    workspacePath: string | null,
+    teamId: string,
+    fromAgent: string,
+    toAgent: string,
+    text: string,
+    summary?: string
+  ): Promise<{ ok: boolean; error?: string }> {
+    if (!teamId || !fromAgent || !toAgent || !text) {
+      return { ok: false, error: 'teamId, fromAgent, toAgent, text are required' }
+    }
+    const teamsDir = this.teamsDirFor(workspacePath)
+    const teamDir = path.join(teamsDir, teamId)
+    const inboxDir = path.join(teamDir, 'inboxes')
+    const inboxPath = path.join(inboxDir, `${toAgent}.json`)
+    try {
+      await fs.mkdir(inboxDir, { recursive: true })
+      let existing: unknown[] = []
+      try {
+        const buf = await fs.readFile(inboxPath, 'utf-8')
+        const parsed = JSON.parse(buf)
+        if (Array.isArray(parsed)) existing = parsed
+      } catch {
+        // first message in this inbox — leave existing as []
+      }
+      existing.push({
+        from: fromAgent,
+        text,
+        summary: summary ?? text.slice(0, 120),
+        timestamp: new Date().toISOString(),
+        read: false,
+      })
+      await fs.writeFile(inboxPath, JSON.stringify(existing, null, 2), 'utf-8')
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: (err as Error).message }
+    }
+  }
+
+  /**
+   * Mark all messages in a member's inbox as read. The renderer calls this
+   * when the user opens the inbox panel for that member.
+   */
+  async markInboxRead(
+    workspacePath: string | null,
+    teamId: string,
+    agentName: string
+  ): Promise<{ ok: boolean; error?: string }> {
+    const teamsDir = this.teamsDirFor(workspacePath)
+    const inboxPath = path.join(teamsDir, teamId, 'inboxes', `${agentName}.json`)
+    try {
+      const buf = await fs.readFile(inboxPath, 'utf-8')
+      const parsed = JSON.parse(buf)
+      if (!Array.isArray(parsed)) return { ok: true }
+      const updated = parsed.map((m: { read?: boolean }) => ({ ...m, read: true }))
+      await fs.writeFile(inboxPath, JSON.stringify(updated, null, 2), 'utf-8')
+      return { ok: true }
+    } catch (err) {
+      const msg = (err as NodeJS.ErrnoException).code === 'ENOENT' ? null : (err as Error).message
+      return msg ? { ok: false, error: msg } : { ok: true }
+    }
+  }
+
+  /** Read a member's inbox messages (newest first). */
+  async readInbox(
+    workspacePath: string | null,
+    teamId: string,
+    agentName: string
+  ): Promise<Array<{ from: string; text: string; summary?: string; timestamp: string; read?: boolean }>> {
+    const teamsDir = this.teamsDirFor(workspacePath)
+    const inboxPath = path.join(teamsDir, teamId, 'inboxes', `${agentName}.json`)
+    try {
+      const buf = await fs.readFile(inboxPath, 'utf-8')
+      const parsed = JSON.parse(buf)
+      if (!Array.isArray(parsed)) return []
+      return parsed.slice().reverse()
+    } catch {
+      return []
+    }
+  }
 
   async merge(
     workspacePath: string | null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.6.4",
+  "version": "0.6.6",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ function toV2Team(team: StoreTeam): V2Team {
       pane: m.name?.slice(0, 4).toUpperCase() ?? 'PANE',
       name: m.name,
       tmuxPaneId: m.tmuxPaneId,
+      unreadCount: m.unreadCount,
     }
   })
   // Aggregate run status: paused (team) > blocked > active > paused (members)
@@ -560,10 +561,25 @@ export default function App() {
     )
   }
 
-  // Map current view → main content
-  let main: React.ReactNode
-  if (view === 'workspace') {
-    main = (
+  // Map current view → main content.
+  //
+  // WorkspaceV2 stays mounted across view changes (display toggled via the
+  // wrapper below). Otherwise navigating to Library/Settings/Git tears down
+  // TerminalAreaV2 + its private SlotRegistry + every <XTerminal>, killing
+  // the user's `claude` shell and resetting the viewport on return — exactly
+  // the "다른 화면 갔다오면 터미널 초기화" regression we kept missing.
+  // Other views (git/dashboard/library/settings) stay conditional because
+  // they don't host live PTYs.
+  const workspaceVisible = view === 'workspace'
+  const workspaceNode = (
+    <div
+      style={{
+        display: workspaceVisible ? 'flex' : 'none',
+        flex: 1,
+        minHeight: 0,
+        flexDirection: 'column',
+      }}
+    >
       <WorkspaceV2
         workspace={activeSummary}
         runs={runs}
@@ -573,21 +589,31 @@ export default function App() {
         onNewRun={onNewRun}
         harnessUpdate={!!harnessUpdateAvailable}
       />
-    )
-  } else if (view === 'git') {
-    main = <GitPanelWired />
+    </div>
+  )
+
+  let secondaryView: React.ReactNode = null
+  if (view === 'git') {
+    secondaryView = <GitPanelWired />
   } else if (view === 'dashboard') {
-    main = <DashboardPanelWired onCmdK={() => setPaletteOpen(true)} />
+    secondaryView = <DashboardPanelWired onCmdK={() => setPaletteOpen(true)} />
   } else if (view === 'library') {
-    main = (
+    secondaryView = (
       <Library
         workspace={activeSummary}
         onApplyComposition={onApplyComposition}
       />
     )
   } else if (view === 'settings') {
-    main = <SettingsFull workspaces={workspaceSummaries} workspace={activeSummary} />
+    secondaryView = <SettingsFull workspaces={workspaceSummaries} workspace={activeSummary} />
   }
+
+  const main = (
+    <>
+      {workspaceNode}
+      {secondaryView}
+    </>
+  )
 
   return (
     <LiveTerminalsRoot>

--- a/src/components/v2/InboxPanel.tsx
+++ b/src/components/v2/InboxPanel.tsx
@@ -1,0 +1,284 @@
+// InboxPanel — 팀 멤버의 inbox 메시지 list + send box.
+//
+// 백엔드 (TeamOperations.sendInboxMessage / readInbox / markInboxRead) 가
+// `<teamDir>/inboxes/<member>.json` 에 entry append/read. 멤버 ↔ 멤버 메시지
+// 채널 — Council 토론 (v0.7.0+) 도 이 inbox 시스템을 활용.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+interface InboxMessage {
+  from: string
+  text: string
+  summary?: string
+  timestamp: string
+  read?: boolean
+}
+
+interface MemberRef {
+  agentId: string
+  name?: string
+}
+
+export interface InboxPanelProps {
+  teamId: string
+  /** Inbox 주인 — 이 멤버의 inbox 를 보여주고, send 시 from 으로 사용. */
+  agentName: string
+  /** Send 시 to 후보로 표시할 다른 멤버들 (자기 자신 제외). */
+  otherMembers: MemberRef[]
+  onClose: () => void
+}
+
+export function InboxPanel({ teamId, agentName, otherMembers, onClose }: InboxPanelProps) {
+  const [messages, setMessages] = useState<InboxMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [draftTo, setDraftTo] = useState<string>(otherMembers[0]?.name ?? otherMembers[0]?.agentId ?? '')
+  const [draftText, setDraftText] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const list = (await window.api?.teams?.readInbox?.({ teamId, agentName })) as InboxMessage[] | undefined
+      setMessages(list ?? [])
+      // Open == read. The watcher's unreadCount picks this up next refresh tick.
+      await window.api?.teams?.markInboxRead?.({ teamId, agentName })
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [teamId, agentName])
+
+  useEffect(() => {
+    void refresh()
+    // Light polling — chokidar already pushes teams:update on inbox writes,
+    // but the subscribe stream doesn't carry inbox payload. 2s poll keeps
+    // the panel responsive without overloading.
+    const id = window.setInterval(refresh, 2000)
+    return () => window.clearInterval(id)
+  }, [refresh])
+
+  const candidates = useMemo(
+    () => otherMembers.filter((m) => (m.name ?? m.agentId) !== agentName),
+    [otherMembers, agentName],
+  )
+
+  async function handleSend() {
+    if (!draftText.trim() || !draftTo) return
+    setSending(true)
+    setError(null)
+    try {
+      const result = await window.api?.teams?.sendMessage?.({
+        teamId,
+        fromAgent: agentName,
+        toAgent: draftTo,
+        text: draftText.trim(),
+      })
+      if (!result?.ok) {
+        setError(result?.error ?? '전송 실패')
+        return
+      }
+      setDraftText('')
+      // Echo into our own panel as confirmation — backend doesn't deliver to
+      // sender's inbox so we add a UI-only optimistic entry.
+      setMessages((prev) => [
+        {
+          from: `${agentName} → ${draftTo}`,
+          text: draftText.trim(),
+          timestamp: new Date().toISOString(),
+          read: true,
+        },
+        ...prev,
+      ])
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function fmtTime(iso: string) {
+    try {
+      const d = new Date(iso)
+      const hh = d.getHours().toString().padStart(2, '0')
+      const mm = d.getMinutes().toString().padStart(2, '0')
+      return `${hh}:${mm}`
+    } catch {
+      return iso
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        width: 380,
+        height: '100vh',
+        background: 'var(--bg-2)',
+        borderLeft: '1px solid var(--line-2)',
+        boxShadow: '-8px 0 32px rgba(0,0,0,0.4)',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 100,
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--line-1)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 12, color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: 1.2 }}>
+            Inbox · {agentName}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-4)' }}>
+            팀원 ↔ 팀원 메시지 · `.claude/teams/{teamId}/inboxes/{agentName}.json`
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close inbox"
+          style={{
+            width: 28,
+            height: 28,
+            border: 'none',
+            background: 'transparent',
+            color: 'var(--text-2)',
+            cursor: 'pointer',
+            fontSize: 18,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Message list (newest first) */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}
+      >
+        {loading && messages.length === 0 ? (
+          <div style={{ color: 'var(--text-4)', fontSize: 12, padding: 16, textAlign: 'center' }}>
+            불러오는 중…
+          </div>
+        ) : messages.length === 0 ? (
+          <div style={{ color: 'var(--text-4)', fontSize: 12, padding: 16, textAlign: 'center' }}>
+            아직 메시지 없음. 아래에서 보내거나 멤버가 보낼 때까지 대기.
+          </div>
+        ) : (
+          messages.map((m, i) => (
+            <div
+              key={i}
+              style={{
+                background: m.read ? 'var(--bg-1)' : 'var(--bg-3)',
+                border: '1px solid var(--line-1)',
+                borderRadius: 6,
+                padding: '10px 12px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>{m.from}</span>
+                <span style={{ flex: 1 }} />
+                <span style={{ fontSize: 10, color: 'var(--text-4)' }}>{fmtTime(m.timestamp)}</span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-1)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {m.text}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Send box */}
+      <div
+        style={{
+          borderTop: '1px solid var(--line-1)',
+          padding: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}
+      >
+        {error && (
+          <div style={{ color: 'var(--danger)', fontSize: 11 }}>{error}</div>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 11, color: 'var(--text-3)' }}>To:</span>
+          <select
+            value={draftTo}
+            onChange={(e) => setDraftTo(e.target.value)}
+            style={{
+              flex: 1,
+              background: 'var(--bg-1)',
+              color: 'var(--text-1)',
+              border: '1px solid var(--line-2)',
+              borderRadius: 4,
+              padding: '4px 8px',
+              fontSize: 12,
+            }}
+          >
+            {candidates.length === 0 && <option value="">(다른 멤버 없음)</option>}
+            {candidates.map((m) => (
+              <option key={m.agentId} value={m.name ?? m.agentId}>
+                {m.name ?? m.agentId}
+              </option>
+            ))}
+          </select>
+        </div>
+        <textarea
+          value={draftText}
+          onChange={(e) => setDraftText(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              e.preventDefault()
+              void handleSend()
+            }
+          }}
+          placeholder="메시지 입력 (⌘+Enter 전송)"
+          rows={3}
+          style={{
+            background: 'var(--bg-1)',
+            color: 'var(--text-1)',
+            border: '1px solid var(--line-2)',
+            borderRadius: 4,
+            padding: '8px',
+            fontSize: 12,
+            fontFamily: 'inherit',
+            resize: 'vertical',
+          }}
+        />
+        <button
+          onClick={() => void handleSend()}
+          disabled={!draftText.trim() || !draftTo || sending}
+          style={{
+            background: draftText.trim() && draftTo ? 'var(--accent)' : 'var(--bg-3)',
+            color: 'var(--text-1)',
+            border: '1px solid var(--line-2)',
+            borderRadius: 4,
+            padding: '6px 12px',
+            fontSize: 12,
+            cursor: draftText.trim() && draftTo ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {sending ? '전송 중…' : '보내기 (⌘+Enter)'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -23,6 +23,7 @@ import type { Team, TeamMember, ActivityItem, MemberState, TerminalLine } from '
 import { MergeConflictView, type ConflictItem } from './MergeConflictView'
 import { LiveTerminalGrid } from './LiveTerminalGrid'
 import { useLiveTerminalsStore } from '@/stores/liveTerminals'
+import { InboxPanel } from './InboxPanel'
 import {
   useTeamActivityStore,
   type ActivityEntry as RealActivityEntry,
@@ -75,6 +76,7 @@ export function RunLiveView({
 }: RunLiveViewProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [feedOpen, setFeedOpen] = useState(true)
+  const [inboxAgent, setInboxAgent] = useState<string | null>(null)
   // Local paused fallback for the design demo (when no real backend status).
   const [localPaused, setLocalPaused] = useState(false)
   const paused = team.status === 'paused' || localPaused
@@ -369,6 +371,8 @@ export function RunLiveView({
                 }
                 onTogglePause={() => handlePauseMember(m)}
                 onOpenTerminal={() => handleOpenAgentTerminal(m)}
+                onOpenInbox={() => setInboxAgent(m.name ?? m.agentId)}
+                unreadCount={m.unreadCount ?? 0}
               />
             ))}
           </div>
@@ -489,6 +493,14 @@ export function RunLiveView({
           onClose={() => setActiveConflict(null)}
         />
       )}
+      {inboxAgent && (
+        <InboxPanel
+          teamId={team.id}
+          agentName={inboxAgent}
+          otherMembers={team.members.map((m) => ({ agentId: m.agentId, name: m.name }))}
+          onClose={() => setInboxAgent(null)}
+        />
+      )}
     </div>
   )
 }
@@ -560,6 +572,10 @@ interface AgentCardProps {
   onTogglePause?: () => void
   /** Open the agent's tmux pane in a new terminal tab. */
   onOpenTerminal?: () => void
+  /** Open the inbox panel for this member (member ↔ member messages). */
+  onOpenInbox?: () => void
+  /** Unread message count for the inbox icon badge. */
+  unreadCount?: number
 }
 
 function AgentCard({
@@ -568,6 +584,8 @@ function AgentCard({
   onClick,
   onTogglePause,
   onOpenTerminal,
+  onOpenInbox,
+  unreadCount = 0,
 }: AgentCardProps) {
   const a = AGENT_BY_ID[member.agentId]
   const stateC = STATE_COLOR[member.state]
@@ -672,6 +690,43 @@ function AgentCard({
             >
               <Icon.Terminal size={11} />
             </CardIconBtn>
+          )}
+          {onOpenInbox && (
+            <div style={{ position: 'relative', display: 'inline-flex' }}>
+              <CardIconBtn
+                title={`${a.name} inbox · 팀원 메시지`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onOpenInbox()
+                }}
+              >
+                <Icon.Mail size={11} />
+              </CardIconBtn>
+              {unreadCount > 0 && (
+                <span
+                  aria-label={`${unreadCount} unread`}
+                  style={{
+                    position: 'absolute',
+                    top: -4,
+                    right: -4,
+                    minWidth: 14,
+                    height: 14,
+                    padding: '0 4px',
+                    background: 'var(--danger)',
+                    color: '#fff',
+                    fontSize: 9,
+                    fontWeight: 700,
+                    borderRadius: 7,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/components/v2/icons.tsx
+++ b/src/components/v2/icons.tsx
@@ -64,6 +64,7 @@ export const Icon = {
   File:     (p: IconProps) => <I {...p}><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></I>,
   Diff:     (p: IconProps) => <I {...p}><path d="M5 4v16M5 8h6M5 14h6M19 4v16M13 16h6M13 10h6"/></I>,
   Send:     (p: IconProps) => <I {...p}><path d="M22 2 11 13M22 2l-7 20-4-9-9-4z"/></I>,
+  Mail:     (p: IconProps) => <I {...p}><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></I>,
   Dot:      (p: IconProps) => <I {...p}><circle cx="12" cy="12" r="4" fill="currentColor"/></I>,
   More:     (p: IconProps) => <I {...p}><circle cx="5" cy="12" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="19" cy="12" r="1.5" fill="currentColor"/></I>,
   Kbd:      (p: IconProps) => <I {...p}><rect x="3" y="6" width="18" height="12" rx="2"/><path d="M7 10h.01M11 10h.01M15 10h.01M7 14h10"/></I>,

--- a/src/components/v2/types.ts
+++ b/src/components/v2/types.ts
@@ -30,6 +30,8 @@ export interface TeamMember {
   /** Optional tmux pane id — when present, the member can attach to a real
    *  terminal session via `window.api.teams.openAgentTerminal`. */
   tmuxPaneId?: string
+  /** Inbox unread count — drives the AgentCard mail icon badge. */
+  unreadCount?: number
 }
 
 export interface Team {

--- a/src/devApiStub.ts
+++ b/src/devApiStub.ts
@@ -138,6 +138,9 @@ export function installDevApiStub(): void {
       openAgentTerminal: (() => Promise.resolve('dev-pty-1')) as AnyFn,
       subscribe: noopUnsub as AnyFn,
       onUpdate: noopUnsub as AnyFn,
+      sendMessage: resolveOk as AnyFn,
+      readInbox: resolveEmptyArr as AnyFn,
+      markInboxRead: resolveOk as AnyFn,
     }),
     git: loggingProxy('git', {
       status: (() =>


### PR DESCRIPTION
worktree baseBranch team/<id> → team/<id>-base (refs hierarchy 충돌 fix). inbox sendMessage IPC + InboxPanel + 멤버 unreadCount 배지. 멤버 model 필드 + bypass flag 분기. WorkspaceV2 항상 mount + display 토글 (v0.6.5 변경 포함). docs/roadmap-v0.6.6-v0.8.md 영구 plan 문서.