### PR TITLE
fix(v0.9.3): packaged CLI 의 ProviderRouter.ts 누락

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",
@@ -105,7 +105,7 @@
       {
         "from": "electron/services",
         "to": "forge-cli/electron/services",
-        "filter": ["TeamOperations.ts"]
+        "filter": ["TeamOperations.ts", "ProviderRouter.ts"]
       }
     ],
     "directories": {


### PR DESCRIPTION
v0.9.0 에서 import 추가했는데 extraResources filter 못 갱신 → packaged forge-team 실행 시 ERR_MODULE_NOT_FOUND. filter 에 추가.