### PR TITLE
feat(v0.9.1): Settings dropdown 진짜화 + 역할별/에이전트별 모델 매핑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useGitStore } from './stores/git'
 import { useAgentTeamStore } from './stores/agentTeam'
 import { useLibraryStore } from './stores/library'
 import { subscribeToMainErrors } from './stores/errorLog'
+import { useModelPolicyStore } from './stores/modelPolicy'
 
 import { Shell } from './components/v2/Shell'
 import { LiveTerminalsRoot } from './components/v2/LiveTerminalsRoot'
@@ -154,7 +155,11 @@ export default function App() {
   const [wizardPrefill, setWizardPrefill] = useState<string[] | undefined>(undefined)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [toast, setToast] = useState<{ name: string; count: number } | null>(null)
-  const [model] = useState({ id: 'sonnet-4.5', label: 'sonnet-4.5' })
+  // TopBar 의 모델 라벨 — modelPolicy store 의 'Other' 역할 default 표시.
+  // 사용자가 Settings 에서 변경하면 즉시 갱신. 클릭 시 Settings 의 Agents
+  // 섹션으로 이동 — Agent별 + 역할별 매핑 UI.
+  const topBarModel = useModelPolicyStore((s) => s.byRole.Other)
+  const model = useMemo(() => ({ id: topBarModel, label: topBarModel }), [topBarModel])
   // Harness update preview modal — opened from the orange HarnessBanner's
   // "diff 보기" button. Renders the file tree + per-file unified diff.
   const [updatePreviewOpen, setUpdatePreviewOpen] = useState(false)
@@ -348,22 +353,12 @@ export default function App() {
   }
 
   /**
-   * Map an agent id to its recommended provider model — drives default model
-   * selection on team create. roadmap-v0.6.6-v0.8.md "에이전트별 추천 모델"
-   * 표 그대로:
-   *   - GPT 강점 (blast radius / 형식 검증 / 정확성):
-   *     prisma-data, security-auditor, spec-verifier, refactor-cleaner
-   *   - Opus 강점 (creative / 큰 그림 / 자연어): 그 외
-   * Council (양 model 동시 spawn) 은 v0.8.x — 여기선 단일 best-fit.
+   * Map an agent id to its model. Settings → "역할별 모델" + "에이전트별
+   * override" 가 사용자 정책의 source of truth. 사용자가 명시 안 한
+   * 항목은 store 의 default (GPT 강점 = Database / 그 외 Opus).
    */
   function defaultModelFor(agentId: string): string {
-    const gpt = new Set([
-      'prisma-data',
-      'security-auditor',
-      'spec-verifier',
-      'refactor-cleaner',
-    ])
-    return gpt.has(agentId) ? 'gpt-5.5' : 'claude-opus-4-7'
+    return useModelPolicyStore.getState().resolveModel(agentId)
   }
 
   const onWizardCreate = async (result: WizardResult) => {

--- a/src/components/v2/SettingsFull.tsx
+++ b/src/components/v2/SettingsFull.tsx
@@ -16,6 +16,7 @@ import { Btn, Pill, Dot, AvatarStack } from './primitives'
 import { Icon } from './icons'
 import type { WorkspaceSummary } from './types'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { useModelPolicyStore, type ModelRole } from '@/stores/modelPolicy'
 import { CodeGraphViz } from './CodeGraphViz'
 import { HarnessLintPanel } from './HarnessLintPanel'
 import { SessionPreview } from './SessionPreview'
@@ -306,26 +307,86 @@ function Toggle({ value, onChange }: ToggleProps) {
   )
 }
 
-function Select({ value }: { value: string }) {
+/**
+ * 진짜 native select. onChange 가 있으면 controlled, 없으면 read-only
+ * (마이그레이션 호환 — onChange 안 단 옛 호출은 그대로 표시만).
+ *
+ * 기본값으로 Anthropic + OpenAI 의 자주 쓰는 모델 list 를 옵션 으로 제공.
+ * 호출자가 options 를 명시하면 그것 우선.
+ */
+const DEFAULT_MODEL_OPTIONS = [
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'opus-4',
+  'sonnet-4.5',
+  'haiku-4.5',
+  'gpt-5.5',
+  'o1-preview',
+  'o3',
+]
+
+function Select({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: string
+  options?: readonly string[]
+  onChange?: (v: string) => void
+  disabled?: boolean
+}) {
+  const opts = options ?? (DEFAULT_MODEL_OPTIONS.includes(value) ? DEFAULT_MODEL_OPTIONS : [value, ...DEFAULT_MODEL_OPTIONS])
+  if (!onChange) {
+    // 호출자가 onChange 안 줬으면 read-only 라벨 (옛 코드 호환)
+    return (
+      <div
+        style={{
+          height: 26,
+          padding: '0 8px',
+          borderRadius: 5,
+          background: 'var(--bg-3)',
+          border: '1px solid var(--line-2)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 12,
+          color: 'var(--text-3)',
+          cursor: 'not-allowed',
+          fontFamily: 'var(--font-mono)',
+          opacity: 0.7,
+        }}
+        title="이 항목은 아직 read-only — onChange 미구현"
+      >
+        {value} <Icon.ChevronD size={11} />
+      </div>
+    )
+  }
   return (
-    <div
+    <select
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
       style={{
         height: 26,
         padding: '0 8px',
         borderRadius: 5,
         background: 'var(--bg-3)',
         border: '1px solid var(--line-2)',
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 6,
         fontSize: 12,
         color: 'var(--text-1)',
-        cursor: 'pointer',
+        cursor: disabled ? 'not-allowed' : 'pointer',
         fontFamily: 'var(--font-mono)',
+        appearance: 'auto',
       }}
     >
-      {value} <Icon.ChevronD size={11} style={{ color: 'var(--text-3)' }} />
-    </div>
+      {opts.map((o) => (
+        <option key={o} value={o}>
+          {o}
+        </option>
+      ))}
+    </select>
   )
 }
 
@@ -634,6 +695,122 @@ export function SettingsHarness({ workspace }: SettingsHarnessProps = {}) {
   )
 }
 
+// ─── Agents — Models per role + per-agent override ────────────────
+
+function ModelsPerRoleCard() {
+  const byRole = useModelPolicyStore((s) => s.byRole)
+  const setRoleModel = useModelPolicyStore((s) => s.setRoleModel)
+  const reset = useModelPolicyStore((s) => s.reset)
+
+  const roles: Array<{ role: ModelRole; description: string }> = [
+    { role: 'Frontend', description: 'flutter-ui / riverpod-logic / dio-retrofit / nextjs-cms' },
+    { role: 'Backend', description: 'nestjs-backend / nestjs-auth' },
+    { role: 'Database', description: 'prisma-data / postgres-patterns (정확성 강점 → GPT 권장)' },
+    { role: 'Tests', description: 'test-writer / tdd-guide / flutter-driver-e2e' },
+    { role: 'Review', description: 'code-reviewer / security-auditor / spec-verifier / refactor-cleaner' },
+    { role: 'Architecture', description: 'tech-architect / planner' },
+    { role: 'Other', description: 'doc-updater / build-error-resolver / loop-operator / harness-optimizer / 사용자 정의' },
+  ]
+
+  return (
+    <SettingsCard
+      title="역할별 모델"
+      right={
+        <button
+          onClick={() => reset('all')}
+          style={{
+            padding: '4px 10px',
+            fontSize: 11,
+            background: 'transparent',
+            border: '1px solid var(--line-2)',
+            color: 'var(--text-3)',
+            borderRadius: 4,
+            cursor: 'pointer',
+          }}
+          title="모든 역할/에이전트 매핑을 default 로 리셋"
+        >
+          기본값으로
+        </button>
+      }
+    >
+      {roles.map((r, i) => (
+        <Row
+          key={r.role}
+          label={r.role}
+          sub={r.description}
+          right={
+            <Select
+              value={byRole[r.role]}
+              onChange={(v) => setRoleModel(r.role, v)}
+            />
+          }
+          last={i === roles.length - 1}
+        />
+      ))}
+    </SettingsCard>
+  )
+}
+
+function AgentOverridesCard() {
+  const byAgent = useModelPolicyStore((s) => s.byAgent)
+  const setAgentModel = useModelPolicyStore((s) => s.setAgentModel)
+  const reset = useModelPolicyStore((s) => s.reset)
+  const resolve = useModelPolicyStore((s) => s.resolveModel)
+
+  const allAgents = [
+    'planner', 'tech-architect', 'flutter-ui', 'riverpod-logic', 'dio-retrofit',
+    'nestjs-backend', 'nestjs-auth', 'prisma-data', 'postgres-patterns', 'nextjs-cms',
+    'test-writer', 'tdd-guide', 'flutter-driver-e2e', 'code-reviewer', 'security-auditor',
+    'spec-verifier', 'refactor-cleaner', 'doc-updater', 'docs-lookup',
+    'build-error-resolver', 'loop-operator', 'harness-optimizer',
+  ]
+
+  return (
+    <SettingsCard
+      title="에이전트별 override"
+      right={
+        <span style={{ fontSize: 10.5, color: 'var(--text-4)' }}>
+          비워두면 역할별 모델 사용
+        </span>
+      }
+    >
+      {allAgents.map((agent, i) => {
+        const explicit = byAgent[agent]
+        const effective = resolve(agent)
+        return (
+          <div
+            key={agent}
+            style={{
+              padding: '10px 16px',
+              borderBottom: i < allAgents.length - 1 ? '1px solid var(--line-1)' : 'none',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+            }}
+          >
+            <span className="mono" style={{ fontSize: 12, color: 'var(--text-1)', flex: 1 }}>
+              {agent}
+            </span>
+            {!explicit && (
+              <span style={{ fontSize: 10, color: 'var(--text-4)' }}>
+                자동 ({effective.toLowerCase().startsWith('gpt') ? 'GPT' : effective.toUpperCase().replace('CLAUDE-', '')})
+              </span>
+            )}
+            <Select
+              value={explicit ?? '(자동)'}
+              options={['(자동)', ...DEFAULT_MODEL_OPTIONS]}
+              onChange={(v) => {
+                if (v === '(자동)') reset({ agentId: agent })
+                else setAgentModel(agent, v)
+              }}
+            />
+          </div>
+        )
+      })}
+    </SettingsCard>
+  )
+}
+
 // ─── Agents ───────────────────────────────────────────────────────
 
 export function SettingsAgents() {
@@ -694,26 +871,8 @@ export function SettingsAgents() {
         />
       </SettingsCard>
 
-      <SettingsCard title="Models per role">
-        {(
-          [
-            { role: 'Frontend', model: 'sonnet-4.5', count: 1 },
-            { role: 'Backend', model: 'sonnet-4.5', count: 1 },
-            { role: 'Database', model: 'sonnet-4.5', count: 1 },
-            { role: 'Tests', model: 'haiku-4.5', count: 1 },
-            { role: 'Review', model: 'opus-4', count: 1 },
-            { role: 'Architecture', model: 'opus-4', count: 1 },
-          ] as const
-        ).map((r, i, arr) => (
-          <Row
-            key={r.role}
-            label={r.role}
-            sub={`${r.count} agents`}
-            right={<Select value={r.model} />}
-            last={i === arr.length - 1}
-          />
-        ))}
-      </SettingsCard>
+      <ModelsPerRoleCard />
+      <AgentOverridesCard />
     </>
   )
 }

--- a/src/components/v2/TopBar.tsx
+++ b/src/components/v2/TopBar.tsx
@@ -320,11 +320,9 @@ export function TopBar({
         display: 'flex', alignItems: 'center', gap: 8, paddingRight: 10,
       }}>
         <button
-          title="모델 선택은 v0.6.0에서 활성화됩니다 — 현재는 sonnet-4.5 고정"
+          title="현재 'Other' 역할의 default 모델. 클릭해서 Settings → Agents 에서 역할별 + 에이전트별 모델 변경"
           onClick={() => {
-            // Model picker UI ships in v0.6.0 — for now route the user to
-            // Settings → Agents → "Models per role" where the per-role model
-            // dropdowns already render (read-only).
+            // Settings → Agents 의 Models per role / 에이전트 override 로 이동
             window.dispatchEvent(
               new CustomEvent('forge:nav-settings', {
                 detail: { section: 'agents' },

--- a/src/stores/modelPolicy.ts
+++ b/src/stores/modelPolicy.ts
@@ -1,0 +1,108 @@
+// modelPolicy — 사용자 model 매핑 정책. localStorage 영속.
+//
+// agentId / role → model id 매핑. App.tsx 의 defaultModelFor() 가 이걸
+// 우선 보고, 없으면 builtin fallback (GPT 강점 4명 / 그 외 Opus).
+//
+// 두 layer:
+//   - byRole: 카테고리 단위 (Frontend/Backend/Database/Tests/Review/Architecture)
+//     → 같은 카테고리 안의 모든 agentId 에 적용
+//   - byAgent: agentId 단위 (override). byAgent 우선.
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type ModelRole = 'Frontend' | 'Backend' | 'Database' | 'Tests' | 'Review' | 'Architecture' | 'Other'
+
+const DEFAULT_BY_ROLE: Record<ModelRole, string> = {
+  Frontend: 'claude-opus-4-7',
+  Backend: 'claude-opus-4-7',
+  Database: 'gpt-5.5', // 정확성 강점
+  Tests: 'claude-opus-4-7',
+  Review: 'claude-opus-4-7',
+  Architecture: 'claude-opus-4-7',
+  Other: 'claude-opus-4-7',
+}
+
+/**
+ * 에이전트 → 역할 매핑. Library 의 default 18개 에이전트 + 사용자 추가는
+ * 'Other' 로 fallback. 사용자가 byAgent override 로 세부 조정.
+ */
+const ROLE_BY_AGENT: Record<string, ModelRole> = {
+  'flutter-ui': 'Frontend',
+  'riverpod-logic': 'Frontend',
+  'dio-retrofit': 'Frontend',
+  'nextjs-cms': 'Frontend',
+  'nestjs-backend': 'Backend',
+  'nestjs-auth': 'Backend',
+  'prisma-data': 'Database',
+  'postgres-patterns': 'Database',
+  'test-writer': 'Tests',
+  'tdd-guide': 'Tests',
+  'flutter-driver-e2e': 'Tests',
+  'code-reviewer': 'Review',
+  'security-auditor': 'Review',
+  'spec-verifier': 'Review',
+  'refactor-cleaner': 'Review',
+  'tech-architect': 'Architecture',
+  'planner': 'Architecture',
+  'doc-updater': 'Other',
+  'docs-lookup': 'Other',
+  'build-error-resolver': 'Other',
+  'loop-operator': 'Other',
+  'harness-optimizer': 'Other',
+}
+
+interface ModelPolicyState {
+  byRole: Record<ModelRole, string>
+  byAgent: Record<string, string>
+
+  setRoleModel(role: ModelRole, model: string): void
+  setAgentModel(agentId: string, model: string): void
+  /** Resolve agentId → effective model. byAgent → byRole → builtin default. */
+  resolveModel(agentId: string): string
+  /** Reset 한 항목만 (또는 전부). */
+  reset(scope: 'all' | { role: ModelRole } | { agentId: string }): void
+}
+
+export const useModelPolicyStore = create<ModelPolicyState>()(
+  persist(
+    (set, get) => ({
+      byRole: { ...DEFAULT_BY_ROLE },
+      byAgent: {},
+
+      setRoleModel(role, model) {
+        set({ byRole: { ...get().byRole, [role]: model } })
+      },
+      setAgentModel(agentId, model) {
+        set({ byAgent: { ...get().byAgent, [agentId]: model } })
+      },
+      resolveModel(agentId) {
+        const { byAgent, byRole } = get()
+        if (byAgent[agentId]) return byAgent[agentId]
+        const role = ROLE_BY_AGENT[agentId] ?? 'Other'
+        return byRole[role] ?? DEFAULT_BY_ROLE[role]
+      },
+      reset(scope) {
+        if (scope === 'all') {
+          set({ byRole: { ...DEFAULT_BY_ROLE }, byAgent: {} })
+          return
+        }
+        if ('role' in scope) {
+          const next = { ...get().byRole }
+          next[scope.role] = DEFAULT_BY_ROLE[scope.role]
+          set({ byRole: next })
+        }
+        if ('agentId' in scope) {
+          const next = { ...get().byAgent }
+          delete next[scope.agentId]
+          set({ byAgent: next })
+        }
+      },
+    }),
+    { name: 'forge-model-policy-v1' },
+  ),
+)
+
+export function getRoleForAgent(agentId: string): ModelRole {
+  return ROLE_BY_AGENT[agentId] ?? 'Other'
+}


### PR DESCRIPTION
Select 컴포넌트 div → 진짜 native select. modelPolicy store (byRole/byAgent + persist). Settings → Agents 에 역할별 모델 카드 + 에이전트별 override 카드. App.tsx defaultModelFor 가 store resolveModel 위임. TopBar 라벨 store 와 sync.