### PR TITLE
feat(v0.7.0): ProviderRouter + forge-team plan/execute CLI

### DIFF
--- a/bin/forge-team.ts
+++ b/bin/forge-team.ts
@@ -187,6 +187,155 @@ async function cmdPause(flags: Map<string, string>): Promise<void> {
   emit(result)
 }
 
+// ────────────────────────────────────────────────────────────────────
+// plan / execute — phase 별 sequential team orchestration
+// ────────────────────────────────────────────────────────────────────
+
+interface PlanPhase {
+  /** Phase 인덱스 (1부터). */
+  phase: number
+  /** Phase 의 한 줄 설명 (한국어 OK). */
+  description: string
+  /** 같은 phase 안의 멤버는 병렬 실행 (worktree 격리). */
+  parallel: boolean
+  /** 멤버 구성. forge-team create 의 --members 와 동일 shape. */
+  members: TeamCreateMember[]
+  /** 의존성 (다른 phase 인덱스 list). */
+  dependsOn?: number[]
+  /** Council 적용 여부 (v0.7.1+). */
+  council?: boolean
+}
+
+interface PlanDocument {
+  goal: string
+  workspaceId: string
+  phases: PlanPhase[]
+  /** v0.7.0 시점에는 사용자가 직접 채우거나 planner agent 가 출력. */
+  notes?: string
+}
+
+/**
+ * forge-team plan — goal 을 받아서 plan.json template 출력.
+ * v0.7.0: hardcoded sensible default phases (prisma → nestjs → flutter+cms 병렬).
+ *         사용자가 출력 받고 수정해서 execute 에 넘김.
+ * v0.7.1: planner agent (Council) 가 동적으로 plan 생성.
+ */
+async function cmdPlan(flags: Map<string, string>): Promise<void> {
+  const goal = requireFlag(flags, 'goal')
+  const workspacePath = requireFlag(flags, 'workspace')
+  const workspaceId = flags.get('workspace-id') || path.basename(path.resolve(workspacePath))
+
+  // Default template — 풀스택 피처 (DB → API → UI 병렬 → 통합 테스트)
+  const plan: PlanDocument = {
+    goal,
+    workspaceId,
+    phases: [
+      {
+        phase: 1,
+        description: '스키마 + 마이그레이션 (Prisma)',
+        parallel: false,
+        members: [{ agentId: 'prisma-data', task: `${goal} 의 스키마 + 마이그레이션`, model: 'gpt-5.5' }],
+      },
+      {
+        phase: 2,
+        description: 'API + 비즈니스 로직 (NestJS)',
+        parallel: false,
+        dependsOn: [1],
+        members: [{ agentId: 'nestjs-backend', task: `${goal} API`, model: 'claude-opus-4-7' }],
+      },
+      {
+        phase: 3,
+        description: 'UI + 상태관리 (Flutter, 병렬)',
+        parallel: true,
+        dependsOn: [2],
+        members: [
+          { agentId: 'flutter-ui', task: `${goal} 화면`, model: 'claude-opus-4-7' },
+          { agentId: 'riverpod-logic', task: `${goal} 상태관리`, model: 'claude-opus-4-7' },
+          { agentId: 'dio-retrofit', task: `${goal} API 클라이언트`, model: 'claude-opus-4-7' },
+        ],
+      },
+      {
+        phase: 4,
+        description: '통합 테스트 + 코드 리뷰',
+        parallel: true,
+        dependsOn: [3],
+        members: [
+          { agentId: 'test-writer', task: `${goal} e2e 테스트`, model: 'claude-opus-4-7' },
+          { agentId: 'code-reviewer', task: 'diff 리뷰', model: 'claude-opus-4-7' },
+          { agentId: 'security-auditor', task: 'OWASP 점검', model: 'gpt-5.5' },
+          { agentId: 'spec-verifier', task: '스펙 정합성', model: 'gpt-5.5' },
+        ],
+      },
+    ],
+    notes:
+      'v0.7.0 template. 멤버 task 채우고 execute 로 phase 별 sequential. ' +
+      '같은 phase 안 멤버는 worktree 격리되어 병렬 안전. dependsOn 순서대로 자동 진행.',
+  }
+
+  emit(plan)
+}
+
+/**
+ * forge-team execute — plan.json 의 한 phase 만 실행.
+ *   --plan <file>     plan JSON 파일
+ *   --phase <n>       실행할 phase (없으면 첫 미완료 phase 추론은 v0.7.1)
+ *   --merge           phase 완료 후 자동 merge (모든 멤버 done 가정)
+ *
+ * v0.7.0: 단일 phase 만 실행. phase 의 모든 멤버를 forge-team create 로 spawn.
+ *         완료 자동 감지는 v0.7.1+ (멤버가 inbox 'task_complete' 보내는 패턴).
+ *         사용자가 모든 멤버 끝나면 --merge 다시 호출.
+ */
+async function cmdExecute(flags: Map<string, string>): Promise<void> {
+  const planFile = requireFlag(flags, 'plan')
+  const workspacePath = requireFlag(flags, 'workspace')
+  const phaseArg = flags.get('phase')
+  const merge = flags.get('merge') === 'true'
+
+  const fs = await import('fs/promises')
+  let plan: PlanDocument
+  try {
+    const buf = await fs.readFile(planFile, 'utf-8')
+    plan = JSON.parse(buf) as PlanDocument
+  } catch (err) {
+    fail(`plan 파일 읽기 실패: ${(err as Error).message}`)
+  }
+
+  if (!phaseArg) {
+    fail('--phase <n> 필요. 첫 phase 부터 sequential 자동 실행은 v0.7.1+')
+  }
+  const phaseNum = parseInt(phaseArg, 10)
+  if (isNaN(phaseNum)) fail(`--phase 는 숫자여야: ${phaseArg}`)
+
+  const phase = plan.phases.find((p) => p.phase === phaseNum)
+  if (!phase) fail(`phase ${phaseNum} 없음 (plan 의 phases: ${plan.phases.map((p) => p.phase).join(', ')})`)
+
+  if (merge) {
+    // Caller signals phase 완료 — base branch 로 merge 시도
+    // 다만 plan 의 phase 자체가 한 팀 ≠ 한 phase 라 — 사용자가 team-id 명시 필요
+    const teamId = requireFlag(flags, 'team-id')
+    const result = await ops.merge(workspacePath, teamId, {
+      mergeStrategy: (flags.get('merge-strategy') as MergeStrategy | undefined) ?? 'squash',
+    })
+    emit({ phase: phaseNum, ...result })
+    if (!result.ok) process.exit(2)
+    return
+  }
+
+  // Spawn — phase 의 모든 멤버를 한 forge-team create 로
+  const teamName = `${plan.goal.slice(0, 24)}-phase${phaseNum}`
+  const result = await ops.create({
+    workspaceId: plan.workspaceId,
+    workspacePath,
+    name: teamName,
+    goal: phase.description,
+    members: phase.members,
+    worktreeStrategy: (flags.get('worktree-strategy') as WorktreeStrategy | undefined) ?? 'isolated',
+    mergeStrategy: (flags.get('merge-strategy') as MergeStrategy | undefined) ?? 'squash',
+    autoStartClaude: flags.get('no-auto-start') !== 'true',
+  })
+  emit({ phase: phaseNum, ...result, instructions: `완료 후 \`forge-team execute --plan ${planFile} --phase ${phaseNum} --team-id ${result.teamId} --merge\`` })
+}
+
 async function cmdResume(flags: Map<string, string>): Promise<void> {
   const workspacePath = resolveWorkspace(flags)
   const teamId = requireFlag(flags, 'team-id')
@@ -212,6 +361,8 @@ function printHelp(): void {
       '  merge    Merge member branches back into the team base branch',
       '  pause    Pause an entire team or a single member (--agent-id)',
       '  resume   Resume an entire team or a single member (--agent-id)',
+      '  plan     goal → phase 별 plan.json template 출력 (v0.7.0+)',
+      '  execute  plan.json 의 단일 phase 실행 (--phase n) 또는 머지 (--merge)',
       '',
       'Common flags:',
       '  --workspace <path>          Workspace root (required)',
@@ -271,6 +422,13 @@ async function main(): Promise<void> {
         break
       case 'resume':
         await cmdResume(flags)
+        break
+      case 'plan':
+        await cmdPlan(flags)
+        break
+      case 'execute':
+      case 'run':
+        await cmdExecute(flags)
         break
       default:
         fail(`unknown command: ${command} (try \`forge-team help\`)`)

--- a/electron/services/ProviderRouter.ts
+++ b/electron/services/ProviderRouter.ts
@@ -1,0 +1,79 @@
+// ProviderRouter — model id 를 적절한 CLI launch 명령으로 매핑.
+//
+// 메인 세션과 멤버 spawn 시 어느 provider (Anthropic claude / OpenAI codex)
+// CLI 를 쓸지 결정. v0.6.6 의 modelLaunchCommand 를 더 풍부한 매핑 + sandbox
+// 옵션 + 환경 변수로 확장.
+//
+// Council 메커니즘 (v0.7.1+) 은 두 provider 를 동시에 spawn 해서 inbox 로
+// 토론 — 그 메커니즘의 가장 안쪽 layer 가 이 라우터.
+
+export type Provider = 'claude' | 'codex'
+
+export interface ProviderSpec {
+  /** Resolved provider id (claude / codex). */
+  provider: Provider
+  /** CLI binary name (claude or codex). */
+  cli: string
+  /** bypass-permissions launch flag. */
+  bypassFlag: string
+  /** Tmux send-keys command — ready to fire after `claude` / `codex` exits. */
+  launchCommand: string
+  /** Optional model id forwarded to the CLI (claude --model X, codex --model X). */
+  modelArg?: string
+}
+
+/**
+ * Resolve a model identifier to a provider + launch command. Examples:
+ *   "claude-opus-4-7"   → claude, --dangerously-skip-permissions, --model claude-opus-4-7
+ *   "opus"              → claude, --dangerously-skip-permissions
+ *   "sonnet-4.5"        → claude, --dangerously-skip-permissions, --model sonnet-4.5
+ *   "gpt-5.5"           → codex,  --dangerously-bypass-approvals-and-sandbox, --model gpt-5.5
+ *   "o1-preview"        → codex,  --dangerously-bypass-approvals-and-sandbox, --model o1-preview
+ *   "codex"             → codex,  --dangerously-bypass-approvals-and-sandbox
+ *   undefined / ""      → claude (default)
+ */
+export function resolveProvider(model: string | undefined): ProviderSpec {
+  const m = (model ?? '').trim().toLowerCase()
+  // OpenAI / codex family
+  if (
+    m.startsWith('gpt') ||
+    m.startsWith('o1') ||
+    m.startsWith('o3') ||
+    m.startsWith('codex') ||
+    m.startsWith('openai')
+  ) {
+    const modelArg = m.startsWith('codex') || m === 'gpt' ? undefined : (model ?? undefined)
+    return {
+      provider: 'codex',
+      cli: 'codex',
+      bypassFlag: '--dangerously-bypass-approvals-and-sandbox',
+      launchCommand: modelArg
+        ? `codex --dangerously-bypass-approvals-and-sandbox --model ${modelArg}`
+        : 'codex --dangerously-bypass-approvals-and-sandbox',
+      modelArg,
+    }
+  }
+
+  // Anthropic / claude family (default)
+  const isShortAlias = m === '' || m === 'claude' || m === 'opus' || m === 'sonnet' || m === 'haiku'
+  const modelArg = isShortAlias ? undefined : (model ?? undefined)
+  return {
+    provider: 'claude',
+    cli: 'claude',
+    bypassFlag: '--dangerously-skip-permissions',
+    launchCommand: modelArg
+      ? `claude --dangerously-skip-permissions --model ${modelArg}`
+      : 'claude --dangerously-skip-permissions',
+    modelArg,
+  }
+}
+
+/** Quick check: is this model id a Claude/Anthropic family member? */
+export function isClaudeModel(model: string | undefined): boolean {
+  return resolveProvider(model).provider === 'claude'
+}
+
+/** Quick check: is this model id an OpenAI/codex family member? */
+export function isCodexModel(model: string | undefined): boolean {
+  return resolveProvider(model).provider === 'codex'
+}

--- a/electron/services/TeamOperations.ts
+++ b/electron/services/TeamOperations.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import fs from 'fs/promises'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { resolveProvider } from './ProviderRouter'
 
 const execFileAsync = promisify(execFile)
 
@@ -42,12 +43,7 @@ export interface TeamCreateMember {
 
 /** Map a model identifier to the bypass-mode launch command. */
 export function modelLaunchCommand(model: string | undefined): string {
-  const m = (model ?? '').toLowerCase()
-  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('codex')) {
-    return 'codex --dangerously-bypass-approvals-and-sandbox'
-  }
-  // Default: claude (opus / sonnet / haiku / claude-* / unspecified).
-  return 'claude --dangerously-skip-permissions'
+  return resolveProvider(model).launchCommand
 }
 
 export interface TeamCreateOptions {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
ProviderRouter — model id 를 claude/codex CLI + bypass flag + --model arg 로 매핑. forge-team plan/execute — phase 기반 sequential 오케스트레이션. plan 은 풀스택 default template, execute 는 단일 phase spawn 또는 phase merge. Council 자체 토론 + 자동 완료 감지는 v0.7.1+.