### PR TITLE
fix(v0.9.4): packaged forge-team CLI 의 ESM .ts 확장자 명시

### DIFF
--- a/electron/services/TeamOperations.ts
+++ b/electron/services/TeamOperations.ts
@@ -3,7 +3,11 @@ import os from 'os'
 import fs from 'fs/promises'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { resolveProvider } from './ProviderRouter'
+// .ts 확장자 명시 — Node 의 --experimental-strip-types 가 packaged
+// forge-team CLI 에서 module 을 resolve 할 때 ESM resolver 가 implicit
+// extension 을 안 채워주므로 명시 필요 (v0.9.4 fix). bin/forge-team.ts
+// 도 같은 패턴으로 './TeamOperations.ts' 명시 중.
+import { resolveProvider } from './ProviderRouter.ts'
 
 const execFileAsync = promisify(execFile)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Node strip-types 가 implicit extension 안 보강. './ProviderRouter' → './ProviderRouter.ts'.