### PR TITLE
feat(v0.9.7): 멤버 역할/영역 주입 + boundary hook + 시나리오 분기

### DIFF
--- a/electron/services/TeamOperations.ts
+++ b/electron/services/TeamOperations.ts
@@ -43,6 +43,18 @@ export interface TeamCreateMember {
    * Defaults to claude (Anthropic) when omitted.
    */
   model?: string
+  /**
+   * 자기 책임 파일/디렉토리 path 들. 다른 멤버는 건드리지 말 것 — 메인 세션의
+   * Phase 1 plan 의 expectedFiles 와 동일. autoStart task prompt 에 자동
+   * 포함되어 멤버 claude/codex 가 자기 영역 + 다른 멤버 영역 알고 충돌 회피.
+   * Shared worktree 모드에서 특히 중요.
+   */
+  expectedFiles?: string[]
+  /**
+   * 멤버의 역할 한 줄 — Frontend / Backend / Database 등. autoStart prompt
+   * 에 명시되어 멤버가 자기 정체성 명확. 빠뜨리면 agentId 에서 자동 추론.
+   */
+  role?: string
 }
 
 /** Map a model identifier to the bypass-mode launch command. */
@@ -109,6 +121,10 @@ export interface RawMember {
   worktreePath?: string
   branch?: string
   state?: 'active' | 'idle'
+  /** 자기 책임 영역 — autoStart prompt + Discussion/충돌 감지에 활용. */
+  expectedFiles?: string[]
+  /** 멤버 역할 (Frontend/Backend/Database 등). */
+  role?: string
 }
 
 export interface RawConfig {
@@ -403,6 +419,10 @@ export class TeamOperations {
         joinedAt: now + idx,
         task: m.task,
         state: 'active',
+        // v0.9.7 — boundary 정보. autoStart task prompt 가 자기 영역 + 다른
+        // 멤버 영역 명시해서 shared/isolated 어느 모드든 충돌 회피.
+        expectedFiles: m.expectedFiles,
+        role: m.role,
       }
 
       // ── Worktree provisioning ──────────────────────────────────────
@@ -450,7 +470,15 @@ export class TeamOperations {
       if (tmuxOk && memberCwd) {
         const session = teamSessionName(teamId, m.agentId)
         const tmux = this.tmuxBin()
-        const env = this.tmuxEnv()
+        // v0.9.7 — FORGE_TEAM_ID + FORGE_MEMBER_NAME env 주입.
+        // forge-boundary-guard.sh PreToolUse hook 이 이걸 보고 멤버 영역
+        // 외 파일 수정 시도 차단. 메인 세션은 이 env 없어서 통과.
+        const env = {
+          ...this.tmuxEnv(),
+          FORGE_TEAM_ID: teamId,
+          FORGE_MEMBER_NAME: member.name,
+          FORGE_TEAM_NAME: opts.name,
+        }
         try {
           await execFileAsync(
             tmux,
@@ -480,26 +508,63 @@ export class TeamOperations {
                 env,
               })
 
-              // v0.9.5 — task 자동 주입. claude/codex 가 부팅 시간 필요해서
-              // 1.5s 대기 후 task 텍스트 send. 부팅 안 끝났으면 멤버가 입력
-              // buffering 해서 처리 (claude/codex 둘 다 readline buffering).
+              // v0.9.5 — task 자동 주입. claude/codex 부팅 1.5s 후 prompt send.
+              // v0.9.7 — 멤버 별 역할 + 자기 책임 영역 + 다른 멤버 영역 + 충돌
+              // 회피 지시 자동 포함. 사용자 요구: "메인 세션이 팀원 역할 + 계획
+              // 명확히 주입해야 동일 폴더에서도 충돌 안 남".
               if (member.task) {
-                const taskPrompt = [
-                  `당신은 팀 "${opts.name}" 의 멤버 "${member.name}".`,
-                  `목표: ${opts.goal ?? opts.name}`,
-                  `자기 task: ${member.task}`,
-                  member.worktreePath && member.worktreePath !== wsPath
-                    ? `자기 worktree: ${member.worktreePath} (cwd 이미 거기). git commit 은 자기 worktree 에서.`
-                    : `자기 worktree: 메인 디렉토리 공유 (shared mode). 자기 sub-directory 만 건드리고 git add/commit 은 메인 세션에 위임.`,
-                  member.branch
-                    ? `자기 브랜치: ${member.branch}`
-                    : '',
-                  `진행: 자율적으로 자기 task 수행. 막히면 inbox 에 다른 멤버 또는 메인에게 메시지.`,
-                ].filter(Boolean).join('\n')
+                const others = rawMembers.filter((o) => o.name !== member.name)
+                const otherRoles = others
+                  .map((o) => {
+                    const roleLabel = o.role ? `${o.role} (${o.name})` : o.name
+                    const files = o.expectedFiles?.length
+                      ? ` — 영역: ${o.expectedFiles.join(', ')}`
+                      : ''
+                    return `  - ${roleLabel}${files}`
+                  })
+                  .join('\n')
 
-                // 1.5s 대기 — claude/codex 부팅 + 첫 prompt 표시까지 충분.
-                // tmux 의 sleep 은 send-keys 의 -t flag 와 함께 못 써서
-                // 별도 setTimeout 으로 순서 보장.
+                const lines: string[] = []
+                lines.push(`[Forge Team 자동 안내] 당신은 팀 "${opts.name}" 의 멤버 "${member.name}".`)
+                if (member.role) lines.push(`역할: ${member.role}`)
+                lines.push(`팀 목표: ${opts.goal ?? opts.name}`)
+                lines.push('')
+                lines.push(`### 당신의 task`)
+                lines.push(member.task)
+                if (member.expectedFiles?.length) {
+                  lines.push('')
+                  lines.push(`### 당신의 책임 영역 (only these files)`)
+                  lines.push(member.expectedFiles.map((f) => `  - ${f}`).join('\n'))
+                  lines.push(`이 영역 외의 파일은 수정하지 마세요. 다른 멤버 영역 침범 금지.`)
+                }
+                if (others.length > 0) {
+                  lines.push('')
+                  lines.push(`### 같은 팀의 다른 멤버 (절대 그들 영역 건드리지 마세요)`)
+                  lines.push(otherRoles)
+                  lines.push(`다른 멤버 영역에 변경 필요하면 inbox 로 협의 요청 (forge-team-cli send-message).`)
+                }
+                lines.push('')
+                lines.push(`### 작업 환경`)
+                if (member.worktreePath && member.worktreePath !== wsPath) {
+                  lines.push(`- 자기 worktree: ${member.worktreePath} (격리됨, 다른 멤버와 별도)`)
+                  lines.push(`- 자기 브랜치: ${member.branch} — 작업 중 자유롭게 commit`)
+                  lines.push(`- 메인 세션이 추후 forge-team merge 로 통합`)
+                } else {
+                  lines.push(`- 메인 디렉토리 공유 (shared mode — worktree 격리 X)`)
+                  lines.push(`- 자기 sub-directory / 영역만 수정. git add/commit 은 메인 세션 일괄 처리.`)
+                  lines.push(`- 다른 멤버와 git race 가능 — 자기 영역 외엔 절대 건드리지 말 것.`)
+                }
+                lines.push('')
+                lines.push(`### 진행 룰`)
+                lines.push(`- TDD 우선: 실패 테스트 먼저 → 통과 코드. 멤버에 test-writer 가 있으면 그 결과 활용.`)
+                lines.push(`- 자기 task 외엔 손대지 말 것. 추가 작업 필요하면 메인 세션에게 inbox 로 의견 요청.`)
+                lines.push(`- 막히면 inbox 의 다른 멤버 또는 메인에게 메시지: \`forge-team-cli send-message --team-id ${teamId} --from ${member.name} --to <상대> --text "..."\``)
+                lines.push(`- 충돌/혼란 시 사용자 결정 받기보다 우선 inbox 협의.`)
+                lines.push('')
+                lines.push(`이제 자율적으로 task 진행하세요.`)
+
+                const taskPrompt = lines.join('\n')
+
                 await new Promise<void>((resolve) => setTimeout(resolve, 1500))
                 await execFileAsync(tmux, ['send-keys', '-t', session, taskPrompt, 'Enter'], {
                   timeout: 4000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-studio",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Forge Studio — Claude Code GUI Wrapper",
   "license": "GPL-3.0-or-later",
   "main": "dist-electron/main.js",

--- a/resources/harness-template/.claude/scripts/forge-boundary-guard.sh
+++ b/resources/harness-template/.claude/scripts/forge-boundary-guard.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# forge-boundary-guard.sh — Forge Team 멤버의 자기 영역 외 파일 수정 차단.
+#
+# 멤버 worktree 의 .claude/teams/<id>/config.json 의 자기 expectedFiles 외의
+# 파일을 Edit/Write 시도하면 차단. shared mode 또는 의도치 않은 침범 방지.
+#
+# Hook 입력 (PreToolUse Write/Edit): JSON via stdin
+#   { "tool_input": { "file_path": "/abs/path/to/file" }, ... }
+#
+# 동작:
+#   - FORGE_TEAM_ID + FORGE_MEMBER_NAME env 가 set 이어야 동작 (forge-team
+#     spawn 시 tmux env 로 set 필요 — 지금은 멤버 세션 자체 식별 X 라
+#     conservative: env 없으면 pass through. v0.10+ 에서 멤버 식별 강화).
+#   - 자기 expectedFiles 안이면 OK
+#   - 외부 영역 시도 → exit 2 + 명시 에러 stderr (Claude Code 가 사용자에게 표시)
+#
+# 메인 세션 (멤버 아님) 에선 FORGE_MEMBER_NAME 미설정 → 통과.
+
+set -e
+
+# Read stdin JSON
+PAYLOAD=$(cat 2>/dev/null || true)
+[ -z "$PAYLOAD" ] && exit 0
+
+# Member 식별 — env 없으면 메인 세션이거나 식별 안 됨, 통과
+if [ -z "$FORGE_MEMBER_NAME" ] || [ -z "$FORGE_TEAM_ID" ]; then
+  exit 0
+fi
+
+# 워크스페이스 root 추론
+WS_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CONFIG_PATH="$WS_ROOT/.claude/teams/$FORGE_TEAM_ID/config.json"
+[ ! -f "$CONFIG_PATH" ] && exit 0  # config 없으면 통과
+
+# 시도하는 파일 path
+FILE_PATH=$(echo "$PAYLOAD" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$FILE_PATH" ] && exit 0
+
+# 자기 expectedFiles 추출 (config.json 의 members 배열에서 자기 멤버)
+EXPECTED=$(jq -r --arg name "$FORGE_MEMBER_NAME" \
+  '.members[] | select(.name == $name) | .expectedFiles // [] | .[]' \
+  "$CONFIG_PATH" 2>/dev/null)
+
+# expectedFiles 비어있으면 boundary 없음 → 통과
+[ -z "$EXPECTED" ] && exit 0
+
+# Glob match 시도. expectedFiles 의 각 패턴이 path 의 일부와 매칭되면 OK
+ALLOWED=0
+while IFS= read -r pattern; do
+  [ -z "$pattern" ] && continue
+  # ** 같은 glob 은 bash 의 extglob 으로 처리. 단순 prefix match 도 포함.
+  case "$FILE_PATH" in
+    *"$pattern"*) ALLOWED=1; break ;;
+  esac
+  # path 가 자기 worktree 안이면 OK (worktree path 도 expectedFiles 의 일부로 간주)
+  case "$pattern" in
+    *"**"*)
+      prefix="${pattern%%\*\**}"
+      case "$FILE_PATH" in
+        *"$prefix"*) ALLOWED=1; break ;;
+      esac
+      ;;
+  esac
+done <<< "$EXPECTED"
+
+if [ "$ALLOWED" = "0" ]; then
+  echo "🚫 BLOCKED [forge-boundary-guard]: 자기 영역 외 파일 수정 시도" >&2
+  echo "  멤버: $FORGE_MEMBER_NAME (팀: $FORGE_TEAM_ID)" >&2
+  echo "  시도 파일: $FILE_PATH" >&2
+  echo "  자기 영역 (expectedFiles):" >&2
+  echo "$EXPECTED" | sed 's/^/    - /' >&2
+  echo "" >&2
+  echo "다른 멤버 영역 수정 필요하면:" >&2
+  echo "  forge-team-cli send-message --team-id $FORGE_TEAM_ID \\" >&2
+  echo "    --from $FORGE_MEMBER_NAME --to <상대 멤버> --text \"<요청 내용>\"" >&2
+  exit 2
+fi
+
+exit 0

--- a/resources/harness-template/.claude/settings.json
+++ b/resources/harness-template/.claude/settings.json
@@ -135,6 +135,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/gateguard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/forge-boundary-guard.sh\""
           }
         ]
       }

--- a/resources/harness-template/CLAUDE.md
+++ b/resources/harness-template/CLAUDE.md
@@ -52,7 +52,39 @@
 
 ---
 
-# 큰 피처 기획 강제 워크플로 (MANDATORY)
+# 시나리오 분기 — 작은 기능 vs 큰 앱
+
+요청 받으면 먼저 **시나리오 판정** 후 적절한 워크플로:
+
+| 시그널 | 분류 | 워크플로 |
+|---|---|---|
+| 기존 client/server/cms 가 부트스트랩 됨 + 명확한 scope ("OAuth 추가", "검색 화면", "버그 fix") | **A. 작은 기능** | Phase 0 mini → Phase 1 단일 → Phase 2 통합 |
+| 빈 디렉토리 또는 client/server/cms 비어있음 + 큰 주제 ("앱 만들어줘", "채팅앱", "쇼핑몰") | **B. 큰 앱** | Phase 0~5 풀 워크플로 |
+
+## 시나리오 A — 작은 기능 추가 (예: "OAuth 로그인")
+
+### Phase 0-mini: 외부 의존만 빠르게 확인
+- 새 외부 provider 필요한가? (OAuth = Google / Kakao / GitHub 중)
+- 새 환경 변수 필요한가? (Settings → Integrations 토큰 입력 안내)
+
+### Phase 1: 단일 phase 4명 병렬 (의존 chain 짧음)
+```
+test-writer (Tests, 먼저 spawn)
+  + prisma-data (Database, schema 변경)
+  + nestjs-backend (Backend, API)
+  + flutter-ui (Frontend, UI)
+```
+isolated worktree 격리되어 4명 병렬 OK. 머지 후 다음.
+
+### Phase 2: 통합 테스트 + 리뷰
+- code-reviewer + security-auditor 병렬
+- /verify + /test-coverage
+
+## 시나리오 B — 큰 앱 부트스트랩 (예: "1ㄷ1 채팅앱")
+
+전체 Phase 0~5 풀 워크플로 — 아래 강제 단계 따름.
+
+# 큰 피처 기획 강제 워크플로 (MANDATORY for 시나리오 B)
 
 큰 작업 ("앱 만들어줘", "기능 추가해줘") 받으면 **반드시 다음 0~5 단계
 순서대로**. 이전 단계 결과 없이 다음 단계 못 간다.
@@ -131,12 +163,48 @@ default (각 항목의 첫 옵션 = Recommended) 선택 후 명시.
 Plan 의 phase 별로 sequential. 각 phase 안의 members 는 parallel:true 면
 한 번에 spawn, false 면 한 명씩.
 
+**핵심**: `--members` 에 JSON 배열로 전달해서 `role` + `expectedFiles` 를
+포함시켜라. 이 정보가 멤버 spawn 시 task prompt 에 자동 주입되어
+**멤버가 자기 영역 + 다른 멤버 영역 + 충돌 회피 지시 모두 인지** 한다.
+이게 핵심 — 동일 폴더 작업 시 충돌 사전 방지의 메커니즘.
+
 ```bash
+MEMBERS='[
+  {
+    "agentId": "test-writer",
+    "role": "Tests",
+    "task": "Phase 1 의 모든 module 의 실패 테스트 먼저 작성",
+    "expectedFiles": ["server/test/**/*.spec.ts", "client/test/**/*.dart"],
+    "model": "claude-opus-4-7"
+  },
+  {
+    "agentId": "prisma-data",
+    "role": "Database",
+    "task": "User Friendship ChatRoom Message MessageRead 스키마 + 마이그레이션",
+    "expectedFiles": ["prisma/schema.prisma", "prisma/migrations/**"],
+    "model": "gpt-5.5"
+  },
+  {
+    "agentId": "nestjs-backend",
+    "role": "Backend",
+    "task": "프로젝트 부트스트랩 + 인증 모듈 (Passport + JWT + bcrypt)",
+    "expectedFiles": ["server/src/**", "server/package.json", "server/tsconfig.json"],
+    "model": "claude-opus-4-7"
+  },
+  {
+    "agentId": "flutter-ui",
+    "role": "Frontend",
+    "task": "Flutter 부트스트랩 + Clean Architecture 골격 + 로그인/회원가입 화면",
+    "expectedFiles": ["client/**", "client/pubspec.yaml"],
+    "model": "claude-opus-4-7"
+  }
+]'
+
 forge-team create \
-  --workspace <ws> \
-  --name "<goal>-phase<n>" \
-  --goal "<phase description>" \
-  --members "<agentId1:task1,agentId2:task2,...>" \
+  --workspace . \
+  --name "chat-app-phase1" \
+  --goal "1ㄷ1 채팅앱 부트스트랩 + 스키마 + 인증" \
+  --members "$MEMBERS" \
   --worktree-strategy isolated \
   --merge-strategy squash \
   --auto-start
@@ -145,6 +213,44 @@ forge-team create \
 **`worktreesCreated: 0` 이 나오면 즉시 중단**. shared mode fallback 은
 멤버끼리 git race 발생 → 사용자에게 보고하고 재시도. v0.9.5 부터 빈 repo
 자동 처리되지만 다른 결함이면 stderr 로 표시됨.
+
+### 멤버에 자동 주입되는 prompt (참고)
+
+forge-team CLI 가 멤버 spawn 직후 tmux send-keys 로 다음 prompt 자동 전송
+(claude/codex 부팅 후 1.5s):
+
+```
+[Forge Team 자동 안내] 당신은 팀 "<name>" 의 멤버 "<member-name>".
+역할: <role>
+팀 목표: <goal>
+
+### 당신의 task
+<task>
+
+### 당신의 책임 영역 (only these files)
+  - <expectedFiles[0]>
+  - <expectedFiles[1]>
+이 영역 외의 파일은 수정하지 마세요. 다른 멤버 영역 침범 금지.
+
+### 같은 팀의 다른 멤버 (절대 그들 영역 건드리지 마세요)
+  - Backend (nestjs-backend) — 영역: server/**, server/package.json
+  - Database (prisma-data) — 영역: prisma/schema.prisma, prisma/migrations/**
+  - Tests (test-writer) — 영역: server/test/**, client/test/**
+다른 멤버 영역에 변경 필요하면 inbox 로 협의 요청.
+
+### 작업 환경
+- 자기 worktree: <path> (격리됨)
+- 자기 브랜치: <branch> — 작업 중 자유롭게 commit
+- 메인 세션이 추후 forge-team merge 로 통합
+
+### 진행 룰
+- TDD 우선
+- 자기 task 외엔 손대지 말 것
+- 막히면 inbox 의 다른 멤버 또는 메인에게 메시지
+```
+
+이게 **메인 세션이 팀원에게 역할 + 계획을 주입하는 메커니즘**. 동일 폴더에서도
+멤버가 자기 영역 외 안 건드리게 강제.
 
 ## Phase 4 — 머지 + 검증 (per phase)
 


### PR DESCRIPTION
TeamCreateMember 에 expectedFiles + role. autoStart prompt 가 자기 영역 + 다른 멤버 영역 + 충돌 회피 자동 주입. forge-boundary-guard.sh hook 이 멤버 영역 외 수정 시도 차단. CLAUDE.md 에 작은 기능 (시나리오 A) vs 큰 앱 (시나리오 B) 분기 추가.