### PR TITLE
feat(v0.7.1): 멤버 model 배지 + Wizard default model 자동 매핑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ function toV2Team(team: StoreTeam): V2Team {
       name: m.name,
       tmuxPaneId: m.tmuxPaneId,
       unreadCount: m.unreadCount,
+      model: m.model,
     }
   })
   // Aggregate run status: paused (team) > blocked > active > paused (members)
@@ -345,6 +346,25 @@ export default function App() {
     setWizardOpen(true)
   }
 
+  /**
+   * Map an agent id to its recommended provider model — drives default model
+   * selection on team create. roadmap-v0.6.6-v0.8.md "에이전트별 추천 모델"
+   * 표 그대로:
+   *   - GPT 강점 (blast radius / 형식 검증 / 정확성):
+   *     prisma-data, security-auditor, spec-verifier, refactor-cleaner
+   *   - Opus 강점 (creative / 큰 그림 / 자연어): 그 외
+   * Council (양 model 동시 spawn) 은 v0.8.x — 여기선 단일 best-fit.
+   */
+  function defaultModelFor(agentId: string): string {
+    const gpt = new Set([
+      'prisma-data',
+      'security-auditor',
+      'spec-verifier',
+      'refactor-cleaner',
+    ])
+    return gpt.has(agentId) ? 'gpt-5.5' : 'claude-opus-4-7'
+  }
+
   const onWizardCreate = async (result: WizardResult) => {
     if (!activeWorkspace) {
       // Without a workspace we have nowhere to write the team config — silently
@@ -358,7 +378,10 @@ export default function App() {
         workspacePath: activeWorkspace.path,
         name: result.name,
         goal: result.goal,
-        members: result.members.map((agentId) => ({ agentId })),
+        // 각 멤버의 default model 매핑 — roadmap 의 "에이전트별 추천 모델" 적용:
+        // GPT (영향 분석/형식 검증) vs Opus (creative/큰 그림). 사용자가
+        // Wizard UI 에서 override 하는 건 v0.8.0+.
+        members: result.members.map((agentId) => ({ agentId, model: defaultModelFor(agentId) })),
         worktreeStrategy: result.worktree,
         mergeStrategy: result.merge,
       })

--- a/src/components/v2/RunLiveView.tsx
+++ b/src/components/v2/RunLiveView.tsx
@@ -768,12 +768,48 @@ function AgentCard({
       >
         <span>{member.tokens > 0 ? `${(member.tokens / 1000).toFixed(1)}k` : '—'} tok</span>
         <span>{member.files} 파일</span>
+        {member.model && (
+          <span
+            title={`provider model: ${member.model}`}
+            style={{
+              padding: '0 5px',
+              borderRadius: 3,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 0.3,
+              border: '1px solid var(--line-2)',
+              color: modelBadgeColor(member.model),
+              background: 'transparent',
+            }}
+          >
+            {modelBadgeLabel(member.model)}
+          </span>
+        )}
         <span style={{ color: stateC, fontWeight: 600, letterSpacing: 0.3 }}>
           {STATE_LABEL[member.state]}
         </span>
       </div>
     </div>
   )
+}
+
+function modelBadgeLabel(model: string): string {
+  const m = model.toLowerCase()
+  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('codex') || m.startsWith('openai')) {
+    return 'GPT'
+  }
+  if (m.includes('opus')) return 'OPUS'
+  if (m.includes('sonnet')) return 'SONNET'
+  if (m.includes('haiku')) return 'HAIKU'
+  return 'CLAUDE'
+}
+
+function modelBadgeColor(model: string): string {
+  const m = model.toLowerCase()
+  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('codex') || m.startsWith('openai')) {
+    return 'var(--info)'
+  }
+  return 'var(--accent)'
 }
 
 // ─── Tiny icon-only button used inside AgentCard ────────────────────

--- a/src/components/v2/types.ts
+++ b/src/components/v2/types.ts
@@ -32,6 +32,9 @@ export interface TeamMember {
   tmuxPaneId?: string
   /** Inbox unread count — drives the AgentCard mail icon badge. */
   unreadCount?: number
+  /** Provider model id (claude-opus-4-7 / gpt-5.5 / etc). Drives the model
+   *  badge on AgentCard + ProviderRouter dispatch on team spawn. */
+  model?: string
 }
 
 export interface Team {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -208,6 +208,9 @@ export interface Team {
 export interface TeamCreateMember {
   agentId: string
   task?: string
+  /** Provider model id (claude-opus-4-7 / gpt-5.5 / etc). 멤버 spawn 시
+   *  ProviderRouter 가 해당 CLI 로 dispatch. 미지정 시 claude default. */
+  model?: string
 }
 
 export interface TeamCreateOptions {


### PR DESCRIPTION
AgentCard 에 OPUS/GPT 배지. Wizard onCreate 가 defaultModelFor() 로 자동 매핑 — GPT (prisma-data/security-auditor/spec-verifier/refactor-cleaner), 그 외 Opus.